### PR TITLE
Update readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,16 +1,20 @@
-<a href="https://github.com/swup/swup/discussions/424">We're looking for maintainers!</a>   👀
+<br>
 
-<br/>
+<p align="center">
+  <img width="280" alt="swup" src="https://swup.js.org/assets/images/swup-logo.svg">
+</p>
 
-<img src="https://swup.js.org/assets/images/swup-logo.svg" alt="swup logo" height="50" align="right">
+<p align="center">
+  <a href="https://www.npmjs.com/package/swup"><img src="https://img.shields.io/npm/v/swup.svg" alt="npm version"></a>
+  <img src="https://img.shields.io/bundlephobia/minzip/swup.svg" alt="Gzip Size">
+  <a href="https://github.com/gmrchk/swup/blob/master/LICENSE"><img src="https://img.shields.io/github/license/gmrchk/swup.svg" alt="License"></a>
+  <a href="https://www.npmjs.com/package/swup"><img src="https://img.shields.io/npm/dt/swup.svg" alt="npm downloads"></a>
+  <a href="https://circleci.com/gh/swup/swup"><img src="https://circleci.com/gh/swup/swup.svg?style=svg" alt="CircleCI"></a>
+</p>
+
+<br>
 
 # Swup
-
-[![npm version](https://img.shields.io/npm/v/swup.svg)](https://www.npmjs.com/package/swup)
-[![Bundle size](https://img.shields.io/bundlephobia/minzip/swup.svg)](https://bundlephobia.com/package/swup)
-[![License](https://img.shields.io/github/license/gmrchk/swup.svg)](https://github.com/gmrchk/swup/blob/master/LICENSE)
-[![npm downloads](https://img.shields.io/npm/dt/swup.svg)](https://www.npmjs.com/package/swup)
-[![Build status](https://circleci.com/gh/swup/swup.svg?style=shield)](https://circleci.com/gh/swup/swup)
 
 Complete, flexible, extensible and easy to use page transition library for your static website.
 
@@ -31,12 +35,12 @@ other quality-of-life improvements.
 
 ## Features
 
-- Auto-detects [CSS transitions](https://swup.js.org/getting-started/how-it-works) for perfect timing
-- Updates URLs and preserves native browser history behavior
-- Uses a [cache](https://swup.js.org/api/cache) to speed up subsequent page loads
-- Offers [events](https://swup.js.org/events) for hooking into the lifecycle
-- Has a powerful [plugin system](https://swup.js.org/plugins) and many official and third-party plugins
-- Provides ready-to-go [themes](https://swup.js.org/themes) to get started quickly
+- ✨ Auto-detects [CSS transitions](https://swup.js.org/getting-started/how-it-works) for perfect timing
+- 🔗 Updates URLs and preserves native browser history behavior
+- 📦 Uses a [cache](https://swup.js.org/api/cache) to speed up subsequent page loads
+- 💡 Offers [events](https://swup.js.org/events) for hooking into the lifecycle
+- 🔌 Has a powerful [plugin system](https://swup.js.org/plugins) and many official and third-party plugins
+- 🎨 Provides ready-to-go [themes](https://swup.js.org/themes) to get started quickly
 
 ## Examples
 
@@ -49,6 +53,8 @@ Take a look at [Sites using swup](https://github.com/swup/swup/discussions/333) 
 If you're having trouble implementing swup, check out the [Common Issues](https://swup.js.org/other/common-issues) section of the docs, look at [closed issues](https://github.com/gmrchk/swup/issues?q=is%3Aissue+is%3Aclosed) or create a [new discussion](https://github.com/swup/swup/discussions/new).
 
 ## Want to Contribute?
+
+<a href="https://github.com/swup/swup/discussions/424">We're looking for maintainers!</a>   👀
 
 Become a sponsor on [Open Collective](https://opencollective.com/swup) or support development through
 [GitHub sponsors](https://github.com/sponsors/gmrchk).

--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,7 @@
 
 # Swup
 
-Complete, flexible, extensible and easy to use page transition library for your static website.
+Complete, flexible, extensible, and easy-to-use page transition library for your server-side rendered website.
 
 [Features](#features) •
 [Documentation](https://swup.js.org/getting-started) •

--- a/readme.md
+++ b/readme.md
@@ -6,10 +6,10 @@
 
 <p align="center">
   <a href="https://www.npmjs.com/package/swup"><img src="https://img.shields.io/npm/v/swup.svg" alt="npm version"></a>
-  <img src="https://img.shields.io/bundlephobia/minzip/swup.svg" alt="Gzip Size">
+  <a href="https://bundlephobia.com/package/swup"><img src="https://img.shields.io/bundlephobia/minzip/swup.svg" alt="Bundle size"></a>
   <a href="https://github.com/gmrchk/swup/blob/master/LICENSE"><img src="https://img.shields.io/github/license/gmrchk/swup.svg" alt="License"></a>
   <a href="https://www.npmjs.com/package/swup"><img src="https://img.shields.io/npm/dt/swup.svg" alt="npm downloads"></a>
-  <a href="https://circleci.com/gh/swup/swup"><img src="https://circleci.com/gh/swup/swup.svg?style=svg" alt="CircleCI"></a>
+  <a href="https://circleci.com/gh/swup/swup"><img src="https://circleci.com/gh/swup/swup.svg?style=shield" alt="Build status"></a>
 </p>
 
 <br>

--- a/readme.md
+++ b/readme.md
@@ -1,60 +1,54 @@
-<h3 align="center">
-    <a href="https://github.com/swup/swup/discussions/424">We're looking for maintainers!</a>
-</h3>
+<a href="https://github.com/swup/swup/discussions/424">We're looking for maintainers!</a> 👀
 
 ---
 
-<p align="center">
-    <img width="300" alt="swup" src="https://swup.js.org/assets/images/swup-logo.svg">
-</p>
+<img src="https://swup.js.org/assets/images/swup-logo.svg" alt="swup logo" height="50" align="right">
 
-<p align="center">
-    Complete, flexible, extensible and easy to use page transition library for your static website.
-</p>
+# Swup
 
-<p align="center">
-    <a href="https://www.npmjs.com/package/swup">
-        <img src="https://img.shields.io/npm/v/swup.svg" alt="npm version">
-    </a>
-    <a href="https://bundlephobia.com/package/swup">
-        <img src="https://img.shields.io/bundlephobia/minzip/swup.svg" alt="Bundle size">
-    </a>
-    <a href="https://github.com/gmrchk/swup/blob/master/LICENSE">
-        <img src="https://img.shields.io/github/license/gmrchk/swup.svg" alt="License">
-    </a>
-    <a href="https://www.npmjs.com/package/swup">
-        <img src="https://img.shields.io/npm/dt/swup.svg" alt="npm downloads">
-    </a>
-    <a href="https://circleci.com/gh/swup/swup">
-        <img src="https://circleci.com/gh/swup/swup.svg?style=shield" alt="CircleCI">
-    </a>
-</p>
+[![npm version](https://img.shields.io/npm/v/swup.svg)](https://www.npmjs.com/package/swup)
+[![Bundle size](https://img.shields.io/bundlephobia/minzip/swup.svg)](https://bundlephobia.com/package/swup)
+[![License](https://img.shields.io/github/license/gmrchk/swup.svg)](https://github.com/gmrchk/swup/blob/master/LICENSE)
+[![npm downloads](https://img.shields.io/npm/dt/swup.svg)](https://www.npmjs.com/package/swup)
+[![Build status](https://circleci.com/gh/swup/swup.svg?style=shield)](https://circleci.com/gh/swup/swup)
 
-[Here](https://medium.com/@gmarcuk/introducing-swup-v2-814e40316dee)'s what's new in v2. Check [changelog](https://swup.js.org/other/changelog) for recent changes, see all [swup repositories](https://github.com/swup/) to discover more, or checkout the [discussions](https://github.com/swup/swup/discussions).
+Complete, flexible, extensible and easy to use page transition library for your static website.
+
+[Features](#features) •
+[Documentation](https://swup.js.org/getting-started) •
+[Plugins](https://swup.js.org/plugins) •
+[Themes](https://swup.js.org/themes) •
+[Discussions](https://github.com/swup/swup/discussions)
+
+## Overview
+
+Swup is a library that helps you add page transitions to server-side rendered websites. It handles
+the complete lifecycle of a page visit by intercepting link clicks, loading the new page in the
+background, replacing the content and transitioning between the old and the new page.
+
+Its goal is to make adding transition to a site as simple as possible, while providing lots of
+other quality-of-life improvements.
+
+## Features
+
+- Auto-detects [CSS transitions](https://swup.js.org/getting-started/how-it-works) for perfect timing
+- Updates URLs and preserves native browser history behavior
+- Uses a [cache](https://swup.js.org/api/cache) to speed up subsequent page loads
+- Offers [events](https://swup.js.org/events) for hooking into the lifecycle
+- Has a powerful [plugin system](https://swup.js.org/plugins) and many official and third-party plugins
+- Provides ready-to-go [themes](https://swup.js.org/themes) to get started quickly
+
+## Examples
 
 <img src="https://user-images.githubusercontent.com/9338324/49190360-50125480-f372-11e8-89e9-d2fb091a2240.gif" width="100%">
 
-- [Discussions](https://github.com/swup/swup/discussions)
-- [Getting Started](https://swup.js.org/getting-started)
-  - [Example](https://swup.js.org/getting-started/example)
-  - [Demo](https://swup.js.org/getting-started/demo)
-  - [Reloading JavaScript](https://swup.js.org/getting-started/reloading-javascript)
-  - [Video Tutorials](https://swup.js.org/getting-started/videos)
-- [Options](https://swup.js.org/options)
-- [Events](https://swup.js.org/events)
-- Extensions
-  - [Plugins](https://swup.js.org/plugins)
-  - [Themes](https://swup.js.org/themes)
-  - [3rd Party Integrations](https://swup.js.org/third-party-integrations)
-- [JavaScript API](https://swup.js.org/api)
-- [Swup CLI](https://swup.js.org/cli)
-- [CI/CD Integration](https://swup.js.org/ci-cd)
-- Other
-  - [Changelog](https://swup.js.org//other/changelog)
-  - [Contributions](https://swup.js.org/other/contributions)
-  - [Repositories](https://github.com/swup)
-  - [Sites using swup](https://github.com/swup/swup/discussions/333)
+Take a look at [Sites using swup](https://github.com/swup/swup/discussions/333) for more examples.
 
-If you're having trouble implementing swup, checkout [Common Issues](https://swup.js.org/other/common-issues), [Closed Issues](https://github.com/gmrchk/swup/issues?q=is%3Aissue+is%3Aclosed) or open a [new one](https://github.com/gmrchk/swup/issues/new).
+## Having trouble?
 
-[Become a backer or sponsor on Open Collective](https://opencollective.com/swup) or support swup through [GitHub sponsors](https://github.com/sponsors/gmrchk).
+If you're having trouble implementing swup, check out the [Common Issues](https://swup.js.org/other/common-issues) section of the docs, look at [closed issues](https://github.com/gmrchk/swup/issues?q=is%3Aissue+is%3Aclosed) or create a [new discussion](https://github.com/swup/swup/discussions/new).
+
+## Want to Contribute?
+
+Become a sponsor on [Open Collective](https://opencollective.com/swup) or support development through
+[GitHub sponsors](https://github.com/sponsors/gmrchk).

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 <a href="https://github.com/swup/swup/discussions/424">We're looking for maintainers!</a>   👀
 
-<hr style="border-bottom:1px solid var(--color-border-muted);">
+<br/>
 
 <img src="https://swup.js.org/assets/images/swup-logo.svg" alt="swup logo" height="50" align="right">
 

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,10 @@
 
 ---
 
-<img src="https://swup.js.org/assets/images/swup-logo.svg" alt="swup logo" height="50" align="right">
+<span align="right">
+    <img src="https://swup.js.org/assets/images/swup-logo.svg" alt="swup logo" height="50" align="right">
+    <br>
+</span>
 
 # Swup
 

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,6 @@
-<h3 align="center"><a href="https://github.com/swup/swup/discussions/424">We're looking for maintainers!</a></h3>
+<h3 align="center">
+    <a href="https://github.com/swup/swup/discussions/424">We're looking for maintainers!</a>
+</h3>
 
 ---
 
@@ -25,17 +27,17 @@ Complete, flexible, extensible and easy to use page transition library for your 
 - [Options](https://swup.js.org/options)
 - [Events](https://swup.js.org/events)
 - Extensions
-    - [Plugins](https://swup.js.org/plugins)
-    - [Themes](https://swup.js.org/themes)
-    - [3rd Party Integrations](https://swup.js.org/third-party-integrations)
+  - [Plugins](https://swup.js.org/plugins)
+  - [Themes](https://swup.js.org/themes)
+  - [3rd Party Integrations](https://swup.js.org/third-party-integrations)
 - [JavaScript API](https://swup.js.org/api)
 - [Swup CLI](https://swup.js.org/cli)
 - [CI/CD Integration](https://swup.js.org/ci-cd)
 - Other
-    - [Changelog](https://swup.js.org//other/changelog)
-    - [Contributions](https://swup.js.org/other/contributions)
-    - [Repositories](https://github.com/swup)
-    - [Sites using swup](https://github.com/swup/swup/discussions/333)
+  - [Changelog](https://swup.js.org//other/changelog)
+  - [Contributions](https://swup.js.org/other/contributions)
+  - [Repositories](https://github.com/swup)
+  - [Sites using swup](https://github.com/swup/swup/discussions/333)
 
 If you're having trouble implementing swup, checkout [Common Issues](https://swup.js.org/other/common-issues), [Closed Issues](https://github.com/gmrchk/swup/issues?q=is%3Aissue+is%3Aclosed) or open a [new one](https://github.com/gmrchk/swup/issues/new).
 

--- a/readme.md
+++ b/readme.md
@@ -9,11 +9,21 @@
 Complete, flexible, extensible and easy to use page transition library for your static web.
 </p>
 <p align="center">
-    <a href="https://www.npmjs.com/package/swup"><img src="https://img.shields.io/npm/v/swup.svg" alt="npm version"></a>
-    <img src="https://img.shields.io/bundlephobia/minzip/swup.svg" alt="Gzip Size">
-    <a href="https://github.com/gmrchk/swup/blob/master/LICENSE"><img src="https://img.shields.io/github/license/gmrchk/swup.svg" alt="License"></a>
-    <a href="https://www.npmjs.com/package/swup"><img src="https://img.shields.io/npm/dt/swup.svg" alt="npm downloads"></a>
-    <a href="https://circleci.com/gh/swup/swup"><img src="https://circleci.com/gh/swup/swup.svg?style=svg" alt="CircleCI"></a>
+    <a href="https://www.npmjs.com/package/swup">
+        <img src="https://img.shields.io/npm/v/swup.svg" alt="npm version">
+    </a>
+    <a href="https://bundlephobia.com/package/swup">
+        <img src="https://img.shields.io/bundlephobia/minzip/swup.svg" alt="Bundle size">
+    </a>
+    <a href="https://github.com/gmrchk/swup/blob/master/LICENSE">
+        <img src="https://img.shields.io/github/license/gmrchk/swup.svg" alt="License">
+    </a>
+    <a href="https://www.npmjs.com/package/swup">
+        <img src="https://img.shields.io/npm/dt/swup.svg" alt="npm downloads">
+    </a>
+    <a href="https://circleci.com/gh/swup/swup">
+        <img src="https://circleci.com/gh/swup/swup.svg?style=shield" alt="CircleCI">
+    </a>
 </p>
 
 [Here](https://medium.com/@gmarcuk/introducing-swup-v2-814e40316dee)'s what's new in v2. Check [changelog](https://swup.js.org/other/changelog) for recent changes, see all [swup repositories](https://github.com/swup/) to discover more, or checkout the [discussions](https://github.com/swup/swup/discussions).

--- a/readme.md
+++ b/readme.md
@@ -2,10 +2,7 @@
 
 ---
 
-<span align="right">
-    <img src="https://swup.js.org/assets/images/swup-logo.svg" alt="swup logo" height="50" align="right">
-    <br>
-</span>
+<img src="https://swup.js.org/assets/images/swup-logo.svg" alt="swup logo" height="50" align="right">
 
 # Swup
 

--- a/readme.md
+++ b/readme.md
@@ -4,10 +4,14 @@
 
 ---
 
-<p align="center"><img width="420" alt="swup" src="https://swup.js.org/assets/images/swup-logo.svg"></p>
 <p align="center">
-Complete, flexible, extensible and easy to use page transition library for your static web.
+    <img width="300" alt="swup" src="https://swup.js.org/assets/images/swup-logo.svg">
 </p>
+
+<p align="center">
+    Complete, flexible, extensible and easy to use page transition library for your static website.
+</p>
+
 <p align="center">
     <a href="https://www.npmjs.com/package/swup">
         <img src="https://img.shields.io/npm/v/swup.svg" alt="npm version">

--- a/readme.md
+++ b/readme.md
@@ -30,7 +30,7 @@ Swup is a library that helps you add page transitions to server-side rendered we
 the complete lifecycle of a page visit by intercepting link clicks, loading the new page in the
 background, replacing the content and transitioning between the old and the new page.
 
-Its goal is to make adding transition to a site as simple as possible, while providing lots of
+Its goal is to make adding transitions to a site as simple as possible, while providing lots of
 other quality-of-life improvements.
 
 ## Features

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
-<a href="https://github.com/swup/swup/discussions/424">We're looking for maintainers!</a> 👀
+<a href="https://github.com/swup/swup/discussions/424">We're looking for maintainers!</a>   👀
 
----
+<hr style="border-bottom:1px solid var(--color-border-muted);">
 
 <img src="https://swup.js.org/assets/images/swup-logo.svg" alt="swup logo" height="50" align="right">
 

--- a/readme.md
+++ b/readme.md
@@ -32,6 +32,8 @@
 
 [Here](https://medium.com/@gmarcuk/introducing-swup-v2-814e40316dee)'s what's new in v2. Check [changelog](https://swup.js.org/other/changelog) for recent changes, see all [swup repositories](https://github.com/swup/) to discover more, or checkout the [discussions](https://github.com/swup/swup/discussions).
 
+<img src="https://user-images.githubusercontent.com/9338324/49190360-50125480-f372-11e8-89e9-d2fb091a2240.gif" width="100%">
+
 - [Discussions](https://github.com/swup/swup/discussions)
 - [Getting Started](https://swup.js.org/getting-started)
   - [Example](https://swup.js.org/getting-started/example)
@@ -55,6 +57,4 @@
 
 If you're having trouble implementing swup, checkout [Common Issues](https://swup.js.org/other/common-issues), [Closed Issues](https://github.com/gmrchk/swup/issues?q=is%3Aissue+is%3Aclosed) or open a [new one](https://github.com/gmrchk/swup/issues/new).
 
-[Become a backer or sponsor on Open Collective](https://opencollective.com/swup) or support swup through [GitHub sponsors](https://github.com/sponsors/gmrchk). 
-
-<img src="https://user-images.githubusercontent.com/9338324/49190360-50125480-f372-11e8-89e9-d2fb091a2240.gif" width="100%">
+[Become a backer or sponsor on Open Collective](https://opencollective.com/swup) or support swup through [GitHub sponsors](https://github.com/sponsors/gmrchk).


### PR DESCRIPTION
The readme recently felt a bit out of date. I've tried to clean it up a little, explain the motivation and main features and provide some useful links on the very top. The logo is a bit smaller here to allow us to explain that swup is very early on and avoid having to scroll down.

I've been thinking about recreating the example GIF in better resolution and with a browser UI around it, to make it a bit more appealing, but that's for later.

You can check it out by visiting the branch URL directly: [updated](https://github.com/swup/swup/tree/update-readme) vs. [original](https://github.com/swup/swup/tree/master) versions.

<img width="927" alt="Screenshot 2022-09-03 at 17 16 54" src="https://user-images.githubusercontent.com/22225348/188277268-0df98583-c5da-4d45-8de2-fa815688f6fd.png">