### PR TITLE
update cypress

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "swup",
-      "version": "3.0.0-rc.1",
+      "version": "3.0.0-rc.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -16,7 +16,7 @@
       "devDependencies": {
         "@cypress/code-coverage": "^3.10.0",
         "@swup/prettier-config": "^1.0.0",
-        "cypress": "^10.0.2",
+        "cypress": "^12.3.0",
         "http-server": "^14.1.1",
         "istanbul-lib-coverage": "^3.2.0",
         "microbundle": "^0.15.0",
@@ -3642,9 +3642,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "10.11.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-10.11.0.tgz",
-      "integrity": "sha512-lsaE7dprw5DoXM00skni6W5ElVVLGAdRUUdZjX2dYsGjbY/QnpzWZ95Zom1mkGg0hAaO/QVTZoFVS7Jgr/GUPA==",
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.3.0.tgz",
+      "integrity": "sha512-ZQNebibi6NBt51TRxRMYKeFvIiQZ01t50HSy7z/JMgRVqBUey3cdjog5MYEbzG6Ktti5ckDt1tfcC47lmFwXkw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -3695,7 +3695,7 @@
         "cypress": "bin/cypress"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": "^14.0.0 || ^16.0.0 || >=18.0.0"
       }
     },
     "node_modules/cypress/node_modules/bluebird": {
@@ -12011,9 +12011,9 @@
       }
     },
     "cypress": {
-      "version": "10.11.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-10.11.0.tgz",
-      "integrity": "sha512-lsaE7dprw5DoXM00skni6W5ElVVLGAdRUUdZjX2dYsGjbY/QnpzWZ95Zom1mkGg0hAaO/QVTZoFVS7Jgr/GUPA==",
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.3.0.tgz",
+      "integrity": "sha512-ZQNebibi6NBt51TRxRMYKeFvIiQZ01t50HSy7z/JMgRVqBUey3cdjog5MYEbzG6Ktti5ckDt1tfcC47lmFwXkw==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "devDependencies": {
     "@cypress/code-coverage": "^3.10.0",
     "@swup/prettier-config": "^1.0.0",
-    "cypress": "^10.0.2",
+    "cypress": "^12.3.0",
     "http-server": "^14.1.1",
     "istanbul-lib-coverage": "^3.2.0",
     "microbundle": "^0.15.0",


### PR DESCRIPTION
**Description**

Updating the cypress as it seems to help the test stability, at least in local. The problem is that random files (from unpkg) give 500 server error instead of loading. Not sure if it's actual unpkg returning that based on some cypress provided headers, or whether it's just cypress faking it. In any way, probably a long fixed cypress bug. 🤷 

**Checks**

- [ ] The PR is submitted to the `master` branch
- [ ] The code was linted before pushing (`npm run lint`)
- [ ] All tests are passing (`npm run test`)
- [ ] New or updated tests are included
- [ ] The documentation was updated as required

**Additional information**

<!--
Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc.
-->
