### PR TITLE
Make `ignoreLink` accessible for plugins

### DIFF
--- a/src/helpers/Link.js
+++ b/src/helpers/Link.js
@@ -1,11 +1,16 @@
 export default class Link {
 	constructor(elementOrUrl) {
+		this.link = document.createElement('a');
+
 		if (elementOrUrl instanceof Element || elementOrUrl instanceof SVGElement) {
-			this.link = elementOrUrl;
-		} else {
-			this.link = document.createElement('a');
+			this.link.href = elementOrUrl.getAttribute('href') || elementOrUrl.getAttribute('xlink:href');
+		} else if (typeof elementOrUrl === 'string') {
 			this.link.href = elementOrUrl;
 		}
+	}
+
+	getHref() {
+		return this.link.href;
 	}
 
 	getPath() {

--- a/src/index.js
+++ b/src/index.js
@@ -211,9 +211,10 @@ export default class Swup {
 
 	linkClickHandler(event) {
 		const linkEl = event.delegateTarget;
+		const link = new Link(linkEl);
 
 		// Exit early if the link should be ignored
-		if (this.shouldIgnoreVisit(linkEl.href, { el: linkEl })) {
+		if (this.shouldIgnoreVisit(link.getHref(), { el: linkEl })) {
 			return;
 		}
 
@@ -231,7 +232,6 @@ export default class Swup {
 		this.triggerEvent('clickLink', event);
 		event.preventDefault();
 
-		const link = new Link(linkEl);
 		const url = link.getAddress();
 		const hash = link.getHash();
 

--- a/src/index.js
+++ b/src/index.js
@@ -195,7 +195,7 @@ export default class Swup {
 			return true;
 		}
 
-		// Ignore if the link/form would open new window (or none at all)
+		// Ignore if the link/form would open a new window (or none at all)
 		if (el && this.triggerWillOpenNewWindow(el)) {
 			return true;
 		}
@@ -205,7 +205,7 @@ export default class Swup {
 			return true;
 		}
 
-		// Finally, allow the link
+		// Finally, allow the visit
 		return false;
 	}
 

--- a/src/index.js
+++ b/src/index.js
@@ -31,7 +31,7 @@ export default class Swup {
 			cache: true,
 			containers: ['#swup'],
 			ignoreLink: (el) => {
-				return el.origin !== window.location.origin || el.closest('[data-no-swup]');
+				return el.closest('[data-no-swup]');
 			},
 			linkSelector: 'a[href]',
 			plugins: [],
@@ -189,18 +189,30 @@ export default class Swup {
 		document.documentElement.classList.remove('swup-enabled');
 	}
 
+	ignoreLink(linkEl) {
+		// Ignore if the links origin doesn't match the window origin
+		if (linkEl.origin !== window.location.origin) {
+			return true;
+		}
+
+		// Ignore if the link would open new window (or none at all)
+		if (this.triggerWillOpenNewWindow(linkEl)) {
+			return true;
+		}
+
+		// Ignore if the link should be ignored
+		if (this.options.ignoreLink(linkEl)) {
+			return true;
+		}
+		// Finally, allow the link
+		return false;
+	}
+
 	linkClickHandler(event) {
 		const linkEl = event.delegateTarget;
 
-		// Exit early if the link would open new window (or none at all)
-		if (this.triggerWillOpenNewWindow(linkEl)) {
-			return;
-		}
-
 		// Exit early if the link should be ignored
-		if (this.options.ignoreLink(linkEl)) {
-			return;
-		}
+		if (this.ignoreLink(linkEl)) return;
 
 		// Exit early if control key pressed
 		if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {

--- a/src/index.js
+++ b/src/index.js
@@ -30,7 +30,7 @@ export default class Swup {
 			animationSelector: '[class*="transition-"]',
 			cache: true,
 			containers: ['#swup'],
-			ignoreVisit: (href, { el }) => el?.closest('[data-no-swup]'),
+			ignoreVisit: (href, { el } = {}) => el?.closest('[data-no-swup]'),
 			linkSelector: 'a[href]',
 			plugins: [],
 			resolveUrl: (url) => url,

--- a/test/site/assets/main.css
+++ b/test/site/assets/main.css
@@ -306,20 +306,20 @@ html.test--complex-transitions.is-animating .transition-default {
 
 .test--keyframe-transitions .transition-default {
   transition: none;
+}
+html.test--keyframe-transitions.is-changing .transition-default {
   animation: test-animation 400ms 300ms;
 }
-
-html.test--keyframe-transitions.is-animating .transition-default {
-  transform: translateY(10px);
-  opacity: 0;
+html.test--keyframe-transitions.is-rendering .transition-default {
+  animation-direction: reverse;
 }
 
 @keyframes test-animation {
-  0%, 100% {
+  from {
     transform: translateY(0);
     opacity: 1;
   }
-  50% {
+  to {
     transform: translateY(10px);
     opacity: 0;
   }


### PR DESCRIPTION
- move all checks out of `linkClickHandler` and in a dedicated method `ignoreLink`
- move the `el.origin` check from the option inside this method

Makes it possible for plugins to call `swup.ignoreLink(el)`

Related: #551 