### PR TITLE
Switch to fetch API

### DIFF
--- a/src/helpers/fetch.js
+++ b/src/helpers/fetch.js
@@ -1,34 +1,22 @@
-const fetch = (setOptions, callback = false) => {
-	let defaults = {
-		url: window.location.pathname + window.location.search,
-		method: 'GET',
-		data: null,
-		headers: {}
-	};
-
-	let options = {
-		...defaults,
-		...setOptions
-	};
-
-	let request = new XMLHttpRequest();
-
-	request.onreadystatechange = function() {
-		if (request.readyState === 4) {
-			if (request.status !== 500) {
-				callback(request);
-			} else {
-				callback(request);
-			}
-		}
-	};
-
-	request.open(options.method, options.url, true);
-	Object.keys(options.headers).forEach((key) => {
-		request.setRequestHeader(key, options.headers[key]);
-	});
-	request.send(options.data);
-	return request;
+const defaults = {
+	url: window.location.pathname + window.location.search,
+	method: 'GET',
+	headers: {}
 };
 
-export default fetch;
+const fetchWrapper = (options, callback = false) => {
+	const { url, method, data, body, headers } = { ...defaults, ...options };
+
+	const init = { method, headers, body: body || data };
+
+	return fetch(url, init)
+		.then((response) => response.text())
+		.then((html) => {
+			// Compatibility layer for other methods expecting XHR properties
+			response.responseURL = response.url;
+			response.responseText = html;
+			callback(response);
+		});
+};
+
+export default fetchWrapper;

--- a/src/helpers/fetch.js
+++ b/src/helpers/fetch.js
@@ -1,11 +1,14 @@
-const defaults = {
-	url: window.location.pathname + window.location.search,
-	method: 'GET',
-	headers: {}
-};
-
 const fetchWrapper = (options, callback = false) => {
-	const { url, method, data, body, headers } = { ...defaults, ...options };
+	const defaults = {
+		url: window.location.pathname + window.location.search,
+		method: 'GET',
+		headers: {}
+	};
+
+	const { url, method, data, body, headers } = {
+		...defaults,
+		...options
+	};
 
 	const init = { method, headers, body: body || data };
 

--- a/src/helpers/fetch.js
+++ b/src/helpers/fetch.js
@@ -10,10 +10,12 @@ const fetchWrapper = (options, callback = false) => {
 	const init = { method, headers, body: body || data };
 
 	return fetch(url, init)
-		.then((response) => response.text())
-		.then((html) => {
+		.then((response) => {
+			return response.text().then((html) => ({ response, html }))
+		})
+		.then(({ response, html }) => {
 			// Compatibility layer for other methods expecting XHR properties
-			response.responseURL = response.url;
+			response.responseURL = response.url || url;
 			response.responseText = html;
 			callback(response);
 		});

--- a/src/helpers/fetch.js
+++ b/src/helpers/fetch.js
@@ -11,7 +11,7 @@ const fetchWrapper = (options, callback = false) => {
 
 	return fetch(url, init)
 		.then((response) => {
-			return response.text().then((html) => ({ response, html }))
+			return response.text().then((html) => ({ response, html }));
 		})
 		.then(({ response, html }) => {
 			// Compatibility layer for other methods expecting XHR properties

--- a/src/modules/loadPage.js
+++ b/src/modules/loadPage.js
@@ -37,7 +37,18 @@ const loadPage = function(data, popstate = false) {
 	} else {
 		// Fetch from server
 		xhrPromise = new Promise((resolve, reject) => {
-			fetch({ ...data, headers: this.options.requestHeaders }, (response) => {
+			const { abort } = fetch({ ...data, headers: this.options.requestHeaders }, (response) => {
+				// Reject without URL for aborted requests (will prevent browser reloads)
+				if (response.error === 'aborted') {
+					reject();
+					return;
+				}
+				// Reject with URL for arbitary errors in fetch
+				if (response.error) {
+					reject(url);
+					return;
+				}
+				// Reject with URL for server errors
 				if (response.status === 500) {
 					this.triggerEvent('serverError');
 					reject(url);


### PR DESCRIPTION
**Description**

- [x] Switch to native `fetch` API
- [x] Add a compatibility layer for methods and plugins expecting XHR properties like `responseURL`
- [x]  Allow aborting requests
- [x] Test if server errors (500) are propagated properly as before
- [ ] Test this with plugins (forms, preload and custom-payload plugins specifically)
    - [ ] Make sure none of the plugins depend on the previously returned `xmlHttpRequest` directly

**Checks**

- [x] The PR is submitted to the `next` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [ ] ~~New or updated tests are included~~
- [ ] ~~The documentation was updated as required~~

**Closes**

#566 