### PR TITLE
Add Accept text/html header to request

### DIFF
--- a/src/modules/request.js
+++ b/src/modules/request.js
@@ -24,6 +24,7 @@ module.exports = function(options, callback = false) {
 
     request.open(data.method, data.url, true)
     request.setRequestHeader("X-Requested-With", "swup")
+    request.setRequestHeader("Accept", "text/html, application/xhtml+xml")
     request.send(data.data)
     return request
 }


### PR DESCRIPTION
This prevents issues with browsersync proxy, it does not rewrite links hosts in html without this header

Turbolinks [does this](https://github.com/turbolinks/turbolinks/blob/c340c42e2ece8c057aec611074971462a6e76c71/src/turbolinks/http_request.coffee#L66) as well