### PR TITLE
Allow usage without animations

### DIFF
--- a/cypress/e2e/main.spec.js
+++ b/cypress/e2e/main.spec.js
@@ -2,7 +2,7 @@
 
 // window._swup holds the swup instance
 
-const durationTolerance = 0.1; // 10% plus/minus
+const durationTolerance = 0.15; // 15% plus/minus
 
 context('Window', () => {
     beforeEach(() => {

--- a/cypress/e2e/main.spec.js
+++ b/cypress/e2e/main.spec.js
@@ -132,6 +132,15 @@ context('Window', () => {
         cy.shouldHaveH1('Page 3');
     });
 
+    it('should transition if no containers defined', () => {
+        cy.window().then(window => {
+            window._swup.options.animationSelector = false;
+        });
+        cy.triggerClickOnLink('/page2/');
+        cy.shouldBeAtPage('/page2/');
+        cy.shouldHaveH1('Page 2');
+    });
+
     it('should transition if no CSS transition is defined', () => {
         cy.window().then(window => {
             window.document.documentElement.classList.add('test--no-transitions');

--- a/src/modules/getAnimationPromises.js
+++ b/src/modules/getAnimationPromises.js
@@ -21,6 +21,8 @@ export default function getAnimationPromises() {
 
 	// Allow usage of swup without animations
 	if (selector === false) {
+		// Use array of a single resolved promise instead of an empty array to allow
+		// possible future use with Promise.race() which requires an actual value
 		return [Promise.resolve()];
 	}
 

--- a/src/modules/getAnimationPromises.js
+++ b/src/modules/getAnimationPromises.js
@@ -18,8 +18,15 @@ if (window.onanimationend === undefined && window.onwebkitanimationend !== undef
 
 export default function getAnimationPromises() {
 	const selector = this.options.animationSelector;
+
+	// Allow usage of swup without animations
+	if (selector === false) {
+		return [Promise.resolve()];
+	}
+
 	const animatedElements = queryAll(selector, document.body);
 
+	// Warn if no animated containers found on page, but keep things going
 	if (!animatedElements.length) {
 		console.warn(`[swup] No animated elements found by selector ${selector}`);
 		return [Promise.resolve()];


### PR DESCRIPTION
Closes #510 by not warning about missing containers if the animation selector is boolean `false`.

**Checks**

- [x] The PR is submitted to the `next` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [x] New or updated tests are included
- [ ] The documentation was updated as required