### PR TITLE
Fix `Referer` request header

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -13,6 +13,9 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
       - name: Run cypress tests
         uses: cypress-io/github-action@v4.2.2
         with:

--- a/cypress/e2e/main.spec.js
+++ b/cypress/e2e/main.spec.js
@@ -11,10 +11,21 @@ describe('Request', function () {
 	});
 
 	it('should send the correct referer', function () {
+		const referer = `${baseUrl}/page-1.html`;
 		cy.intercept('GET', '/page-2.html').as('request');
 		cy.triggerClickOnLink('/page-2.html');
-		const referer = `${baseUrl}/page-1.html`;
 		cy.wait('@request').its('request.headers.referer').should('eq', referer);
+	});
+
+	it('should send the correct request headers', function () {
+		const expected = this.swup.options.requestHeaders;
+		cy.intercept('GET', '/page-3.html').as('request');
+		cy.triggerClickOnLink('/page-3.html');
+		cy.wait('@request').its('request.headers').then((headers) => {
+			Object.entries(expected).forEach(([header, value]) => {
+				cy.wrap(headers).its(header.toLowerCase()).should('eq', value);
+			});
+		});
 	});
 });
 

--- a/cypress/e2e/main.spec.js
+++ b/cypress/e2e/main.spec.js
@@ -4,6 +4,20 @@
 
 const baseUrl = Cypress.config('baseUrl');
 
+describe('Request', function () {
+	beforeEach(() => {
+		cy.visit('/page-1.html');
+		cy.wrapSwupInstance();
+	});
+
+	it('should send the correct referer', function () {
+		cy.intercept('GET', '/page-2.html').as('request');
+		cy.triggerClickOnLink('/page-2.html');
+		const referer = `${baseUrl}/page-1.html`;
+		cy.wait('@request').its('request.headers.referer').should('eq', referer);
+	});
+});
+
 describe('Cache', function () {
 	beforeEach(() => {
 		cy.visit('/page-1.html');

--- a/src/modules/loadPage.ts
+++ b/src/modules/loadPage.ts
@@ -41,15 +41,15 @@ export function performPageLoad(this: Swup, data: PageLoadOptions) {
 	// start/skip animation
 	const animationPromises = this.leavePage({ event, skipTransition });
 
+	// Load page data
+	const fetchPromise = this.fetchPage(data);
+
 	// create history record if this is not a popstate call (with or without anchor)
 	if (!isHistoryVisit) {
 		createHistoryRecord(url + (this.scrollToElement || ''));
 	}
 
 	this.currentPageUrl = getCurrentUrl();
-
-	// Load page data
-	const fetchPromise = this.fetchPage(data);
 
 	// when everything is ready, render the page
 	Promise.all<PageRecord | void>([fetchPromise, ...animationPromises])


### PR DESCRIPTION
Fixes #616

**Description**

Right now, the native `Referer` request header always contains the same URL as the requested page, since `fetchPage` is being executed right **after** the URL was updated through `createHistoryRecord`. This PR attempts to fix this behavior by initializing `fetchPage` right **before** updating the URL.

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)

**Additional information**

Tested this manually, works as expected on my end (correct `Referer` header).
