### PR TITLE
Feature: Cache expiration

### DIFF
--- a/src/Swup.ts
+++ b/src/Swup.ts
@@ -12,7 +12,7 @@ import {
 } from './helpers';
 import { Unsubscribe } from './helpers/delegateEvent';
 
-import { Cache } from './modules/Cache';
+import { Cache, PageRecord } from './modules/Cache';
 import { enterPage } from './modules/enterPage';
 import { getAnchorElement } from './modules/getAnchorElement';
 import { getAnimationPromises } from './modules/getAnimationPromises';
@@ -49,6 +49,7 @@ export type Options = {
 	skipPopStateHandling: (event: any) => boolean;
 	ignoreVisit: (url: string, { el }: { el?: Element }) => boolean;
 	resolveUrl: (url: string) => string;
+	getTimeToLive: (page: PageRecord) => number;
 };
 
 export default class Swup {
@@ -130,7 +131,8 @@ export default class Swup {
 			'X-Requested-With': 'swup',
 			Accept: 'text/html, application/xhtml+xml'
 		},
-		skipPopStateHandling: (event) => event.state?.source !== 'swup'
+		skipPopStateHandling: (event) => event.state?.source !== 'swup',
+		getTimeToLive: (page) => 600
 	};
 
 	constructor(options: Partial<Options> = {}) {

--- a/src/modules/Cache.ts
+++ b/src/modules/Cache.ts
@@ -76,17 +76,8 @@ export class Cache {
 	 * Will return true if the page was saved more then 10 minutes ago
 	 */
 	isExpiredPage(page: PageRecord): boolean {
-		const ttl = this.getTimeToLive(page);
+		const ttl = this.swup.options.getTimeToLive(page);
 		if (ttl === 0) return false;
 		return new Date(Date.now() - page.timestamp).getSeconds() > ttl;
-	}
-
-	/**
-	 * Get the time to live for a page record.
-	 * Defaults to 600 seconds (10 minutes).
-	 * If this returns 0 the cache for the requested page will never expire
-	 */
-	getTimeToLive(page: PageRecord): number {
-		return 600;
 	}
 }

--- a/src/modules/getPageData.ts
+++ b/src/modules/getPageData.ts
@@ -4,6 +4,7 @@ import { PageHtmlData } from '../helpers/getDataFromHtml';
 
 export type PageData = PageHtmlData & {
 	responseURL: string;
+	timestamp: number;
 };
 export const getPageData = function (this: Swup, request: XMLHttpRequest): PageData | null {
 	// this method can be replaced in case other content than html is expected to be received from server
@@ -19,6 +20,7 @@ export const getPageData = function (this: Swup, request: XMLHttpRequest): PageD
 
 	return {
 		...pageHtmlData,
-		responseURL: request.responseURL || window.location.href
+		responseURL: request.responseURL || window.location.href,
+		timestamp: Date.now()
 	};
 };


### PR DESCRIPTION
**Description**

As discussed in #602 , this is a draft for a cache expiration mechanism.

- Each time a page from the cache is requested, the cache is being freed from expired pages before checking for a result
- The time to live for each page can be overwritten with a new option: `getTimeToLive: (page: PageRecord) => number;`
- The default `ttl` is 600 seconds (10 minutes) for all pages
- Returning `0` for a page will never expire it.

The callback option opens the door for very interesting use cases. Primary pages could always stay in the cache by returning `0` from the callback, other pages could get fine-grained control over the `ttl` based on user-defined logic.

**Checks**

- [x] The PR is submitted to the `next` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [ ] New or updated tests are included
- [ ] The documentation was updated as required

