### PR TITLE
Use and validate `cachedPage` directly instead of casting it to `PageRecord`

### DIFF
--- a/src/modules/fetchPage.ts
+++ b/src/modules/fetchPage.ts
@@ -7,9 +7,11 @@ export function fetchPage(this: Swup, data: TransitionOptions): Promise<PageReco
 	const headers = this.options.requestHeaders;
 	const { url } = data;
 
-	if (this.cache.exists(url)) {
+	const cachedPage = this.cache.getPage(url);
+
+	if (cachedPage !== null) {
 		this.triggerEvent('pageRetrievedFromCache');
-		return Promise.resolve(this.cache.getPage(url) as PageRecord);
+		return Promise.resolve(cachedPage);
 	}
 
 	return new Promise((resolve, reject) => {


### PR DESCRIPTION
In response to https://github.com/swup/swup/pull/603#discussion_r1084214034

- [x] The PR is submitted to the `next` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [ ] ~New or updated tests are included~
- [ ] ~The documentation was updated as required~

