### PR TITLE
Make swup agnostic of preload plugin

### DIFF
--- a/src/helpers/fetch.ts
+++ b/src/helpers/fetch.ts
@@ -2,38 +2,33 @@ import { TransitionOptions } from '../modules/loadPage.js';
 import { Options } from '../index.js';
 
 const fetch = (
-	setOptions: TransitionOptions & { headers: Options['requestHeaders'] },
+	options: TransitionOptions & { headers: Options['requestHeaders'] },
 	callback: (request: XMLHttpRequest) => void
 ): XMLHttpRequest => {
-	let defaults = {
+	const defaults = {
 		url: window.location.pathname + window.location.search,
 		method: 'GET',
 		data: null,
 		headers: {}
 	};
 
-	let options = {
-		...defaults,
-		...setOptions
-	};
+	const { url, method, headers, data } = { ...defaults, ...options };
 
-	let request = new XMLHttpRequest();
+	const request = new XMLHttpRequest();
 
 	request.onreadystatechange = function() {
 		if (request.readyState === 4) {
-			if (request.status !== 500) {
-				callback(request);
-			} else {
-				callback(request);
-			}
+			// if (request.status === 500) {} else {}
+			callback(request);
 		}
 	};
 
-	request.open(options.method, options.url, true);
-	Object.keys(options.headers).forEach((key) => {
-		request.setRequestHeader(key, options.headers[key]);
+	request.open(method, url, true);
+	Object.entries(headers).forEach(([key, header]) => {
+		request.setRequestHeader(key, header);
 	});
-	request.send(options.data);
+	request.send(data);
+
 	return request;
 };
 

--- a/src/helpers/getDataFromHtml.ts
+++ b/src/helpers/getDataFromHtml.ts
@@ -6,6 +6,7 @@ export type PageHtmlData = {
 	blocks: string[];
 	pageClass?: string;
 };
+
 const getDataFromHtml = (html: string, containers: string[]): PageHtmlData => {
 	let fakeDom = document.createElement('html');
 	fakeDom.innerHTML = html;

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import enterPage from './modules/enterPage.js';
 import getAnchorElement from './modules/getAnchorElement.js';
 import getAnimationPromises from './modules/getAnimationPromises.js';
 import getPageData from './modules/getPageData.js';
+import getPageFetchPromise from './modules/getPageFetchPromise.js';
 import leavePage from './modules/leavePage.js';
 import loadPage from './modules/loadPage.js';
 import replaceContent from './modules/replaceContent.js';
@@ -109,6 +110,7 @@ export default class Swup {
 	updateTransition = updateTransition;
 	getAnimationPromises = getAnimationPromises;
 	getPageData = getPageData;
+	getPageFetchPromise = getPageFetchPromise;
 	getAnchorElement = getAnchorElement;
 	log: (message: string, context?: any) => void = () => {}; // here so it can be used by plugins
 	use = use;

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ import enterPage from './modules/enterPage.js';
 import getAnchorElement from './modules/getAnchorElement.js';
 import getAnimationPromises from './modules/getAnimationPromises.js';
 import getPageData from './modules/getPageData.js';
-import getPageFetchPromise from './modules/getPageFetchPromise.js';
+import fetchPage from './modules/fetchPage.js';
 import leavePage from './modules/leavePage.js';
 import loadPage from './modules/loadPage.js';
 import replaceContent from './modules/replaceContent.js';
@@ -110,7 +110,7 @@ export default class Swup {
 	updateTransition = updateTransition;
 	getAnimationPromises = getAnimationPromises;
 	getPageData = getPageData;
-	getPageFetchPromise = getPageFetchPromise;
+	fetchPage = fetchPage;
 	getAnchorElement = getAnchorElement;
 	log: (message: string, context?: any) => void = () => {}; // here so it can be used by plugins
 	use = use;

--- a/src/modules/fetchPage.ts
+++ b/src/modules/fetchPage.ts
@@ -1,11 +1,16 @@
 import Swup from '../index.js';
 import { fetch } from '../helpers.js';
-import { TransitionOptions } from '../modules/loadPage.js';
+import { TransitionOptions } from './loadPage.js';
 import { PageRecord } from './Cache.js';
 
-export default function getPageFetchPromise(this: Swup, data: TransitionOptions): Promise<PageRecord> {
-	const { url } = data;
+export default function fetchPage(this: Swup, data: TransitionOptions): Promise<PageRecord> {
 	const headers = this.options.requestHeaders;
+	const { url } = data;
+
+	if (this.cache.exists(url)) {
+		this.triggerEvent('pageRetrievedFromCache');
+		return Promise.resolve(this.cache.getPage(url));
+	}
 
 	return new Promise((resolve, reject) => {
 		fetch({ ...data, headers }, (response) => {

--- a/src/modules/getPageFetchPromise.ts
+++ b/src/modules/getPageFetchPromise.ts
@@ -1,0 +1,30 @@
+import Swup from '../index.js';
+import { fetch } from '../helpers.js';
+import { TransitionOptions } from '../modules/loadPage.js';
+import { PageRecord } from './Cache.js';
+
+export default function getPageFetchPromise(this: Swup, data: TransitionOptions): Promise<PageRecord> {
+	const { url } = data;
+	const headers = this.options.requestHeaders;
+
+	return new Promise((resolve, reject) => {
+		fetch({ ...data, headers }, (response) => {
+			if (response.status === 500) {
+				this.triggerEvent('serverError');
+				reject(url);
+				return;
+			}
+			// get json data
+			const page = this.getPageData(response);
+			if (!page || !page.blocks.length) {
+				reject(url);
+				return;
+			}
+			// render page
+			const cacheablePageData = { ...page, url };
+			this.cache.cacheUrl(cacheablePageData);
+			this.triggerEvent('pageLoaded');
+			resolve(cacheablePageData);
+		});
+	});
+}

--- a/src/modules/loadPage.ts
+++ b/src/modules/loadPage.ts
@@ -1,6 +1,5 @@
 import { classify, createHistoryRecord, getCurrentUrl } from '../helpers.js';
 import Swup from '../index.js';
-import { PageRecord } from './Cache.js';
 
 export type TransitionOptions = {
 	url: string;
@@ -8,9 +7,6 @@ export type TransitionOptions = {
 };
 
 const loadPage = function(this: Swup, data: TransitionOptions, popstate: PopStateEvent | null) {
-	let animationPromises: Promise<void>[] = [];
-	let xhrPromise: Promise<PageRecord>;
-
 	const { url, customTransition } = data;
 	const skipTransition = !!(popstate && !this.options.animateHistoryBrowsing);
 
@@ -23,7 +19,7 @@ const loadPage = function(this: Swup, data: TransitionOptions, popstate: PopStat
 	}
 
 	// start/skip animation
-	animationPromises = this.leavePage(data, { popstate, skipTransition });
+	const animationPromises = this.leavePage(data, { popstate, skipTransition });
 
 	// create history record if this is not a popstate call (with or without anchor)
 	if (!popstate) {
@@ -33,20 +29,10 @@ const loadPage = function(this: Swup, data: TransitionOptions, popstate: PopStat
 	this.currentPageUrl = getCurrentUrl();
 
 	// Load page data
-	if (this.cache.exists(url)) {
-		// Found in Cache, resolve directly
-		xhrPromise = Promise.resolve(this.cache.getPage(url));
-		this.triggerEvent('pageRetrievedFromCache');
-	} else if (this.preloadPromise && this.preloadPromise.route === url) {
-		// Alreay preloading, re-use
-		xhrPromise = this.preloadPromise;
-		this.preloadPromise = null;
-	} else {
-		xhrPromise = this.getPageFetchPromise(data);
-	}
+	const fetchPromise = this.fetchPage(data);
 
 	// when everything is ready, handle the outcome
-	Promise.all([xhrPromise, ...animationPromises])
+	Promise.all([fetchPromise, ...animationPromises])
 		.then(([pageData]) => {
 			this.renderPage(pageData, { popstate, skipTransition });
 			this.preloadPromise = null;


### PR DESCRIPTION
**Description**

- Extract `fetchPage` method that returns a Promise for loading a page
- Allow plugins to overwrite that method, optionally returning a custom promise
- Preload plugin will overwrite method and store promise on itself (see [PR #56](https://github.com/swup/preload-plugin/pull/56))

**Checks**

- [x] The PR is submitted to the `typescript` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
