### PR TITLE
Add option `cache.resolvePath: path => path`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -39,6 +39,9 @@ export default class Swup {
 			plugins: [],
 			skipPopStateHandling: function(event) {
 				return !(event.state && event.state.source === 'swup');
+			},
+			cache: {
+				resolvePath: path => path
 			}
 		};
 
@@ -88,7 +91,7 @@ export default class Swup {
 		this.boundPopStateHandler = this.popStateHandler.bind(this);
 
 		// make modules accessible in instance
-		this.cache = new Cache();
+		this.cache = new Cache(options.cache);
 		this.cache.swup = this;
 		this.loadPage = loadPage;
 		this.renderPage = renderPage;
@@ -262,7 +265,6 @@ export default class Swup {
 			document.documentElement.classList.remove('is-animating');
 			cleanupAnimationClasses();
 		}
-
 		this.loadPage({ url: link.getAddress() }, event);
 	}
 }

--- a/src/modules/Cache.js
+++ b/src/modules/Cache.js
@@ -1,13 +1,25 @@
 import { getCurrentUrl, normalizeUrl } from '../helpers.js';
 
 export class Cache {
-	constructor() {
+	constructor(options) {
 		this.pages = {};
 		this.last = null;
+
+		const defaults = {
+			resolvePath: path => path
+		}
+		this.options = {
+			...defaults,
+			...options
+		};
+	}
+
+	normalizeUrl(url) {
+		return this.options.resolvePath(normalizeUrl(url));
 	}
 
 	cacheUrl(page) {
-		page.url = normalizeUrl(page.url);
+		page.url = this.normalizeUrl(page.url);
 		if (page.url in this.pages === false) {
 			this.pages[page.url] = page;
 		}
@@ -16,7 +28,7 @@ export class Cache {
 	}
 
 	getPage(url) {
-		url = normalizeUrl(url);
+		url = this.normalizeUrl(url);
 		return this.pages[url];
 	}
 
@@ -25,7 +37,7 @@ export class Cache {
 	}
 
 	exists(url) {
-		url = normalizeUrl(url);
+		url = this.normalizeUrl(url);
 		return url in this.pages;
 	}
 

--- a/src/modules/renderPage.js
+++ b/src/modules/renderPage.js
@@ -3,7 +3,7 @@ import { Link } from '../helpers.js';
 const renderPage = function(page, popstate) {
 	document.documentElement.classList.remove('is-leaving');
 
-	const isCurrentPage = this.getCurrentUrl() === page.url;
+	const isCurrentPage = this.cache.normalizeUrl(this.getCurrentUrl()) === page.url;
 	if (!isCurrentPage) return;
 
 	// replace state in case the url was redirected


### PR DESCRIPTION
Allows control over how swup's cache resolves a path. Very simple usage example:

```js
const swup = const swup = new Swup({
    cache: {
        resolvePath: path => {
            if( path.startsWith('/projects/?') ) return '/projects/';
            return path;
        }
    }
});
```