### PR TITLE
Rename `resolvePath()` to `resolveUrl()`

### DIFF
--- a/cypress/e2e/main.spec.js
+++ b/cypress/e2e/main.spec.js
@@ -2,7 +2,7 @@
 
 // window._swup holds the swup instance
 
-const durationTolerance = 0.15; // 15% plus/minus
+const durationTolerance = 0.2; // 20% plus/minus
 
 context('Window', () => {
     beforeEach(() => {

--- a/cypress/e2e/main.spec.js
+++ b/cypress/e2e/main.spec.js
@@ -386,9 +386,9 @@ context('Window', () => {
         });
     });
 
-    it('should ignore links for equal resolved paths', () => {
+    it('should ignore links for equal resolved urls', () => {
          cy.window().then(window => {
-            window._swup.options.resolvePath = path => '/page1/';
+            window._swup.options.resolveUrl = url =>'/page1/';
             cy.triggerClickOnLink('/page2/');
             cy.wait(500).then(() => {
                 cy.shouldBeAtPage('/page1/');
@@ -396,9 +396,9 @@ context('Window', () => {
          });
     });
 
-    it('should skip popstate handling for equal resolved paths', () => {
+    it('should skip popstate handling for equal resolved urls', () => {
         cy.window().then(window => {
-            window._swup.options.resolvePath = path => '/page1/';
+            window._swup.options.resolveUrl = url =>'/page1/';
             window.history.pushState(
                 {
                     url: '/pushed-page-1/',

--- a/src/helpers/createHistoryRecord.js
+++ b/src/helpers/createHistoryRecord.js
@@ -1,4 +1,4 @@
-import { getCurrentUrl } from '../helpers.js';
+import { default as getCurrentUrl } from './getCurrentUrl.js';
 
 const createHistoryRecord = (url, customData = {}) => {
 	url = url || getCurrentUrl({ hash: true });

--- a/src/helpers/updateHistoryRecord.js
+++ b/src/helpers/updateHistoryRecord.js
@@ -1,4 +1,4 @@
-import { getCurrentUrl } from '../helpers.js';
+import { default as getCurrentUrl } from './getCurrentUrl.js';
 
 const updateHistoryRecord = (url = null, customData = {}) => {
 	url = url || getCurrentUrl({ hash: true });

--- a/src/index.js
+++ b/src/index.js
@@ -37,7 +37,7 @@ export default class Swup {
 			},
 			linkSelector: 'a[href]',
 			plugins: [],
-			resolvePath: (path) => path,
+			resolveUrl: (url) => url,
 			requestHeaders: {
 				'X-Requested-With': 'swup',
 				Accept: 'text/html, application/xhtml+xml'
@@ -229,7 +229,7 @@ export default class Swup {
 		}
 
 		// Exit early if the resolved path hasn't changed
-		if (this.isSameResolvedPath(url, getCurrentUrl())) return;
+		if (this.isSameResolvedUrl(url, getCurrentUrl())) return;
 
 		// Store the element that should be scrolled to after loading the next page
 		this.scrollToElement = hash || null;
@@ -275,7 +275,7 @@ export default class Swup {
 		}
 
 		// Exit early if the resolved path hasn't changed
-		if (this.isSameResolvedPath(getCurrentUrl(), this.currentPageUrl)) {
+		if (this.isSameResolvedUrl(getCurrentUrl(), this.currentPageUrl)) {
 			return;
 		}
 
@@ -299,30 +299,34 @@ export default class Swup {
 	}
 
 	/**
-	 * Utility function to validate and run the global option 'resolvePath'
-	 * @param {string} path
-	 * @returns {string} the resolved path
+	 * Utility function to validate and run the global option 'resolveUrl'
+	 * @param {string} url
+	 * @returns {string} the resolved url
 	 */
-	resolvePath(path) {
-		if (typeof this.options.resolvePath !== 'function') {
-			console.warn(`[swup] options.resolvePath needs to be a function.`);
-			return path;
+	resolveUrl(url) {
+		if (typeof this.options.resolveUrl !== 'function') {
+			console.warn(`[swup] options.resolveUrl expects a callback function.`);
+			return url;
 		}
-		const result = this.options.resolvePath(path);
+		const result = this.options.resolveUrl(url);
 		if (!result || typeof result !== 'string') {
-			console.warn(`[swup] options.resolvePath needs to return a path`);
-			return path;
+			console.warn(`[swup] options.resolveUrl needs to return a url`);
+			return url;
+		}
+		if (result.startsWith('//') || result.startsWith('http')) {
+			console.warn(`[swup] options.resolveUrl needs to return a relative url`);
+			return url;
 		}
 		return result;
 	}
 
 	/**
 	 * Compares the resolved version of two paths and returns true if they are the same
-	 * @param {string} path1
-	 * @param {string} path2
+	 * @param {string} url1
+	 * @param {string} url2
 	 * @returns {boolean}
 	 */
-	isSameResolvedPath(path1, path2) {
-		return this.resolvePath(path1) === this.resolvePath(path2);
+	isSameResolvedUrl(url1, url2) {
+		return this.resolveUrl(url1) === this.resolveUrl(url2);
 	}
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,26 +1,25 @@
 import delegate from 'delegate-it';
 
-// modules
 import Cache from './modules/Cache.js';
-import loadPage from './modules/loadPage.js';
-import leavePage from './modules/leavePage.js';
-import renderPage from './modules/renderPage.js';
 import enterPage from './modules/enterPage.js';
-import triggerEvent from './modules/triggerEvent.js';
-import on from './modules/on.js';
-import off from './modules/off.js';
-import updateTransition from './modules/updateTransition.js';
 import getAnchorElement from './modules/getAnchorElement.js';
 import getAnimationPromises from './modules/getAnimationPromises.js';
 import getPageData from './modules/getPageData.js';
+import leavePage from './modules/leavePage.js';
+import loadPage from './modules/loadPage.js';
+import off from './modules/off.js';
+import on from './modules/on.js';
 import { use, unuse, findPlugin } from './modules/plugins.js';
+import renderPage from './modules/renderPage.js';
+import triggerEvent from './modules/triggerEvent.js';
+import updateTransition from './modules/updateTransition.js';
 
 import { queryAll } from './utils.js';
 import {
-	getCurrentUrl,
-	markSwupElements,
-	Link,
 	cleanupAnimationClasses,
+	getCurrentUrl,
+	Link,
+	markSwupElements,
 	updateHistoryRecord
 } from './helpers.js';
 

--- a/src/modules/Cache.js
+++ b/src/modules/Cache.js
@@ -7,7 +7,7 @@ export class Cache {
 	}
 
 	getCacheUrl(url) {
-		return this.swup.resolvePath(normalizeUrl(url));
+		return this.swup.resolveUrl(normalizeUrl(url));
 	}
 
 	cacheUrl(page) {

--- a/src/modules/renderPage.js
+++ b/src/modules/renderPage.js
@@ -5,7 +5,7 @@ const renderPage = function(page, { popstate } = {}) {
 	document.documentElement.classList.remove('is-leaving');
 
 	// do nothing if another page was requested in the meantime
-	if (!this.isSameResolvedPath(getCurrentUrl(), page.url)) {
+	if (!this.isSameResolvedUrl(getCurrentUrl(), page.url)) {
 		return;
 	}
 
@@ -13,7 +13,7 @@ const renderPage = function(page, { popstate } = {}) {
 
 	// update cache and state if the url was redirected
 	const url = new Link(page.responseURL).getAddress();
-	if (!this.isSameResolvedPath(getCurrentUrl(), url)) {
+	if (!this.isSameResolvedUrl(getCurrentUrl(), url)) {
 		this.cache.cacheUrl({ ...page, url });
 		this.currentPageUrl = getCurrentUrl();
 		updateHistoryRecord(url);


### PR DESCRIPTION
Due to consistency with legacy naming of `getCurrentUrl`, we are moving `resolvePath()` to `resolveUrl()`, as well.