### PR TITLE
New global option: `resolvePath`

### DIFF
--- a/cypress/e2e/main.spec.js
+++ b/cypress/e2e/main.spec.js
@@ -2,7 +2,7 @@
 
 // window._swup holds the swup instance
 
-const durationTolerance = 0.1; // 10% plus/minus
+const durationTolerance = 0.15; // 10% plus/minus
 
 context('Window', () => {
     beforeEach(() => {

--- a/cypress/e2e/main.spec.js
+++ b/cypress/e2e/main.spec.js
@@ -276,4 +276,44 @@ context('Window', () => {
             });
         });
     });
+
+	it('should ignore links for equal resolved paths', () => {
+		 cy.window().then(window => {
+			window._swup.options.resolvePath = path => '/page1/';
+			cy.triggerClickOnLink('/page2/');
+			cy.shouldBeAtPage('/page1/');
+		 });
+	});
+
+	it('should skip PopState handling for equal resolved paths', () => {
+		cy.window().then(window => {
+			window._swup.options.resolvePath = path => '/page1/';
+			window.history.pushState(
+				{
+					url: '/pushed-page-1/',
+					random: Math.random(),
+					source: 'swup'
+				},
+				document.title,
+				'/pushed-page-1/'
+			);
+
+            window.history.pushState(
+                {
+                    url: '/pushed-page-2/',
+                    random: Math.random(),
+                    source: 'swup'
+                },
+                document.title,
+                '/pushed-page-2/'
+            );
+
+			cy.wait(500).then(() => {
+				window.history.back();
+				cy.shouldBeAtPage('/pushed-page-1/');
+				cy.shouldHaveH1('Page 1');
+			})
+		});
+	})
+
 });

--- a/src/index.js
+++ b/src/index.js
@@ -274,7 +274,7 @@ export default class Swup {
 	/**
 	 * Utility function to validate and run the global option 'resolvePath'
 	 * @param {string} path
-	 * @returns string the resolved path
+	 * @returns {string} the resolved path
 	 */
 	resolvePath(path) {
 		if( typeof this.options.resolvePath !== 'function' ) {
@@ -283,7 +283,7 @@ export default class Swup {
 		return this.options.resolvePath(path);
 	}
 	/**
-	 * Compares the resolved path of two paths and returns true if they are the same
+	 * Compares the resolved version of two paths and returns true if they are the same
 	 * @param {string} path1
 	 * @param {string} path2
 	 * @returns {boolean}

--- a/src/index.js
+++ b/src/index.js
@@ -277,9 +277,15 @@ export default class Swup {
 	 */
 	resolvePath(path) {
 		if( typeof this.options.resolvePath !== 'function' ) {
+			console.warn(`[swup] options.resolvePath needs to be a function.`);
 			return path;
 		}
-		return this.options.resolvePath(path);
+		const result = this.options.resolvePath(path);
+		if( typeof result !== 'string' ) {
+			console.warn(`[swup] options.resolvePath needs to return a path`);
+			return path;
+		}
+		return result;
 	}
 	/**
 	 * Compares the resolved version of two paths and returns true if they are the same

--- a/src/index.js
+++ b/src/index.js
@@ -227,7 +227,7 @@ export default class Swup {
 						// link to the same URL without hash
 						this.triggerEvent('samePage', event);
 					}
-				} else {
+				} else if(!this.isSameResolvedPath(link.getAddress(), getCurrentUrl())) {
 					// link to different url
 					if (link.getHash() != '') {
 						this.scrollToElement = link.getHash();

--- a/src/index.js
+++ b/src/index.js
@@ -277,4 +277,13 @@ export default class Swup {
 		}
 		return this.options.resolvePath(path);
 	}
+	/**
+	 * Compares the resolved path of two paths and returns true if they are the same
+	 * @param {string} path1
+	 * @param {string} path2
+	 * @returns {boolean}
+	 */
+	isSameResolvedPath(path1, path2) {
+		return this.resolvePath(path1) === this.resolvePath(path2);
+	}
 }

--- a/src/index.js
+++ b/src/index.js
@@ -281,7 +281,7 @@ export default class Swup {
 			return path;
 		}
 		const result = this.options.resolvePath(path);
-		if( typeof result !== 'string' ) {
+		if( !result || typeof result !== 'string' ) {
 			console.warn(`[swup] options.resolvePath needs to return a path`);
 			return path;
 		}

--- a/src/index.js
+++ b/src/index.js
@@ -87,9 +87,8 @@ export default class Swup {
 		this.delegatedListeners = {};
 		// so we are able to remove the listener
 		this.boundPopStateHandler = this.popStateHandler.bind(this);
-		// allows us to compare the current resolved path inside popStateHandler
-		this.currentResolvedPath = null;
-		this.updateCurrentResolvedPath();
+		// allows us to compare the current and new path inside popStateHandler
+		this.currentPath = getCurrentUrl();
 
 		// make modules accessible in instance
 		this.cache = new Cache();
@@ -255,7 +254,7 @@ export default class Swup {
 	popStateHandler(event) {
 		if (this.options.skipPopStateHandling(event)) return;
 		// bail early if the resolved path hasn't changed
-		if (this.isSameResolvedPath(getCurrentUrl(), this.currentResolvedPath) ) return;
+		if (this.isSameResolvedPath(getCurrentUrl(), this.currentPath) ) return;
 		const link = new Link(event.state ? event.state.url : window.location.pathname);
 		if (link.getHash() !== '') {
 			this.scrollToElement = link.getHash();
@@ -290,12 +289,5 @@ export default class Swup {
 	 */
 	isSameResolvedPath(path1, path2) {
 		return this.resolvePath(path1) === this.resolvePath(path2);
-	}
-	/**
-	 * Utility method to update the current resolved path from the current URL
-	 * @returns {void}
-	 */
-	updateCurrentResolvedPath() {
-		this.currentResolvedPath = this.resolvePath(getCurrentUrl());
 	}
 }

--- a/src/index.js
+++ b/src/index.js
@@ -88,7 +88,7 @@ export default class Swup {
 		// so we are able to remove the listener
 		this.boundPopStateHandler = this.popStateHandler.bind(this);
 		// allows us to compare the current and new path inside popStateHandler
-		this.currentPath = getCurrentUrl();
+		this.currentPageUrl = getCurrentUrl();
 
 		// make modules accessible in instance
 		this.cache = new Cache();
@@ -254,7 +254,7 @@ export default class Swup {
 	popStateHandler(event) {
 		if (this.options.skipPopStateHandling(event)) return;
 		// bail early if the resolved path hasn't changed
-		if (this.isSameResolvedPath(getCurrentUrl(), this.currentPath) ) return;
+		if (this.isSameResolvedPath(getCurrentUrl(), this.currentPageUrl) ) return;
 		const link = new Link(event.state ? event.state.url : window.location.pathname);
 		if (link.getHash() !== '') {
 			this.scrollToElement = link.getHash();

--- a/src/index.js
+++ b/src/index.js
@@ -39,7 +39,8 @@ export default class Swup {
 			plugins: [],
 			skipPopStateHandling: function(event) {
 				return !(event.state && event.state.source === 'swup');
-			}
+			},
+			resolvePath: path => path
 		};
 
 		// merge options
@@ -264,5 +265,16 @@ export default class Swup {
 		}
 
 		this.loadPage({ url: link.getAddress() }, event);
+	}
+	/**
+	 * Utility function to validate and run the global option 'resolvePath'
+	 * @param {string} path
+	 * @returns string the resolved path
+	 */
+	resolvePath(path) {
+		if( typeof this.options.resolvePath !== 'function' ) {
+			return path;
+		}
+		return this.options.resolvePath(path);
 	}
 }

--- a/src/index.js
+++ b/src/index.js
@@ -87,8 +87,9 @@ export default class Swup {
 		this.delegatedListeners = {};
 		// so we are able to remove the listener
 		this.boundPopStateHandler = this.popStateHandler.bind(this);
-		// initially set the resolvedPath, so that we can compare it later
-		this.currentResolvedPath = this.resolvePath(getCurrentUrl());
+		// allows us to compare the current resolved path inside popStateHandler
+		this.currentResolvedPath = null;
+		this.updateCurrentResolvedPath();
 
 		// make modules accessible in instance
 		this.cache = new Cache();
@@ -289,5 +290,12 @@ export default class Swup {
 	 */
 	isSameResolvedPath(path1, path2) {
 		return this.resolvePath(path1) === this.resolvePath(path2);
+	}
+	/**
+	 * Utility method to update the current resolved path from the current URL
+	 * @returns {void}
+	 */
+	updateCurrentResolvedPath() {
+		this.currentResolvedPath = this.resolvePath(getCurrentUrl());
 	}
 }

--- a/src/index.js
+++ b/src/index.js
@@ -87,6 +87,8 @@ export default class Swup {
 		this.delegatedListeners = {};
 		// so we are able to remove the listener
 		this.boundPopStateHandler = this.popStateHandler.bind(this);
+		// initially set the resolvedPath, so that we can compare it later
+		this.currentResolvedPath = this.resolvePath(getCurrentUrl());
 
 		// make modules accessible in instance
 		this.cache = new Cache();
@@ -251,6 +253,8 @@ export default class Swup {
 
 	popStateHandler(event) {
 		if (this.options.skipPopStateHandling(event)) return;
+		// bail early if the resolved path hasn't changed
+		if (this.isSameResolvedPath(getCurrentUrl(), this.currentResolvedPath) ) return;
 		const link = new Link(event.state ? event.state.url : window.location.pathname);
 		if (link.getHash() !== '') {
 			this.scrollToElement = link.getHash();

--- a/src/modules/Cache.js
+++ b/src/modules/Cache.js
@@ -15,6 +15,7 @@ export class Cache {
 		if (page.url in this.pages === false) {
 			this.pages[page.url] = page;
 		}
+		page.responseURL = this.getCacheUrl(page.responseURL);
 		this.last = this.pages[page.url];
 		this.swup.log(`Cache (${Object.keys(this.pages).length})`, this.pages);
 	}

--- a/src/modules/Cache.js
+++ b/src/modules/Cache.js
@@ -6,8 +6,12 @@ export class Cache {
 		this.last = null;
 	}
 
+	getCacheUrl(url) {
+		return this.swup.resolvePath(normalizeUrl(url));
+	}
+
 	cacheUrl(page) {
-		page.url = normalizeUrl(page.url);
+		page.url = this.getCacheUrl(page.url);
 		if (page.url in this.pages === false) {
 			this.pages[page.url] = page;
 		}
@@ -16,7 +20,7 @@ export class Cache {
 	}
 
 	getPage(url) {
-		url = normalizeUrl(url);
+		url = this.getCacheUrl(url);
 		return this.pages[url];
 	}
 
@@ -25,7 +29,7 @@ export class Cache {
 	}
 
 	exists(url) {
-		url = normalizeUrl(url);
+		url = this.getCacheUrl(url);
 		return url in this.pages;
 	}
 
@@ -36,7 +40,7 @@ export class Cache {
 	}
 
 	remove(url) {
-		delete this.pages[url];
+		delete this.pages[this.getCacheUrl(url)];
 	}
 }
 

--- a/src/modules/loadPage.js
+++ b/src/modules/loadPage.js
@@ -53,7 +53,7 @@ const loadPage = function(data, popstate) {
 		this.triggerEvent('animationSkipped');
 	}
 
-	this.currentPath = getCurrentUrl();
+	this.currentPageUrl = getCurrentUrl();
 
 	// start/skip loading of page
 	if (this.cache.exists(data.url)) {

--- a/src/modules/loadPage.js
+++ b/src/modules/loadPage.js
@@ -1,4 +1,4 @@
-import { classify, createHistoryRecord, fetch } from '../helpers.js';
+import { classify, createHistoryRecord, fetch, getCurrentUrl } from '../helpers.js';
 
 const loadPage = function(data, popstate) {
 	// create array for storing animation promises
@@ -53,7 +53,7 @@ const loadPage = function(data, popstate) {
 		this.triggerEvent('animationSkipped');
 	}
 
-	this.updateCurrentResolvedPath();
+	this.currentPath = getCurrentUrl();
 
 	// start/skip loading of page
 	if (this.cache.exists(data.url)) {

--- a/src/modules/loadPage.js
+++ b/src/modules/loadPage.js
@@ -53,6 +53,8 @@ const loadPage = function(data, popstate) {
 		this.triggerEvent('animationSkipped');
 	}
 
+	this.updateCurrentResolvedPath();
+
 	// start/skip loading of page
 	if (this.cache.exists(data.url)) {
 		xhrPromise = new Promise((resolve) => {

--- a/src/modules/renderPage.js
+++ b/src/modules/renderPage.js
@@ -22,7 +22,7 @@ const renderPage = function(page, popstate) {
 		// save new record for redirected url
 		this.cache.cacheUrl({ ...page, url });
 
-		this.updateCurrentResolvedPath();
+		this.currentPath = getCurrentUrl();
 	}
 
 	// only add for non-popstate transitions

--- a/src/modules/renderPage.js
+++ b/src/modules/renderPage.js
@@ -3,8 +3,10 @@ import { Link, getCurrentUrl } from '../helpers.js';
 const renderPage = function(page, popstate) {
 	document.documentElement.classList.remove('is-leaving');
 
-	const isCurrentPage = this.isSameResolvedPath(getCurrentUrl(), page.url);
-	if (!isCurrentPage) return;
+	// do nothing if the URL has already changed since the request
+	if( !this.isSameResolvedPath(getCurrentUrl(), page.url) ) {
+		return;
+	}
 
 	// replace state in case the url was redirected
 	const url = new Link(page.responseURL).getPath();

--- a/src/modules/renderPage.js
+++ b/src/modules/renderPage.js
@@ -24,7 +24,7 @@ const renderPage = function(page, popstate) {
 		// save new record for redirected url
 		this.cache.cacheUrl({ ...page, url });
 
-		this.currentPath = getCurrentUrl();
+		this.currentPageUrl = getCurrentUrl();
 	}
 
 	// only add for non-popstate transitions

--- a/src/modules/renderPage.js
+++ b/src/modules/renderPage.js
@@ -1,14 +1,14 @@
-import { Link } from '../helpers.js';
+import { Link, getCurrentUrl } from '../helpers.js';
 
 const renderPage = function(page, popstate) {
 	document.documentElement.classList.remove('is-leaving');
 
-	const isCurrentPage = this.getCurrentUrl() === page.url;
+	const isCurrentPage = this.isSameResolvedPath(getCurrentUrl(), page.url);
 	if (!isCurrentPage) return;
 
 	// replace state in case the url was redirected
 	const url = new Link(page.responseURL).getPath();
-	if (window.location.pathname !== url) {
+	if (!this.isSameResolvedPath(window.location.pathname, url)) {
 		window.history.replaceState(
 			{
 				url,

--- a/src/modules/renderPage.js
+++ b/src/modules/renderPage.js
@@ -21,6 +21,8 @@ const renderPage = function(page, popstate) {
 
 		// save new record for redirected url
 		this.cache.cacheUrl({ ...page, url });
+
+		this.updateCurrentResolvedPath();
 	}
 
 	// only add for non-popstate transitions


### PR DESCRIPTION
Replaces #508 

Adds a new global option to swup, that allows to run a callback for how swup should resolve a path. 

## What is the problem?

Right now, to be able to leave and re-enter control over the browser URL/state by swup, three steps are necessary: 

- Use [`skipPopStateHandling`](https://swup.js.org/options#skip-popstate-handling) with custom logic
- Manually ignore links with one of the given options ([`linkSelector`](https://swup.js.org/options#link-selector), [`stopPropagation()`](https://github.com/swup/swup/issues/236#issuecomment-1203786475) during the capture phase,...)
- Manually adjust the cache URLs so that back- and forward navigation doesn't need additional server requests

While this kind of behavior is already possible to achieve with the currently available swup API, it adds a lot of boilerplate to each new site that wants to have this. Also, the current cache implementation is less than ideal for that kind of scenario right now. It will either fill itself up with unnecessary duplicates of the same page or have cache misses for pages that were previously already loaded from the server.

## Proposed solution

All three of the above topics basically boil down to always the same question: Should various paths actually be resolved to just one by swup?

- on `popState`: Is the resolved version of the new browser URL the same as the previous one? > ignore
- on `clickLink`: Is the resolved href of the link the same as the current browser URL? > ignore
- Accordingly to swup ignoring the above events if paths resolve to the same one, the cache can also just keep one copy for all URLs that resolve to the same one.

## Demo & Test Site

I have set-up a test site here: https://test.rassohilber.com/swup-resolve-path/test/ 

On that site, the whole filter logic is done by a custom component that doesn't want swup to interfere. It does everything from updating the URL to rendering the state. Navigation away from the list to one of the character detail pages or to the "about"-page and back again is being handled by swup again. To make it more obvious that there is no page load between filters, I added a staggered animation to the items that only runs if the page is being fully rendered (initially and by swup).

## Code Example

```js
const swup = new Swup({
  resolvePath: path => {
    // resolve every URL that contains '/?=filter=xyz' to '/'
    return path.replace(/\/\?filter=.+/, '/');
  }
})
```

## Checks
- [x] The code was linted before pushing
- [x] All tests are passing
- [x] New or updated tests are included
- [ ] The documentation was updated as required
- [ ] Make sure that [restoring scroll positions in ScrollPlugin](https://github.com/swup/scroll-plugin/pull/26) also uses the resolved path
