### PR TITLE
Code formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
+max_line_length = 100
+
+[*.{js,mjs}]
+indent_style = tab
+indent_size = 4
+
+[*.{json,md,yaml,yml}]
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ wiki-images files
 wiki-wishlist
 *.sublime-project
 *.sublime-workspace
-.editorconfig
 .idea
 .vscode
 lib

--- a/package.json
+++ b/package.json
@@ -52,5 +52,6 @@
   "collective": {
     "type": "opencollective",
     "url": "https://opencollective.com/swup"
-  }
+  },
+  "prettier": "@swup/prettier-config"
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "cy:open": "cypress open",
     "compile": "babel --presets es2015,stage-0 -d lib/ src/",
     "build": "webpack-cli",
+    "lint": "prettier src/**/*.{js,mjs} --write",
     "prepublish": "npm run compile && npm run build",
     "postinstall": "opencollective-postinstall || true",
     "test": "npm run build && npm run test:instrument && start-server-and-test test:server http://localhost:8080 test:run",

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,1 +1,0 @@
-module.exports = require('@swup/prettier-config');

--- a/src/helpers/cleanupAnimationClasses.js
+++ b/src/helpers/cleanupAnimationClasses.js
@@ -1,16 +1,16 @@
 const cleanupAnimationClasses = () => {
-  document.documentElement.className.split(' ').forEach((classItem) => {
-    if (
-      // remove "to-{page}" classes
-      new RegExp('^to-').test(classItem) ||
-      // remove all other classes
-      classItem === 'is-changing' ||
-      classItem === 'is-rendering' ||
-      classItem === 'is-popstate'
-    ) {
-      document.documentElement.classList.remove(classItem);
-    }
-  });
+	document.documentElement.className.split(' ').forEach((classItem) => {
+		if (
+			// remove "to-{page}" classes
+			new RegExp('^to-').test(classItem) ||
+			// remove all other classes
+			classItem === 'is-changing' ||
+			classItem === 'is-rendering' ||
+			classItem === 'is-popstate'
+		) {
+			document.documentElement.classList.remove(classItem);
+		}
+	});
 };
 
 export default cleanupAnimationClasses;

--- a/src/helpers/normalizeUrl.js
+++ b/src/helpers/normalizeUrl.js
@@ -1,7 +1,7 @@
 import Link from './Link';
 
 const normalizeUrl = (url) => {
-	return (new Link(url)).getAddress();
+	return new Link(url).getAddress();
 };
 
 export default normalizeUrl;

--- a/src/helpers/transitionEnd.js
+++ b/src/helpers/transitionEnd.js
@@ -1,8 +1,8 @@
 const transitionEnd = () => {
 	if (window.ontransitionend === undefined && window.onwebkittransitionend !== undefined) {
-		return 'webkitTransitionEnd'
+		return 'webkitTransitionEnd';
 	} else {
-		return 'transitionend'
+		return 'transitionend';
 	}
 };
 

--- a/src/helpers/transitionProperty.js
+++ b/src/helpers/transitionProperty.js
@@ -1,8 +1,8 @@
 const transitionProperty = () => {
 	if (window.ontransitionend === undefined && window.onwebkittransitionend !== undefined) {
-		return 'WebkitTransition'
+		return 'WebkitTransition';
 	} else {
-		return 'transition'
+		return 'transition';
 	}
 };
 

--- a/src/modules/getAnimationPromises.js
+++ b/src/modules/getAnimationPromises.js
@@ -2,19 +2,23 @@ import { queryAll } from '../utils';
 import { transitionEnd, transitionProperty } from '../helpers';
 
 const getAnimationPromises = function() {
+	const selector = this.options.animationSelector;
+	const durationProperty = `${transitionProperty()}Duration`;
 	const promises = [];
-	const animatedElements = queryAll(this.options.animationSelector, document.body);
+	const animatedElements = queryAll(selector, document.body);
 
 	if (!animatedElements.length) {
-		console.warn(`[swup] No animated elements found by selector ${this.options.animationSelector}`);
+		console.warn(`[swup] No animated elements found by selector ${selector}`);
 		return [Promise.resolve()];
 	}
 
 	animatedElements.forEach((element) => {
-		const transitionDuration = window.getComputedStyle(element)[`${transitionProperty()}Duration`];
+		const transitionDuration = window.getComputedStyle(element)[durationProperty];
 		// Resolve immediately if no transition defined
 		if (!transitionDuration || transitionDuration == '0s') {
-			console.warn(`[swup] No CSS transition duration defined for element of selector ${this.options.animationSelector}`);
+			console.warn(
+				`[swup] No CSS transition duration defined for element of selector ${selector}`
+			);
 			promises.push(Promise.resolve());
 			return;
 		}


### PR DESCRIPTION
Simplify code formatting across the codebase.

- [x] Add .editorconfig matching the current prettier config
- [x] Add npm script `lint` that runs prettier on the `src` folder
- [x] Reference prettier config from package.json (one less file)

Tackle in a later PR:
- [ ] Auto-lint code in CI for all incoming PRs
