### PR TITLE
Specify exact types for each type of event handler

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -12,5 +12,6 @@ export default {
 			},
 		],
 	},
-	rootDir: 'src'
+	setupFilesAfterEnv: ['./setup-jest.ts'],
+	modulePathIgnorePatterns: ['<rootDir>/cypress/'],
 };

--- a/setup-jest.ts
+++ b/setup-jest.ts
@@ -1,0 +1,3 @@
+console.log = jest.fn();
+console.warn = jest.fn();
+console.error = jest.fn();

--- a/src/Swup.ts
+++ b/src/Swup.ts
@@ -279,7 +279,7 @@ export default class Swup {
 		this.performPageLoad({ url, customTransition });
 	}
 
-	handleLinkToSamePage(url: string, hash: string, event: MouseEvent) {
+	handleLinkToSamePage(url: string, hash: string, event: delegate.Event<MouseEvent>) {
 		// Emit event and exit early if the url points to the same page without hash
 		if (!hash) {
 			this.triggerEvent('samePage', event);

--- a/src/__test__/index.test.ts
+++ b/src/__test__/index.test.ts
@@ -1,10 +1,6 @@
 import pckg from '../../package.json';
 import Swup, { Options, Plugin } from '../index';
 
-console.log = jest.fn();
-console.warn = jest.fn();
-console.error = jest.fn();
-
 const baseUrl = window.location.origin;
 
 function createPlugin(plugin = {}) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,10 @@
 import Swup, { Options } from './Swup';
 import { Plugin } from './modules/plugins';
+import { Handler } from './modules/events';
 
 export default Swup;
 
 export * from './helpers';
 export * from './utils';
 
-export type { Options, Plugin };
+export type { Options, Plugin, Handler };

--- a/src/modules/__test__/events.test.ts
+++ b/src/modules/__test__/events.test.ts
@@ -54,7 +54,7 @@ describe('events', () => {
 		expect(handler).toBeCalledWith(event);
 	});
 
-	it('should trigger event handler with event', () => {
+	it('types work and error when necessary', () => {
 		const swup = new Swup();
 
 		// @ts-expect-no-error

--- a/src/modules/__test__/events.test.ts
+++ b/src/modules/__test__/events.test.ts
@@ -1,0 +1,70 @@
+import Swup from '../../Swup';
+
+describe('events', () => {
+	it('should add event handlers to handlers array', () => {
+		const swup = new Swup();
+		const handler = jest.fn();
+
+		swup.on('enabled', handler);
+
+		expect(swup._handlers.enabled.indexOf(handler)).toBe(0);
+	});
+
+	it('should remove event handlers from handlers array', () => {
+		const swup = new Swup();
+		const handler = jest.fn();
+
+		swup.on('enabled', handler);
+		swup.on('animationInDone', handler);
+		swup.on('animationInStart', handler);
+
+		expect(swup._handlers.enabled.indexOf(handler)).toBe(0);
+		expect(swup._handlers.animationInDone.indexOf(handler)).toBe(0);
+		expect(swup._handlers.animationInStart.indexOf(handler)).toBe(0);
+
+		swup.off('enabled', handler);
+		expect(swup._handlers.enabled.indexOf(handler)).toBe(-1);
+
+		swup.off('animationInDone');
+		expect(swup._handlers.animationInDone.indexOf(handler)).toBe(-1);
+
+		swup.off();
+		expect(swup._handlers.animationInStart.indexOf(handler)).toBe(-1);
+	});
+
+	it('should trigger event handler', () => {
+		const swup = new Swup();
+		const handler = jest.fn();
+
+		swup.on('enabled', handler);
+
+		swup.triggerEvent('enabled');
+
+		expect(handler).toBeCalledTimes(1);
+	});
+
+	it('should trigger event handler with event', () => {
+		const swup = new Swup();
+		const handler = jest.fn();
+		const event = new PopStateEvent('');
+
+		swup.on('popState', handler);
+		swup.triggerEvent('popState', event);
+
+		expect(handler).toBeCalledWith(event);
+	});
+
+	it('should trigger event handler with event', () => {
+		const swup = new Swup();
+
+		// @ts-expect-no-error
+		swup.on('popState', (event: PopStateEvent) => {});
+		// @ts-expect-no-error
+		swup.triggerEvent('popState', new PopStateEvent(''));
+
+		// @ts-expect-error
+		swup.on('popState', (event: MouseEvent) => {});
+		// @ts-expect-error
+		swup.triggerEvent('popState', new MouseEvent(''));
+	});
+});

--- a/src/modules/__test__/events.test.ts
+++ b/src/modules/__test__/events.test.ts
@@ -1,4 +1,5 @@
 import Swup from '../../Swup';
+import { Handler } from '../events';
 
 describe('events', () => {
 	it('should add event handlers to handlers array', () => {
@@ -45,7 +46,7 @@ describe('events', () => {
 
 	it('should trigger event handler with event', () => {
 		const swup = new Swup();
-		const handler = jest.fn();
+		const handler: Handler<'popState'> = jest.fn();
 		const event = new PopStateEvent('');
 
 		swup.on('popState', handler);

--- a/src/modules/events.ts
+++ b/src/modules/events.ts
@@ -1,42 +1,60 @@
 import Swup from '../Swup';
 
-export type EventType =
-	| 'animationInDone'
-	| 'animationInStart'
-	| 'animationOutDone'
-	| 'animationOutStart'
-	| 'animationSkipped'
-	| 'clickLink'
-	| 'contentReplaced'
-	| 'disabled'
-	| 'enabled'
-	| 'openPageInNewTab'
-	| 'pageLoaded'
-	| 'pageRetrievedFromCache'
-	| 'pageView'
-	| 'popState'
-	| 'samePage'
-	| 'samePageWithHash'
-	| 'serverError'
-	| 'transitionStart'
-	| 'transitionEnd'
-	| 'willReplaceContent';
-export type Handler = (event?: Event) => void;
-export type Handlers = Record<EventType, Handler[]>;
+type HandlersEventMap = {
+	animationInDone: undefined;
+	animationInStart: undefined;
+	animationOutDone: undefined;
+	animationOutStart: undefined;
+	animationSkipped: undefined;
+	clickLink: MouseEvent;
+	contentReplaced: PopStateEvent | undefined;
+	disabled: undefined;
+	enabled: undefined;
+	openPageInNewTab: MouseEvent;
+	pageLoaded: undefined;
+	pageRetrievedFromCache: undefined;
+	pageView: PopStateEvent | undefined;
+	popState: PopStateEvent;
+	samePage: MouseEvent;
+	samePageWithHash: MouseEvent;
+	serverError: undefined;
+	transitionStart: PopStateEvent | undefined;
+	transitionEnd: PopStateEvent | undefined;
+	willReplaceContent: PopStateEvent | undefined;
+};
+type EventTypes = HandlersEventMap[keyof HandlersEventMap];
+type AvailableEventNames = keyof HandlersEventMap;
 
-export function on(this: Swup, event: EventType, handler: Handler) {
-	if (this._handlers[event]) {
-		this._handlers[event].push(handler);
+export type Handler<T extends EventTypes = undefined> = (event: T) => void;
+export type Handlers = {
+	[Key in keyof HandlersEventMap as `${Key}`]: Handler<HandlersEventMap[Key]>[];
+};
+
+export function on<TEventType extends AvailableEventNames>(
+	this: Swup,
+	event: TEventType,
+	handler: Handler<HandlersEventMap[TEventType]>
+): void {
+	const eventHandlers = this._handlers[event] as Handler<HandlersEventMap[TEventType]>[];
+
+	if (eventHandlers) {
+		eventHandlers.push(handler);
 	} else {
 		console.warn(`Unsupported event ${event}.`);
 	}
 }
 
-export function off(this: Swup, event?: EventType, handler?: Handler) {
+export function off<TEventType extends AvailableEventNames>(
+	this: Swup,
+	event?: TEventType,
+	handler?: Handler<HandlersEventMap[TEventType]>
+) {
 	if (event && handler) {
+		const eventHandlers = this._handlers[event] as Handler<HandlersEventMap[TEventType]>[];
 		// Remove specific handler
-		if (this._handlers[event].includes(handler)) {
-			this._handlers[event] = this._handlers[event].filter((h) => h !== handler);
+		if (eventHandlers.includes(handler)) {
+			(this._handlers[event] as Handler<HandlersEventMap[TEventType]>[]) =
+				eventHandlers.filter((h) => h !== handler);
 		} else {
 			console.warn(`Handler for event '${event}' not found.`);
 		}
@@ -46,16 +64,22 @@ export function off(this: Swup, event?: EventType, handler?: Handler) {
 	} else {
 		// Remove all handlers for all events
 		Object.keys(this._handlers).forEach((event) => {
-			this._handlers[event as EventType] = [];
+			this._handlers[event as keyof HandlersEventMap] = [];
 		});
 	}
 }
 
-export function triggerEvent(this: Swup, eventName: EventType, originalEvent?: Event): void {
+export function triggerEvent<TEventType extends AvailableEventNames>(
+	this: Swup,
+	eventName: TEventType,
+	originalEvent?: HandlersEventMap[TEventType]
+): void {
+	const eventHandlers = this._handlers[eventName] as Handler<HandlersEventMap[TEventType]>[];
+
 	// call saved handlers with "on" method and pass originalEvent object if available
-	this._handlers[eventName].forEach((handler) => {
+	eventHandlers.forEach((handler) => {
 		try {
-			handler(originalEvent);
+			handler(originalEvent as HandlersEventMap[TEventType]);
 		} catch (error) {
 			console.error(error);
 		}

--- a/src/modules/events.ts
+++ b/src/modules/events.ts
@@ -1,4 +1,5 @@
 import Swup from '../Swup';
+import delegate from 'delegate-it';
 
 type HandlersEventMap = {
 	animationInDone: undefined;
@@ -6,17 +7,17 @@ type HandlersEventMap = {
 	animationOutDone: undefined;
 	animationOutStart: undefined;
 	animationSkipped: undefined;
-	clickLink: MouseEvent;
+	clickLink: delegate.Event<MouseEvent>;
 	contentReplaced: PopStateEvent | undefined;
 	disabled: undefined;
 	enabled: undefined;
-	openPageInNewTab: MouseEvent;
+	openPageInNewTab: delegate.Event<MouseEvent>;
 	pageLoaded: undefined;
 	pageRetrievedFromCache: undefined;
 	pageView: PopStateEvent | undefined;
 	popState: PopStateEvent;
-	samePage: MouseEvent;
-	samePageWithHash: MouseEvent;
+	samePage: delegate.Event<MouseEvent>;
+	samePageWithHash: delegate.Event<MouseEvent>;
 	serverError: undefined;
 	transitionStart: PopStateEvent | undefined;
 	transitionEnd: PopStateEvent | undefined;

--- a/src/modules/events.ts
+++ b/src/modules/events.ts
@@ -23,20 +23,19 @@ type HandlersEventMap = {
 	transitionEnd: PopStateEvent | undefined;
 	willReplaceContent: PopStateEvent | undefined;
 };
-type EventTypes = HandlersEventMap[keyof HandlersEventMap];
 type AvailableEventNames = keyof HandlersEventMap;
 
-export type Handler<T extends EventTypes = undefined> = (event: T) => void;
+export type Handler<T extends keyof HandlersEventMap> = (event: HandlersEventMap[T]) => void;
 export type Handlers = {
-	[Key in keyof HandlersEventMap as `${Key}`]: Handler<HandlersEventMap[Key]>[];
+	[Key in keyof HandlersEventMap]: Handler<Key>[];
 };
 
 export function on<TEventType extends AvailableEventNames>(
 	this: Swup,
 	event: TEventType,
-	handler: Handler<HandlersEventMap[TEventType]>
+	handler: Handler<TEventType>
 ): void {
-	const eventHandlers = this._handlers[event] as Handler<HandlersEventMap[TEventType]>[];
+	const eventHandlers = this._handlers[event] as Handler<TEventType>[];
 
 	if (eventHandlers) {
 		eventHandlers.push(handler);
@@ -48,14 +47,15 @@ export function on<TEventType extends AvailableEventNames>(
 export function off<TEventType extends AvailableEventNames>(
 	this: Swup,
 	event?: TEventType,
-	handler?: Handler<HandlersEventMap[TEventType]>
+	handler?: Handler<TEventType>
 ) {
 	if (event && handler) {
-		const eventHandlers = this._handlers[event] as Handler<HandlersEventMap[TEventType]>[];
+		const eventHandlers = this._handlers[event] as Handler<TEventType>[];
 		// Remove specific handler
 		if (eventHandlers.includes(handler)) {
-			(this._handlers[event] as Handler<HandlersEventMap[TEventType]>[]) =
-				eventHandlers.filter((h) => h !== handler);
+			(this._handlers[event] as Handler<TEventType>[]) = eventHandlers.filter(
+				(h) => h !== handler
+			);
 		} else {
 			console.warn(`Handler for event '${event}' not found.`);
 		}
@@ -75,7 +75,7 @@ export function triggerEvent<TEventType extends AvailableEventNames>(
 	eventName: TEventType,
 	originalEvent?: HandlersEventMap[TEventType]
 ): void {
-	const eventHandlers = this._handlers[eventName] as Handler<HandlersEventMap[TEventType]>[];
+	const eventHandlers = this._handlers[eventName] as Handler<TEventType>[];
 
 	// call saved handlers with "on" method and pass originalEvent object if available
 	eventHandlers.forEach((handler) => {

--- a/src/modules/loadPage.ts
+++ b/src/modules/loadPage.ts
@@ -9,7 +9,7 @@ export type TransitionOptions = {
 
 export type PageLoadOptions = {
 	url: string;
-	event?: Event;
+	event?: PopStateEvent;
 	customTransition?: string;
 };
 

--- a/src/modules/renderPage.ts
+++ b/src/modules/renderPage.ts
@@ -3,7 +3,7 @@ import Swup from '../Swup';
 import { PageRecord } from './Cache';
 
 export type PageRenderOptions = {
-	event?: Event;
+	event?: PopStateEvent;
 	skipTransition?: boolean;
 };
 


### PR DESCRIPTION
**Description**

Since Swup event handler types were so far defined as `Event,` there is no way to use it adequately other than casting it to your event where needed. We also need to find out when the event is defined for the handler and when it isn't.

This adds specific types to the event handlers, which should infer specific types based on the event type you use.

There are no changes to the implementation, only types. Still, we can consider this a breaking change to the API.

```ts
const swup = new Swup();
swup.on('popState', (event) => { // <- always PopStateEvent
	console.log(event);
});
swup.on('clickLink', (event) => { // <- always MouseEvent
	console.log(event);
});
swup.on('animationInDone', (event) => { // <- always undefined
	console.log(event);
});
swup.on('transitionStart', (event) => { // <- PopStateEvent | undefined
	console.log(event);
});

swup.off('popState', (event) => {  // <- PopStateEvent
	console.log(event);
});
swup.off('clickLink', (event) => { // <- MouseEvent
	console.log(event);
});
swup.off('animationInDone', (event) => { // <- undefined
	console.log(event);
});

// these just still work without a handler or event name altogether.
swup.off('clickLink');  
swup.off();
```


**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [x] New or updated tests are included
- [x] The documentation was updated as required
