### PR TITLE
Switch to `Map` for `cache.pages`

### DIFF
--- a/src/modules/Cache.ts
+++ b/src/modules/Cache.ts
@@ -7,7 +7,7 @@ export interface PageRecord extends PageData {
 	responseURL: string;
 }
 export class Cache {
-	pages: Record<string, PageRecord> = {};
+	pages: Map<string, PageRecord> = new Map();
 	last: PageRecord | null = null;
 	swup: Swup;
 
@@ -21,35 +21,35 @@ export class Cache {
 
 	cacheUrl(page: PageRecord) {
 		page.url = this.getCacheUrl(page.url);
+		console.log( page.url in this.pages );
 		if (page.url in this.pages === false) {
-			this.pages[page.url] = page;
+			this.pages.set(page.url, page);
 		}
 		page.responseURL = this.getCacheUrl(page.responseURL);
-		this.last = this.pages[page.url];
+		this.last = this.pages.get(page.url) || null;
 		this.swup.log(`Cache (${Object.keys(this.pages).length})`, this.pages);
 	}
 
-	getPage(url: string): PageRecord {
+	getPage(url: string): PageRecord | null {
 		url = this.getCacheUrl(url);
-		return this.pages[url];
+		return this.pages.get(url) || null;
 	}
 
-	getCurrentPage(): PageRecord {
-		return this.getPage(getCurrentUrl());
+	getCurrentPage(): PageRecord | null {
+		return this.getPage(this.getCacheUrl(getCurrentUrl()));
 	}
 
 	exists(url: string): boolean {
-		url = this.getCacheUrl(url);
-		return url in this.pages;
+		return this.pages.has(this.getCacheUrl(url));
 	}
 
 	empty(): void {
-		this.pages = {};
+		this.pages.clear();
 		this.last = null;
 		this.swup.log('Cache cleared');
 	}
 
 	remove(url: string): void {
-		delete this.pages[this.getCacheUrl(url)];
+		this.pages.delete(this.getCacheUrl(url));
 	}
 }

--- a/src/modules/Cache.ts
+++ b/src/modules/Cache.ts
@@ -21,12 +21,14 @@ export class Cache {
 
 	cacheUrl(page: PageRecord) {
 		page.url = this.getCacheUrl(page.url);
-		console.log( page.url in this.pages );
-		if (page.url in this.pages === false) {
+		page.responseURL = this.getCacheUrl(page.responseURL);
+
+		if (!this.exists(page.url)) {
 			this.pages.set(page.url, page);
 		}
-		page.responseURL = this.getCacheUrl(page.responseURL);
-		this.last = this.pages.get(page.url) || null;
+
+		this.last = this.getPage(page.url);
+
 		this.swup.log(`Cache (${Object.keys(this.pages).length})`, this.pages);
 	}
 

--- a/src/modules/Cache.ts
+++ b/src/modules/Cache.ts
@@ -31,12 +31,11 @@ export class Cache {
 	}
 
 	getPage(url: string): PageRecord | null {
-		url = this.getCacheUrl(url);
-		return this.pages.get(url) || null;
+		return this.pages.get(this.getCacheUrl(url)) || null;
 	}
 
 	getCurrentPage(): PageRecord | null {
-		return this.getPage(this.getCacheUrl(getCurrentUrl()));
+		return this.getPage(getCurrentUrl());
 	}
 
 	exists(url: string): boolean {

--- a/src/modules/fetchPage.ts
+++ b/src/modules/fetchPage.ts
@@ -9,7 +9,7 @@ export function fetchPage(this: Swup, data: TransitionOptions): Promise<PageReco
 
 	if (this.cache.exists(url)) {
 		this.triggerEvent('pageRetrievedFromCache');
-		return Promise.resolve(this.cache.getPage(url));
+		return Promise.resolve(this.cache.getPage(url) as PageRecord);
 	}
 
 	return new Promise((resolve, reject) => {


### PR DESCRIPTION
**Description**

Use a `Map` instead of a `Record` for `cache.pages`, as proposed in https://github.com/swup/swup/issues/602#issuecomment-1400248073

**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the ~`master`~ `next` branch, since it's a breaking change. Consumers might be directly accessing the `pages` object in their code bases.
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [ ] The documentation was updated as required

