### PR TITLE
Allow defering in-animation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import getAnimationPromises from './modules/getAnimationPromises.js';
 import getPageData from './modules/getPageData.js';
 import leavePage from './modules/leavePage.js';
 import loadPage from './modules/loadPage.js';
+import replaceContent from './modules/replaceContent.js';
 import off from './modules/off.js';
 import on from './modules/on.js';
 import { use, unuse, findPlugin } from './modules/plugins.js';
@@ -94,6 +95,7 @@ export default class Swup {
 		this.loadPage = loadPage;
 		this.leavePage = leavePage;
 		this.renderPage = renderPage;
+		this.replaceContent = replaceContent;
 		this.enterPage = enterPage;
 		this.triggerEvent = triggerEvent;
 		this.delegateEvent = delegateEvent;

--- a/src/modules/renderPage.js
+++ b/src/modules/renderPage.js
@@ -1,5 +1,4 @@
 import { Location, updateHistoryRecord, getCurrentUrl } from '../helpers.js';
-import { query } from '../utils.js';
 
 const renderPage = function(page, { popstate } = {}) {
 	document.documentElement.classList.remove('is-leaving');
@@ -27,28 +26,21 @@ const renderPage = function(page, { popstate } = {}) {
 
 	this.triggerEvent('willReplaceContent', popstate);
 
-	// replace blocks
-	page.blocks.forEach((html, i) => {
-		const block = query(`[data-swup="${i}"]`, document.body);
-		block.outerHTML = html;
+	this.replaceContent().then(() => {
+		this.triggerEvent('contentReplaced', popstate);
+		this.triggerEvent('pageView', popstate);
+
+		// empty cache if it's disabled (because pages could be preloaded and stuff)
+		if (!this.options.cache) {
+			this.cache.empty();
+		}
+
+		// Perform in transition
+		this.enterPage({ popstate, skipTransition });
+
+		// reset scroll-to element
+		this.scrollToElement = null;
 	});
-
-	// set title
-	document.title = page.title;
-
-	this.triggerEvent('contentReplaced', popstate);
-	this.triggerEvent('pageView', popstate);
-
-	// empty cache if it's disabled (because pages could be preloaded and stuff)
-	if (!this.options.cache) {
-		this.cache.empty();
-	}
-
-	// Perform in transition
-	this.enterPage({ popstate, skipTransition });
-
-	// reset scroll-to element
-	this.scrollToElement = null;
 };
 
 export default renderPage;

--- a/src/modules/renderPage.js
+++ b/src/modules/renderPage.js
@@ -26,7 +26,7 @@ const renderPage = function(page, { popstate } = {}) {
 
 	this.triggerEvent('willReplaceContent', popstate);
 
-	this.replaceContent().then(() => {
+	this.replaceContent(page).then(() => {
 		this.triggerEvent('contentReplaced', popstate);
 		this.triggerEvent('pageView', popstate);
 

--- a/src/modules/replaceContent.js
+++ b/src/modules/replaceContent.js
@@ -1,0 +1,17 @@
+import { query } from '../utils.js';
+
+const replaceContent = function({ blocks, title }) {
+	// replace blocks
+	blocks.forEach((html, i) => {
+		const block = query(`[data-swup="${i}"]`, document.body);
+		block.outerHTML = html;
+	});
+
+		// set title
+	document.title = title;
+
+	// Return a Promise to allow plugins to defer
+	return Promise.resolve();
+};
+
+export default replaceContent;

--- a/src/modules/replaceContent.js
+++ b/src/modules/replaceContent.js
@@ -1,5 +1,3 @@
-import { query } from '../utils.js';
-
 /**
  * Perform the replacement of content after loading a page.
  *
@@ -15,7 +13,7 @@ import { query } from '../utils.js';
 const replaceContent = function({ blocks, title }) {
 	// Replace content blocks
 	blocks.forEach((html, i) => {
-		const block = query(`[data-swup="${i}"]`, document.body);
+		const block = document.body.querySelector(`[data-swup="${i}"]`);
 		block.outerHTML = html;
 	});
 

--- a/src/modules/replaceContent.js
+++ b/src/modules/replaceContent.js
@@ -1,13 +1,25 @@
 import { query } from '../utils.js';
 
+/**
+ * Perform the replacement of content after loading a page.
+ *
+ * This method can be replaced or augmented by plugins to allow pausing.
+ *
+ * It takes an object with the page data as return from `getPageData` and has to
+ * return a Promise that resolves once all content has been replaced and the
+ * site is ready to start animating in the new page.
+ *
+ * @param {object} page The page object
+ * @returns Promise
+ */
 const replaceContent = function({ blocks, title }) {
-	// replace blocks
+	// Replace content blocks
 	blocks.forEach((html, i) => {
 		const block = query(`[data-swup="${i}"]`, document.body);
 		block.outerHTML = html;
 	});
 
-		// set title
+	// Update browser title
 	document.title = title;
 
 	// Return a Promise to allow plugins to defer


### PR DESCRIPTION
**Description**

Allow plugins to defer the in-animation by:

- Move the logic for replacing blocks and document title into separate `replaceContent` method
- Make `replaceContent` return a Promise and wait for it before starting the in-animation
- This allows overwriting the method and returning a custom or a chained Promise, pausing execution
- No breaking changes as all external APIs and existing methods are untouched

**Solves**

#561 

**Checks**

- [x] The PR is submitted to the `next` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [ ] ~~New or updated tests are included~~
- [ ] ~~The documentation was updated as required~~
