### PR TITLE
Add refactorings from fragments branch

### DIFF
--- a/cypress/e2e/main.spec.js
+++ b/cypress/e2e/main.spec.js
@@ -257,7 +257,7 @@ context('Window', () => {
         cy.window().then(window => {
             window.history.back();
             cy.window().should(() => {
-                expect(window.history.state.url, 'page url not saved').to.equal('http://localhost:8274/page1/');
+                expect(window.history.state.url, 'page url not saved').to.equal('/page1/');
                 expect(window.history.state.source, 'state source not saved').to.equal('swup');
             });
         });

--- a/src/helpers/createHistoryRecord.js
+++ b/src/helpers/createHistoryRecord.js
@@ -1,13 +1,12 @@
-const createHistoryRecord = (url) => {
-	window.history.pushState(
-		{
-			url: url || window.location.href.split(window.location.hostname)[1],
-			random: Math.random(),
-			source: 'swup'
-		},
-		document.title,
-		url || window.location.href.split(window.location.hostname)[1]
-	);
+const createHistoryRecord = (url, customData = {}) => {
+	url = url || window.location.href.split(window.location.hostname)[1];
+	const data = {
+		url,
+		random: Math.random(),
+		source: 'swup',
+		...customData
+	};
+	window.history.pushState(data, document.title, url);
 };
 
 export default createHistoryRecord;

--- a/src/helpers/createHistoryRecord.js
+++ b/src/helpers/createHistoryRecord.js
@@ -1,5 +1,7 @@
+import { getCurrentUrl } from '../helpers.js';
+
 const createHistoryRecord = (url, customData = {}) => {
-	url = url || location.href;
+	url = url || getCurrentUrl({ hash: true });
 	const data = {
 		url,
 		random: Math.random(),

--- a/src/helpers/createHistoryRecord.js
+++ b/src/helpers/createHistoryRecord.js
@@ -1,12 +1,12 @@
 const createHistoryRecord = (url, customData = {}) => {
-	url = url || window.location.href.split(window.location.hostname)[1];
+	url = url || location.href;
 	const data = {
 		url,
 		random: Math.random(),
 		source: 'swup',
 		...customData
 	};
-	window.history.pushState(data, document.title, url);
+	history.pushState(data, '', url);
 };
 
 export default createHistoryRecord;

--- a/src/helpers/getCurrentUrl.js
+++ b/src/helpers/getCurrentUrl.js
@@ -1,5 +1,5 @@
-const getCurrentUrl = () => {
-	return window.location.pathname + window.location.search;
+const getCurrentUrl = ({ hash = false } = {}) => {
+	return location.pathname + location.search + (hash ? location.hash : '');
 };
 
 export default getCurrentUrl;

--- a/src/helpers/getDataFromHtml.js
+++ b/src/helpers/getDataFromHtml.js
@@ -20,18 +20,14 @@ const getDataFromHtml = (html, containers) => {
 		}
 	});
 
-	const json = {
-		title: (fakeDom.querySelector('title') || {}).innerText,
-		pageClass: fakeDom.querySelector('body').className,
-		originalContent: html,
-		blocks: blocks
-	};
+	const title = query('title', fakeDom)?.innerText;
+	const pageClass = query('body', fakeDom)?.className;
 
 	// to prevent memory leaks
 	fakeDom.innerHTML = '';
 	fakeDom = null;
 
-	return json;
+	return { title, pageClass, blocks, originalContent: html };
 };
 
 export default getDataFromHtml;

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -1,5 +1,6 @@
 export { default as classify } from './classify.js';
 export { default as createHistoryRecord } from './createHistoryRecord.js';
+export { default as updateHistoryRecord } from './updateHistoryRecord.js';
 export { default as getDataFromHtml } from './getDataFromHtml.js';
 export { default as fetch } from './fetch.js';
 export { default as getCurrentUrl } from './getCurrentUrl.js';

--- a/src/helpers/updateHistoryRecord.js
+++ b/src/helpers/updateHistoryRecord.js
@@ -1,13 +1,13 @@
 const updateHistoryRecord = (url = null, customData = {}) => {
-	url = url || window.location.href; // window.location.href.split(window.location.hostname)[1];
+	url = url || location.href;
 	const data = {
-		...window.history.state,
+		...history.state,
 		url,
 		random: Math.random(),
 		source: 'swup',
 		...customData
 	};
-	window.history.replaceState(data, document.title, url);
+	history.replaceState(data, '', url);
 };
 
 export default updateHistoryRecord;

--- a/src/helpers/updateHistoryRecord.js
+++ b/src/helpers/updateHistoryRecord.js
@@ -1,0 +1,13 @@
+const updateHistoryRecord = (url = null, customData = {}) => {
+	url = url || window.location.href; // window.location.href.split(window.location.hostname)[1];
+	const data = {
+		...window.history.state,
+		url,
+		random: Math.random(),
+		source: 'swup',
+		...customData
+	};
+	window.history.replaceState(data, document.title, url);
+};
+
+export default updateHistoryRecord;

--- a/src/helpers/updateHistoryRecord.js
+++ b/src/helpers/updateHistoryRecord.js
@@ -1,5 +1,7 @@
+import { getCurrentUrl } from '../helpers.js';
+
 const updateHistoryRecord = (url = null, customData = {}) => {
-	url = url || location.href;
+	url = url || getCurrentUrl({ hash: true });
 	const data = {
 		...history.state,
 		url,

--- a/src/index.js
+++ b/src/index.js
@@ -32,10 +32,9 @@ export default class Swup {
 			animationSelector: '[class*="transition-"]',
 			cache: true,
 			containers: ['#swup'],
-			ignoreLink: (el) => (
-				el.origin !== window.location.origin ||
-				el.closest('[data-no-swup]')
-			),
+			ignoreLink: (el) => {
+				return el.origin !== window.location.origin || el.closest('[data-no-swup]');
+			},
 			linkSelector: 'a[href]',
 			plugins: [],
 			resolvePath: (path) => path,

--- a/src/index.js
+++ b/src/index.js
@@ -222,12 +222,13 @@ export default class Swup {
 		const url = link.getAddress();
 		const hash = link.getHash();
 
+		// Handle links to the same page and exit early, where applicable
 		if (!url || url === getCurrentUrl()) {
 			this.handleLinkToSamePage(url, hash, event);
 			return;
 		}
 
-		// Bail early if the resolved path hasn't changed
+		// Exit early if the resolved path hasn't changed
 		if (this.isSameResolvedPath(url, getCurrentUrl())) return;
 
 		// Store the element that should be scrolled to after loading the next page
@@ -241,7 +242,7 @@ export default class Swup {
 	}
 
 	handleLinkToSamePage(url, hash, event) {
-		// link to the same URL without hash
+		// Emit event and exit early if the url points to the same page without hash
 		if (!hash) {
 			this.triggerEvent('samePage', event);
 			return;
@@ -251,7 +252,8 @@ export default class Swup {
 		this.triggerEvent('samePageWithHash', event);
 
 		const element = getAnchorElement(hash);
-		// Warn and bail early if no element was found for the hash
+
+		// Warn and exit early if no matching element was found for the hash
 		if (!element) {
 			return console.warn(`Element for offset not found (#${hash})`);
 		}

--- a/src/index.js
+++ b/src/index.js
@@ -150,15 +150,7 @@ export default class Swup {
 		});
 
 		// modify initial history record
-		window.history.replaceState(
-			Object.assign({}, window.history.state, {
-				url: window.location.href,
-				random: Math.random(),
-				source: 'swup'
-			}),
-			document.title,
-			window.location.href
-		);
+		updateHistoryRecord();
 
 		// trigger enabled event
 		this.triggerEvent('enabled');

--- a/src/index.js
+++ b/src/index.js
@@ -261,9 +261,11 @@ export default class Swup {
 		}
 
 		// Exit early if the resolved path hasn't changed
-		if (this.isSameResolvedPath(getCurrentUrl(), this.currentPageUrl)) return;
+		if (this.isSameResolvedPath(getCurrentUrl(), this.currentPageUrl)) {
+			return;
+		}
 
-		const url = event.state?.url ?? window.location.href;
+		const url = event.state?.url ?? location.href;
 
 		const link = new Link(url);
 		if (link.getHash()) {

--- a/src/index.js
+++ b/src/index.js
@@ -223,7 +223,7 @@ export default class Swup {
 		const url = link.getAddress();
 		const hash = link.getHash();
 
-		if (url == getCurrentUrl() || url == '') {
+		if (!url || url == getCurrentUrl()) {
 			if (!hash) {
 				// link to the same URL without hash
 				this.triggerEvent('samePage', event);

--- a/src/modules/enterPage.js
+++ b/src/modules/enterPage.js
@@ -1,0 +1,24 @@
+import { nextTick } from '../utils.js';
+
+const enterPage = function({ popstate = false, skipTransition = false } = {}) {
+	if (skipTransition) {
+		this.triggerEvent('transitionEnd', popstate);
+		this.cleanupAnimationClasses();
+		return [Promise.resolve()];
+	}
+
+	nextTick(() => {
+		this.triggerEvent('animationInStart');
+		document.documentElement.classList.remove('is-animating');
+	});
+
+	const animationPromises = this.getAnimationPromises('in');
+	Promise.all(animationPromises).then(() => {
+		this.triggerEvent('animationInDone');
+		this.triggerEvent('transitionEnd', popstate);
+		this.cleanupAnimationClasses();
+	});
+	return animationPromises;
+};
+
+export default enterPage;

--- a/src/modules/getPageData.js
+++ b/src/modules/getPageData.js
@@ -2,18 +2,17 @@ import { getDataFromHtml } from '../helpers.js';
 
 const getPageData = function(request) {
 	// this method can be replaced in case other content than html is expected to be received from server
-	// this function should always return {title, pageClass, originalContent, blocks, responseURL}
+	// this function should always return { title, pageClass, originalContent, blocks, responseURL }
 	// in case page has invalid structure - return null
 	const html = request.responseText;
-	let pageObject = getDataFromHtml(html, this.options.containers);
+	const pageObject = getDataFromHtml(html, this.options.containers);
 
-	if (pageObject) {
-		pageObject.responseURL = request.responseURL ? request.responseURL : window.location.href;
-	} else {
+	if (!pageObject) {
 		console.warn('[swup] Received page is invalid.');
 		return null;
 	}
 
+	pageObject.responseURL = request.responseURL || window.location.href;
 	return pageObject;
 };
 

--- a/src/modules/leavePage.js
+++ b/src/modules/leavePage.js
@@ -1,0 +1,28 @@
+import { classify } from '../helpers.js';
+
+const leavePage = function(data, { popstate = false, skipTransition = false } = {}) {
+	if (skipTransition) {
+		this.triggerEvent('animationSkipped');
+		return [Promise.resolve()];
+	}
+
+	this.triggerEvent('animationOutStart');
+
+	// handle classes
+	document.documentElement.classList.add('is-changing');
+	document.documentElement.classList.add('is-leaving');
+	document.documentElement.classList.add('is-animating');
+	if (popstate) {
+		document.documentElement.classList.add('is-popstate');
+	}
+	document.documentElement.classList.add(`to-${classify(data.url)}`);
+
+	// animation promise stuff
+	const animationPromises = this.getAnimationPromises('out');
+	Promise.all(animationPromises).then(() => {
+		this.triggerEvent('animationOutDone');
+	});
+	return animationPromises;
+};
+
+export default leavePage;

--- a/src/modules/loadPage.js
+++ b/src/modules/loadPage.js
@@ -10,7 +10,7 @@ const loadPage = function(data, popstate = false) {
 	this.triggerEvent('transitionStart', popstate);
 
 	// set transition object
-	this.updateTransition(window.location.pathname, url, customTransition);
+	this.updateTransition(getCurrentUrl(), url, customTransition);
 	if (customTransition != null) {
 		document.documentElement.classList.add(`to-${classify(customTransition)}`);
 	}

--- a/src/modules/loadPage.js
+++ b/src/modules/loadPage.js
@@ -71,7 +71,7 @@ const loadPage = function(data, popstate = false) {
 			};
 
 			// go back to the actual page were still at
-			window.history.go(-1);
+			history.go(-1);
 		});
 };
 

--- a/src/modules/renderPage.js
+++ b/src/modules/renderPage.js
@@ -15,6 +15,7 @@ const renderPage = function(page, { popstate } = {}) {
 	const url = new Link(page.responseURL).getAddress();
 	if (!this.isSameResolvedPath(getCurrentUrl(), url)) {
 		this.cache.cacheUrl({ ...page, url });
+		this.currentPageUrl = getCurrentUrl();
 		updateHistoryRecord(url);
 	}
 

--- a/src/modules/renderPage.js
+++ b/src/modules/renderPage.js
@@ -4,20 +4,18 @@ import { query } from '../utils.js';
 const renderPage = function(page, { popstate } = {}) {
 	document.documentElement.classList.remove('is-leaving');
 
-	// Ignore rendering if another page was loaded in the meantime
-	if (getCurrentUrl() !== page.url) {
+	// do nothing if another page was requested in the meantime
+	if (!this.isSameResolvedPath(getCurrentUrl(), page.url)) {
 		return;
 	}
 
 	const skipTransition = popstate && !this.options.animateHistoryBrowsing;
 
-	// replace state in case the url was redirected
+	// update cache and state if the url was redirected
 	const url = new Link(page.responseURL).getAddress();
-	if (window.location.pathname !== url) {
-		updateHistoryRecord(url);
-
-		// save new record for redirected url
+	if (!this.isSameResolvedPath(getCurrentUrl(), url)) {
 		this.cache.cacheUrl({ ...page, url });
+		updateHistoryRecord(url);
 	}
 
 	// only add for page loads with transitions

--- a/src/modules/renderPage.js
+++ b/src/modules/renderPage.js
@@ -1,44 +1,42 @@
-import { Link, getCurrentUrl } from '../helpers.js';
+import { Link, updateHistoryRecord } from '../helpers.js';
+import { query } from '../utils.js';
 
-const renderPage = function(page, popstate) {
+const renderPage = function(page, { popstate } = {}) {
 	document.documentElement.classList.remove('is-leaving');
 
-	// do nothing if the URL has already changed since the request
-	if (!this.isSameResolvedPath(getCurrentUrl(), page.url)) {
+	const isCurrentPage = this.getCurrentUrl() === page.url;
+	if (!isCurrentPage) {
+		console.log('not current page:', this.getCurrentUrl(), 'vs', page.url, page);
 		return;
 	}
 
+	const skipTransition = popstate && !this.options.animateHistoryBrowsing;
+
 	// replace state in case the url was redirected
-	const url = new Link(page.responseURL).getPath();
-	if (!this.isSameResolvedPath(window.location.pathname, url)) {
-		window.history.replaceState(
-			{
-				url,
-				random: Math.random(),
-				source: 'swup'
-			},
-			document.title,
-			url
-		);
+	const url = new Link(page.responseURL).getAddress();
+	if (window.location.pathname !== url) {
+		updateHistoryRecord(url);
 
 		// save new record for redirected url
 		this.cache.cacheUrl({ ...page, url });
-
-		this.currentPageUrl = getCurrentUrl();
 	}
 
-	// only add for non-popstate transitions
-	if (!popstate || this.options.animateHistoryBrowsing) {
+	// only add for page loads with transitions
+	if (!skipTransition) {
 		document.documentElement.classList.add('is-rendering');
 	}
 
 	this.triggerEvent('willReplaceContent', popstate);
+
 	// replace blocks
-	for (let i = 0; i < page.blocks.length; i++) {
-		document.body.querySelector(`[data-swup="${i}"]`).outerHTML = page.blocks[i];
-	}
+	page.blocks.forEach((html, i) => {
+		const block = query(`[data-swup="${i}"]`, document.body);
+		block.outerHTML = html;
+	});
+
 	// set title
 	document.title = page.title;
+
 	this.triggerEvent('contentReplaced', popstate);
 	this.triggerEvent('pageView', popstate);
 
@@ -47,25 +45,8 @@ const renderPage = function(page, popstate) {
 		this.cache.empty();
 	}
 
-	// start animation IN
-	setTimeout(() => {
-		if (!popstate || this.options.animateHistoryBrowsing) {
-			this.triggerEvent('animationInStart');
-			document.documentElement.classList.remove('is-animating');
-		}
-	}, 10);
-
-	// handle end of animation
-	if (!popstate || this.options.animateHistoryBrowsing) {
-		const animationPromises = this.getAnimationPromises('in');
-		Promise.all(animationPromises).then(() => {
-			this.triggerEvent('animationInDone');
-			this.triggerEvent('transitionEnd', popstate);
-			this.cleanupAnimationClasses();
-		});
-	} else {
-		this.triggerEvent('transitionEnd', popstate);
-	}
+	// Perform in transition
+	this.enterPage({ popstate, skipTransition });
 
 	// reset scroll-to element
 	this.scrollToElement = null;

--- a/src/modules/renderPage.js
+++ b/src/modules/renderPage.js
@@ -1,12 +1,11 @@
-import { Link, updateHistoryRecord } from '../helpers.js';
+import { Link, updateHistoryRecord, getCurrentUrl } from '../helpers.js';
 import { query } from '../utils.js';
 
 const renderPage = function(page, { popstate } = {}) {
 	document.documentElement.classList.remove('is-leaving');
 
-	const isCurrentPage = this.getCurrentUrl() === page.url;
-	if (!isCurrentPage) {
-		console.log('not current page:', this.getCurrentUrl(), 'vs', page.url, page);
+	// Ignore rendering if another page was loaded in the meantime
+	if (getCurrentUrl() !== page.url) {
 		return;
 	}
 

--- a/src/modules/updateTransition.js
+++ b/src/modules/updateTransition.js
@@ -1,10 +1,5 @@
 const updateTransition = function(from, to, custom) {
-	// transition routes
-	this.transition = {
-		from: from,
-		to: to,
-		custom: custom
-	};
+	this.transition = { from, to, custom };
 };
 
 export default updateTransition;

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -14,6 +14,14 @@ export const queryAll = (selector, context = document) => {
 	return Array.from(context.querySelectorAll(selector));
 };
 
+export const nextTick = (callback) => {
+	requestAnimationFrame(() => {
+		requestAnimationFrame(() => {
+			callback();
+		});
+	});
+};
+
 export const escapeCssIdentifier = (ident) => {
 	if (window.CSS && window.CSS.escape) {
 		return CSS.escape(ident);


### PR DESCRIPTION
The fragments feature won't be part of swup 3, but the feature branch has a few things we'd like to merge already:

- General refactoring, simplifications and formatting
- Add early returns to event handlers to avoid excessive nesting of if/else blocks
- Extract `leavePage` and `enterPage` into separate modules/steps, making work on future features easier
- Add `nextTick` helper for animation timings
- Add `updateHistoryRecord` helper in addition to existing `createHistoryRecord`

Tests are still passing.