### PR TITLE
Allow ignoring links from function callback

### DIFF
--- a/cypress/e2e/main.spec.js
+++ b/cypress/e2e/main.spec.js
@@ -157,15 +157,17 @@ context('Window', () => {
     });
 
     it('should ignore links with data-no-swup attr', () => {
-        cy.shouldNativelyLoadPageAfterAction('/page4/', () => {
+        cy.shouldHaveReloadedAfterAction(() => {
             cy.get(`a[data-no-swup]`).first().click();
         });
+        cy.shouldBeAtPage('/page4/');
     });
 
     it('should ignore links with data-no-swup parent', () => {
-        cy.shouldNativelyLoadPageAfterAction('/page4/', () => {
+        cy.shouldHaveReloadedAfterAction(() => {
             cy.get(`li[data-no-swup] a`).first().click();
         });
+        cy.shouldBeAtPage('/page4/');
     });
 
     // it('should ignore clicks when meta key pressed', () => {

--- a/cypress/e2e/main.spec.js
+++ b/cypress/e2e/main.spec.js
@@ -187,9 +187,10 @@ context('Window', () => {
     });
 
     it('should ignore SVG links by default', () => {
-        cy.shouldNativelyLoadPageAfterAction('/page2/', () => {
+        cy.shouldHaveReloadedAfterAction(() => {
             cy.get('svg a').first().click();
         });
+        cy.shouldBeAtPage('/page2/');
     });
 
     it('should follow SVG links when added to selector', () => {
@@ -202,9 +203,10 @@ context('Window', () => {
     });
 
     it('should ignore map area links by default', () => {
-        cy.shouldNativelyLoadPageAfterAction('/page2/', () => {
+        cy.shouldHaveReloadedAfterAction(() => {
             cy.get('map area').first().click({ force: true });
         });
+        cy.shouldBeAtPage('/page2/');
     });
 
     it('should follow map area links when added to selector', () => {

--- a/cypress/e2e/main.spec.js
+++ b/cypress/e2e/main.spec.js
@@ -147,6 +147,15 @@ context('Window', () => {
         cy.shouldHaveH1('Page 2');
     });
 
+    it('should ignore links to different origins', () => {
+        cy.shouldHaveReloadedAfterAction(() => {
+            cy.get('[data-cy=nav-link-ext]').click();
+        });
+        cy.location().should((loc) => {
+            expect(loc.origin).to.eq('https://example.net');
+        });
+    });
+
     it('should ignore links with data-no-swup attr', () => {
         cy.shouldNativelyLoadPageAfterAction('/page4/', () => {
             cy.get(`a[data-no-swup]`).first().click();

--- a/cypress/e2e/main.spec.js
+++ b/cypress/e2e/main.spec.js
@@ -147,6 +147,13 @@ context('Window', () => {
         cy.shouldHaveH1('Page 2');
     });
 
+    it('should resolve document base URLs', () => {
+        cy.visit('/page1/sub1/');
+        cy.get('[data-cy=nav-link-sub]').click();
+        cy.shouldBeAtPage('/page1/sub2/');
+        cy.shouldHaveH1('Sub 2');
+    });
+
     it('should ignore links to different origins', () => {
         cy.shouldHaveReloadedAfterAction(() => {
             cy.get('[data-cy=nav-link-ext]').click();

--- a/cypress/e2e/main.spec.js
+++ b/cypress/e2e/main.spec.js
@@ -147,6 +147,12 @@ context('Window', () => {
         });
     });
 
+    it('should ignore links with data-no-swup parent', () => {
+        cy.shouldNativelyLoadPageAfterAction('/page4/', () => {
+            cy.get(`li[data-no-swup] a`).first().click();
+        });
+    });
+
     // it('should ignore clicks when meta key pressed', () => {
     //     cy.triggerClickOnLink('/page2/', { metaKey: true });
     //     cy.wait(500);

--- a/cypress/e2e/main.spec.js
+++ b/cypress/e2e/main.spec.js
@@ -141,6 +141,12 @@ context('Window', () => {
         cy.shouldHaveH1('Page 2');
     });
 
+    it('should accept relative links', () => {
+        cy.get('[data-cy=nav-link-rel]').click();
+        cy.shouldBeAtPage('/page2/');
+        cy.shouldHaveH1('Page 2');
+    });
+
     it('should ignore links with data-no-swup attr', () => {
         cy.shouldNativelyLoadPageAfterAction('/page4/', () => {
             cy.get(`a[data-no-swup]`).first().click();

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -41,14 +41,6 @@ Cypress.Commands.add("shouldHaveReloadedAfterAction", (action) => {
     cy.window().should('not.have.prop', 'beforeReload');
 });
 
-Cypress.Commands.add("shouldNativelyLoadPageAfterAction", (url, action) => {
-    cy.window().then(window => window.beforeReload = true);
-    cy.window().should('have.prop', 'beforeReload', true);
-    cy.window().then(window => action(window));
-    cy.shouldBeAtPage(url);
-    cy.window().should('not.have.prop', 'beforeReload');
-});
-
 Cypress.Commands.add("shouldHaveH1", (str) => {
     cy.get('h1').should('contain', str);
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -34,6 +34,13 @@ Cypress.Commands.add("shouldBeAtPage", (href) => {
     });
 });
 
+Cypress.Commands.add("shouldHaveReloadedAfterAction", (action) => {
+    cy.window().then(window => window.beforeReload = true);
+    cy.window().should('have.prop', 'beforeReload', true);
+    cy.window().then(window => action(window));
+    cy.window().should('not.have.prop', 'beforeReload');
+});
+
 Cypress.Commands.add("shouldNativelyLoadPageAfterAction", (url, action) => {
     cy.window().then(window => window.beforeReload = true);
     cy.window().should('have.prop', 'beforeReload', true);

--- a/src/index.js
+++ b/src/index.js
@@ -27,9 +27,7 @@ export default class Swup {
 		let defaults = {
 			animateHistoryBrowsing: false,
 			animationSelector: '[class*="transition-"]',
-			linkSelector: `a[href^="${
-				window.location.origin
-			}"]:not([data-no-swup]), a[href^="/"]:not([data-no-swup]), a[href^="#"]:not([data-no-swup])`,
+			linkSelector: `a[href^="${window.location.origin}"], a[href^="/"], a[href^="#"]`,
 			ignoreLink: (el) => false,
 			cache: true,
 			containers: ['#swup'],
@@ -193,7 +191,17 @@ export default class Swup {
 		document.documentElement.classList.remove('swup-enabled');
 	}
 
+	isValidTrigger(triggerEl) {
+		if (triggerEl.closest('[data-no-swup]')) {
+			return false;
+		}
+		return true;
+	}
+
 	linkClickHandler(event) {
+		if (!this.isValidTrigger(event.delegateTarget)) {
+			return;
+		}
 		if (this.options.ignoreLink(event.delegateTarget)) {
 			return;
 		}

--- a/src/index.js
+++ b/src/index.js
@@ -30,6 +30,7 @@ export default class Swup {
 			linkSelector: `a[href^="${
 				window.location.origin
 			}"]:not([data-no-swup]), a[href^="/"]:not([data-no-swup]), a[href^="#"]:not([data-no-swup])`,
+			ignoreLink: (el) => false,
 			cache: true,
 			containers: ['#swup'],
 			requestHeaders: {
@@ -193,6 +194,10 @@ export default class Swup {
 	}
 
 	linkClickHandler(event) {
+		if (this.options.ignoreLink(event.delegateTarget)) {
+			return;
+		}
+
 		// no control key pressed
 		if (!event.metaKey && !event.ctrlKey && !event.shiftKey && !event.altKey) {
 			// index of pressed button needs to be checked because Firefox triggers click on all mouse buttons

--- a/src/index.js
+++ b/src/index.js
@@ -192,6 +192,9 @@ export default class Swup {
 	}
 
 	isValidTrigger(triggerEl) {
+		if (triggerEl.matches('[download], [target="_blank"]')) {
+			return false;
+		}
 		if (triggerEl.closest('[data-no-swup]')) {
 			return false;
 		}

--- a/src/index.js
+++ b/src/index.js
@@ -27,18 +27,10 @@ export default class Swup {
 		let defaults = {
 			animateHistoryBrowsing: false,
 			animationSelector: '[class*="transition-"]',
-			linkSelector: 'a', // deprecated
-			ignoreLink: (el) => {
-				if (el.origin !== window.location.origin) {
-					return true;
-				}
-				if (el.closest('[data-no-swup]')) {
-					return true;
-				}
-				return false;
-			},
 			cache: true,
 			containers: ['#swup'],
+			ignoreLink: (el) => el.origin !== window.location.origin || el.closest('[data-no-swup]'),
+			linkSelector: 'a', // deprecated
 			requestHeaders: {
 				'X-Requested-With': 'swup',
 				Accept: 'text/html, application/xhtml+xml'

--- a/src/index.js
+++ b/src/index.js
@@ -29,16 +29,17 @@ export default class Swup {
 			animationSelector: '[class*="transition-"]',
 			cache: true,
 			containers: ['#swup'],
-			ignoreLink: (el) => el.origin !== window.location.origin || el.closest('[data-no-swup]'),
+			ignoreLink: (el) => (
+				el.origin !== window.location.origin ||
+				el.closest('[data-no-swup]')
+			),
 			linkSelector: 'a[href]',
+			plugins: [],
 			requestHeaders: {
 				'X-Requested-With': 'swup',
-				Accept: 'text/html, application/xhtml+xml'
+				'Accept': 'text/html, application/xhtml+xml'
 			},
-			plugins: [],
-			skipPopStateHandling: function(event) {
-				return !(event.state && event.state.source === 'swup');
-			}
+			skipPopStateHandling: (event) => event.state?.source !== 'swup'
 		};
 
 		// merge options

--- a/src/index.js
+++ b/src/index.js
@@ -27,8 +27,16 @@ export default class Swup {
 		let defaults = {
 			animateHistoryBrowsing: false,
 			animationSelector: '[class*="transition-"]',
-			linkSelector: `a[href^="${window.location.origin}"], a[href^="/"], a[href^="#"]`,
-			ignoreLink: (el) => false,
+			linkSelector: 'a', // deprecated
+			ignoreLink: (el) => {
+				if (el.location.origin !== window.location.origin) {
+					return true;
+				}
+				if (el.closest('[data-no-swup]')) {
+					return true;
+				}
+				return false;
+			},
 			cache: true,
 			containers: ['#swup'],
 			requestHeaders: {
@@ -191,18 +199,8 @@ export default class Swup {
 		document.documentElement.classList.remove('swup-enabled');
 	}
 
-	isValidTrigger(triggerEl) {
-		if (triggerEl.matches('[download], [target="_blank"]')) {
-			return false;
-		}
-		if (triggerEl.closest('[data-no-swup]')) {
-			return false;
-		}
-		return true;
-	}
-
 	linkClickHandler(event) {
-		if (!this.isValidTrigger(event.delegateTarget)) {
+		if (this.triggerWillOpenNewWindow(event.delegateTarget)) {
 			return;
 		}
 		if (this.options.ignoreLink(event.delegateTarget)) {
@@ -262,6 +260,13 @@ export default class Swup {
 			// open in new tab (do nothing)
 			this.triggerEvent('openPageInNewTab', event);
 		}
+	}
+
+	triggerWillOpenNewWindow(triggerEl) {
+		if (triggerEl.matches('[download], [target="_blank"]')) {
+			return true;
+		}
+		return false;
 	}
 
 	popStateHandler(event) {

--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,7 @@ export default class Swup {
 			animationSelector: '[class*="transition-"]',
 			linkSelector: 'a', // deprecated
 			ignoreLink: (el) => {
-				if (el.location.origin !== window.location.origin) {
+				if (el.origin !== window.location.origin) {
 					return true;
 				}
 				if (el.closest('[data-no-swup]')) {

--- a/src/index.js
+++ b/src/index.js
@@ -30,7 +30,7 @@ export default class Swup {
 			cache: true,
 			containers: ['#swup'],
 			ignoreLink: (el) => el.origin !== window.location.origin || el.closest('[data-no-swup]'),
-			linkSelector: 'a', // deprecated
+			linkSelector: 'a[href]',
 			requestHeaders: {
 				'X-Requested-With': 'swup',
 				Accept: 'text/html, application/xhtml+xml'

--- a/src/modules/renderPage.js
+++ b/src/modules/renderPage.js
@@ -4,7 +4,7 @@ const renderPage = function(page, popstate) {
 	document.documentElement.classList.remove('is-leaving');
 
 	// do nothing if the URL has already changed since the request
-	if( !this.isSameResolvedPath(getCurrentUrl(), page.url) ) {
+	if (!this.isSameResolvedPath(getCurrentUrl(), page.url)) {
 		return;
 	}
 

--- a/test/site/page1/index.html
+++ b/test/site/page1/index.html
@@ -28,10 +28,10 @@
             <li><a href="/page3/">Page 3</a></li>
         </ul>
         <ul>
+            <li><a href="./../page2/" data-cy="nav-link-rel">Relative link</a></li>
             <li><a href="https://example.net/" data-cy="nav-link-ext">External link</a></li>
             <li><a href="/page4/" data-no-swup>Ignored link</a></li>
             <li data-no-swup><a href="/page4/">Ignored link parent</a></li>
-            <li><a href="./../page2/" data-cy="nav-link-rel">Relative link</a></li>
         </ul>
     </header>
     <main class="wrapper transition-default" id="swup" data-cy="container">

--- a/test/site/page1/index.html
+++ b/test/site/page1/index.html
@@ -26,7 +26,10 @@
             <li><a href="/page1/#anchor" data-cy="nav-to-anchor">Page 1 with anchor</a></li>
             <li><a href="/page2/">Page 2</a></li>
             <li><a href="/page3/">Page 3</a></li>
-            <li><a href="/page4/" data-no-swup>Page 4 with ignore attr</a></li>
+        </ul>
+        <ul>
+            <li><a href="/page4/" data-no-swup>Ignored link</a></li>
+            <li data-no-swup><a href="/page4/">Ignored link parent</a></li>
         </ul>
     </header>
     <main class="wrapper transition-default" id="swup" data-cy="container">

--- a/test/site/page1/index.html
+++ b/test/site/page1/index.html
@@ -30,6 +30,7 @@
         <ul>
             <li><a href="/page4/" data-no-swup>Ignored link</a></li>
             <li data-no-swup><a href="/page4/">Ignored link parent</a></li>
+            <li><a href="./../page2/" data-cy="nav-link-rel">Relative link</a></li>
         </ul>
     </header>
     <main class="wrapper transition-default" id="swup" data-cy="container">

--- a/test/site/page1/index.html
+++ b/test/site/page1/index.html
@@ -28,6 +28,7 @@
             <li><a href="/page3/">Page 3</a></li>
         </ul>
         <ul>
+            <li><a href="https://example.net/" data-cy="nav-link-ext">External link</a></li>
             <li><a href="/page4/" data-no-swup>Ignored link</a></li>
             <li data-no-swup><a href="/page4/">Ignored link parent</a></li>
             <li><a href="./../page2/" data-cy="nav-link-rel">Relative link</a></li>

--- a/test/site/page1/sub1/index.html
+++ b/test/site/page1/sub1/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>Sub 1</title>
+    <link rel="stylesheet" href="/assets/main.css">
+    <base href="/">
+</head>
+<body>
+    <header class="header">
+        <ul>
+            <li><a href="page1/sub1/">Sub 1</a></li>
+            <li><a href="page1/sub2/" data-cy="nav-link-sub">Sub 2</a></li>
+        </ul>
+    </header>
+    <main class="wrapper transition-default" id="swup">
+        <h1>Sub 1</h1>
+        Lorem ipsum dolor sit amet, consectetur adipisicing elit. Alias assumenda consectetur consequatur enim esse incidunt iusto, magnam maxime molestias nisi perferendis perspiciatis quibusdam quos repellat, vel veniam vero voluptate voluptatem.
+    </main>
+</body>
+</html>

--- a/test/site/page1/sub2/index.html
+++ b/test/site/page1/sub2/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>Sub 1</title>
+    <link rel="stylesheet" href="/assets/main.css">
+    <base href="/">
+</head>
+<body>
+    <header class="header">
+        <ul>
+            <li><a href="page1/sub1/">Sub 1</a></li>
+            <li><a href="page1/sub2/">Sub 2</a></li>
+        </ul>
+    </header>
+    <main class="wrapper transition-default" id="swup">
+        <h1>Sub 2</h1>
+        Lorem ipsum dolor sit amet, consectetur adipisicing elit. Alias assumenda consectetur consequatur enim esse incidunt iusto, magnam maxime molestias nisi perferendis perspiciatis quibusdam quos repellat, vel veniam vero voluptate voluptatem.
+    </main>
+</body>
+</html>


### PR DESCRIPTION
**Description**

Currently, the only official way of ignoring links is by appending the link selector option. This can get very complex very easily and it's not possible to do more advanced checks like e.g. ignoring all links inside a specific container. (The unofficial way would be listening to and preventing the click event in the capture phase).

The proposed change will split the check into to phases: select all links by selector, then filter via user-supplied callback.

This feature has been requested a few times and would be something I'd find very useful in my own projects.

**Advantages**

- Makes the selector much simpler
- Allows ignoring a whole container element with the `data-no-swup` attribute, not just every link individually
- We can add certain checks that will always skip swup, like `target=_blank` or the `download` attr on links
- Plugins can reuse some of the logic for other visit "triggers", e.g. forms plugin

**Checks**

- [x] The PR is submitted to the ~~`master`~~`next` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [x] New or updated tests are included
- [x] The documentation was [updated](https://github.com/swup/docs/pull/81) as required

**Additional information**

- This is a breaking change since we're ignoring `a[download]` elements. Hence submitting to the `next` branch.

**Questions**

- How would this tie in with #508 ?