### PR TITLE
Feature: Only set the --record flag in the CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,4 +44,4 @@ jobs:
           command: npm run compile && npm run build
 
       # run tests!
-      - run: npm run test
+      - run: npm run ci

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -3,7 +3,7 @@ const { defineConfig } = require('cypress')
 module.exports = defineConfig({
   projectId: 'dpucip',
   e2e: {
-    baseUrl: 'http://localhost:8080',
+    baseUrl: 'http://localhost:8274',
     specPattern: 'cypress/e2e/**/*.{js,jsx,ts,tsx}',
     setupNodeEvents(on, config) {
       require('@cypress/code-coverage/task')(on, config)

--- a/cypress/e2e/main.spec.js
+++ b/cypress/e2e/main.spec.js
@@ -189,7 +189,7 @@ context('Window', () => {
 
     it('should cache pages from absolute URLs', () => {
         cy.window().then(window => {
-            window._swup.loadPage({ url: 'http://localhost:8080/page2/' });
+            window._swup.loadPage({ url: 'http://localhost:8274/page2/' });
             cy.shouldBeAtPage('/page2/');
             cy.window().should(() => {
                 expect(window._swup.cache.getCurrentPage()).not.to.be.undefined;

--- a/package.json
+++ b/package.json
@@ -10,10 +10,11 @@
     "lint": "prettier src/**/*.{js,mjs} --write",
     "prepublish": "npm run compile && npm run build",
     "postinstall": "opencollective-postinstall || true",
+    "ci": "npm run build && npm run test:instrument && start-server-and-test test:server http://localhost:8274 test:run -- --record",
     "test": "npm run build && npm run test:instrument && start-server-and-test test:server http://localhost:8274 test:run",
     "test:instrument": "nyc instrument --compact=false dist test/site/swup",
     "test:server": "http-server --port 8274 test/site",
-    "test:run": "cypress run --record"
+    "test:run": "cypress run"
   },
   "author": "Georgy Marchuk",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "prettier src/**/*.{js,mjs} --write",
     "prepublish": "npm run compile && npm run build",
     "postinstall": "opencollective-postinstall || true",
-    "ci": "npm run build && npm run test:instrument && start-server-and-test test:server http://localhost:8274 test:run -- --record",
+    "ci": "export CI=true && npm run build && npm run test:instrument && start-server-and-test test:server http://localhost:8274 test:run -- --record",
     "test": "npm run build && npm run test:instrument && start-server-and-test test:server http://localhost:8274 test:run",
     "test:instrument": "nyc instrument --compact=false dist test/site/swup",
     "test:server": "http-server --port 8274 test/site",

--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
     "lint": "prettier src/**/*.{js,mjs} --write",
     "prepublish": "npm run compile && npm run build",
     "postinstall": "opencollective-postinstall || true",
-    "test": "npm run build && npm run test:instrument && start-server-and-test test:server http://localhost:8080 test:run",
+    "test": "npm run build && npm run test:instrument && start-server-and-test test:server http://localhost:8274 test:run",
     "test:instrument": "nyc instrument --compact=false dist test/site/swup",
-    "test:server": "http-server test/site",
+    "test:server": "http-server --port 8274 test/site",
     "test:run": "cypress run --record"
   },
   "author": "Georgy Marchuk",

--- a/package.json
+++ b/package.json
@@ -10,11 +10,12 @@
     "lint": "prettier src/**/*.{js,mjs} --write",
     "prepublish": "npm run compile && npm run build",
     "postinstall": "opencollective-postinstall || true",
-    "ci": "export CI=true && npm run build && npm run test:instrument && start-server-and-test test:server http://localhost:8274 test:run -- --record",
+    "ci": "npm run build && npm run test:instrument && start-server-and-test test:server http://localhost:8274 test:run:record",
     "test": "npm run build && npm run test:instrument && start-server-and-test test:server http://localhost:8274 test:run",
     "test:instrument": "nyc instrument --compact=false dist test/site/swup",
     "test:server": "http-server --port 8274 test/site",
-    "test:run": "cypress run"
+    "test:run": "cypress run",
+    "test:run:record": "cypress run --record"
   },
   "author": "Georgy Marchuk",
   "license": "MIT",


### PR DESCRIPTION
Added a separate (almost duplicate) script for the CI:

```json
{
    "ci": "npm run build && npm run test:instrument && start-server-and-test test:server http://localhost:8274 test:run -- --record",
    "test": "npm run build && npm run test:instrument && start-server-and-test test:server http://localhost:8274 test:run",
}
```

Sometimes, DRY actually means "Do Repeat Yourself", right? 😉