### PR TITLE
Support TypeScript `"moduleResolution": "node16"`

### DIFF
--- a/src/Swup.ts
+++ b/src/Swup.ts
@@ -1,6 +1,6 @@
 import delegate from 'delegate-it';
 
-import version from './config/version';
+import version from './config/version.js';
 
 import {
 	cleanupAnimationClasses,
@@ -9,24 +9,24 @@ import {
 	Location,
 	markSwupElements,
 	updateHistoryRecord
-} from './helpers';
-import { Unsubscribe } from './helpers/delegateEvent';
+} from './helpers.js';
+import { Unsubscribe } from './helpers/delegateEvent.js';
 
-import { Cache } from './modules/Cache';
-import { enterPage } from './modules/enterPage';
-import { getAnchorElement } from './modules/getAnchorElement';
-import { getAnimationPromises } from './modules/getAnimationPromises';
-import { getPageData } from './modules/getPageData';
-import { fetchPage } from './modules/fetchPage';
-import { leavePage } from './modules/leavePage';
-import { loadPage, performPageLoad } from './modules/loadPage';
-import { replaceContent } from './modules/replaceContent';
-import { on, off, triggerEvent, Handlers } from './modules/events';
-import { use, unuse, findPlugin, Plugin } from './modules/plugins';
-import { renderPage } from './modules/renderPage';
-import { updateTransition, shouldSkipTransition } from './modules/transitions';
+import { Cache } from './modules/Cache.js';
+import { enterPage } from './modules/enterPage.js';
+import { getAnchorElement } from './modules/getAnchorElement.js';
+import { getAnimationPromises } from './modules/getAnimationPromises.js';
+import { getPageData } from './modules/getPageData.js';
+import { fetchPage } from './modules/fetchPage.js';
+import { leavePage } from './modules/leavePage.js';
+import { loadPage, performPageLoad } from './modules/loadPage.js';
+import { replaceContent } from './modules/replaceContent.js';
+import { on, off, triggerEvent, Handlers } from './modules/events.js';
+import { use, unuse, findPlugin, Plugin } from './modules/plugins.js';
+import { renderPage } from './modules/renderPage.js';
+import { updateTransition, shouldSkipTransition } from './modules/transitions.js';
 
-import { queryAll } from './utils';
+import { queryAll } from './utils.js';
 
 export type Transition = {
 	from?: string;

--- a/src/__test__/index.test.ts
+++ b/src/__test__/index.test.ts
@@ -1,7 +1,7 @@
 import delegate from 'delegate-it';
 
 import pckg from '../../package.json';
-import Swup, { Options, Plugin } from '../index';
+import Swup, { Options, Plugin } from '../index.js';
 
 const baseUrl = window.location.origin;
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,13 +1,13 @@
 // Re-export all helpers to allow custom package export path
 // e.g. import { getPageData } from 'swup/helpers'
 
-export { classify } from './helpers/classify';
-export { createHistoryRecord } from './helpers/createHistoryRecord';
-export { updateHistoryRecord } from './helpers/updateHistoryRecord';
-export { delegateEvent } from './helpers/delegateEvent';
-export { getDataFromHtml } from './helpers/getDataFromHtml';
-export { fetch } from './helpers/fetch';
-export { getCurrentUrl } from './helpers/getCurrentUrl';
-export { Location } from './helpers/Location';
-export { markSwupElements } from './helpers/markSwupElements';
-export { cleanupAnimationClasses } from './helpers/cleanupAnimationClasses';
+export { classify } from './helpers/classify.js';
+export { createHistoryRecord } from './helpers/createHistoryRecord.js';
+export { updateHistoryRecord } from './helpers/updateHistoryRecord.js';
+export { delegateEvent } from './helpers/delegateEvent.js';
+export { getDataFromHtml } from './helpers/getDataFromHtml.js';
+export { fetch } from './helpers/fetch.js';
+export { getCurrentUrl } from './helpers/getCurrentUrl.js';
+export { Location } from './helpers/Location.js';
+export { markSwupElements } from './helpers/markSwupElements.js';
+export { cleanupAnimationClasses } from './helpers/cleanupAnimationClasses.js';

--- a/src/helpers/createHistoryRecord.ts
+++ b/src/helpers/createHistoryRecord.ts
@@ -1,4 +1,4 @@
-import { getCurrentUrl } from './getCurrentUrl';
+import { getCurrentUrl } from './getCurrentUrl.js';
 
 export const createHistoryRecord = (
 	url: string,

--- a/src/helpers/delegateEvent.ts
+++ b/src/helpers/delegateEvent.ts
@@ -1,5 +1,5 @@
 import delegate, { EventType } from 'delegate-it';
-import { ParseSelector } from 'typed-query-selector/parser';
+import { ParseSelector } from 'typed-query-selector/parser.js';
 
 export type Unsubscribe = {
 	destroy: () => void;

--- a/src/helpers/fetch.ts
+++ b/src/helpers/fetch.ts
@@ -1,5 +1,5 @@
-import { TransitionOptions } from '../modules/loadPage';
-import { Options } from '../Swup';
+import { TransitionOptions } from '../modules/loadPage.js';
+import { Options } from '../Swup.js';
 
 export const fetch = (
 	options: TransitionOptions & { headers: Options['requestHeaders'] },

--- a/src/helpers/getDataFromHtml.ts
+++ b/src/helpers/getDataFromHtml.ts
@@ -1,4 +1,4 @@
-import { query, queryAll } from '../utils';
+import { query, queryAll } from '../utils.js';
 
 export type PageHtmlData = {
 	title: string;

--- a/src/helpers/markSwupElements.ts
+++ b/src/helpers/markSwupElements.ts
@@ -1,4 +1,4 @@
-import { query, queryAll } from '../utils';
+import { query, queryAll } from '../utils.js';
 
 export const markSwupElements = (element: Element, containers: string[]): void => {
 	let blocks = 0;

--- a/src/helpers/updateHistoryRecord.ts
+++ b/src/helpers/updateHistoryRecord.ts
@@ -1,4 +1,4 @@
-import { getCurrentUrl } from './getCurrentUrl';
+import { getCurrentUrl } from './getCurrentUrl.js';
 
 export const updateHistoryRecord = (
 	url: string | null = null,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,10 @@
-import Swup, { Options } from './Swup';
-import { Plugin } from './modules/plugins';
-import { Handler } from './modules/events';
+import Swup, { Options } from './Swup.js';
+import { Plugin } from './modules/plugins.js';
+import { Handler } from './modules/events.js';
 
 export default Swup;
 
-export * from './helpers';
-export * from './utils';
+export * from './helpers.js';
+export * from './utils.js';
 
 export type { Options, Plugin, Handler };

--- a/src/modules/Cache.ts
+++ b/src/modules/Cache.ts
@@ -1,6 +1,6 @@
-import { getCurrentUrl, Location } from '../helpers';
-import Swup from '../Swup';
-import { PageData } from './getPageData';
+import { getCurrentUrl, Location } from '../helpers.js';
+import Swup from '../Swup.js';
+import { PageData } from './getPageData.js';
 
 export interface PageRecord extends PageData {
 	url: string;

--- a/src/modules/__test__/events.test.ts
+++ b/src/modules/__test__/events.test.ts
@@ -1,5 +1,5 @@
-import Swup from '../../Swup';
-import { Handler } from '../events';
+import Swup from '../../Swup.js';
+import { Handler } from '../events.js';
 
 describe('events', () => {
 	it('should add event handlers to handlers array', () => {

--- a/src/modules/enterPage.ts
+++ b/src/modules/enterPage.ts
@@ -1,6 +1,6 @@
-import { nextTick } from '../utils';
-import Swup from '../Swup';
-import { PageRenderOptions } from './renderPage';
+import { nextTick } from '../utils.js';
+import Swup from '../Swup.js';
+import { PageRenderOptions } from './renderPage.js';
 
 export const enterPage = function (this: Swup, { event, skipTransition }: PageRenderOptions = {}) {
 	if (skipTransition) {

--- a/src/modules/events.ts
+++ b/src/modules/events.ts
@@ -1,4 +1,4 @@
-import Swup from '../Swup';
+import Swup from '../Swup.js';
 import delegate from 'delegate-it';
 
 type HandlersEventMap = {

--- a/src/modules/fetchPage.ts
+++ b/src/modules/fetchPage.ts
@@ -1,7 +1,7 @@
-import Swup from '../Swup';
-import { fetch } from '../helpers';
-import { TransitionOptions } from './loadPage';
-import { PageRecord } from './Cache';
+import Swup from '../Swup.js';
+import { fetch } from '../helpers.js';
+import { TransitionOptions } from './loadPage.js';
+import { PageRecord } from './Cache.js';
 
 export function fetchPage(this: Swup, data: TransitionOptions): Promise<PageRecord> {
 	const headers = this.options.requestHeaders;

--- a/src/modules/getAnchorElement.ts
+++ b/src/modules/getAnchorElement.ts
@@ -1,4 +1,4 @@
-import { escapeCssIdentifier, query } from '../utils';
+import { escapeCssIdentifier, query } from '../utils.js';
 
 export const getAnchorElement = (hash: string): Element | null => {
 	if (!hash) {

--- a/src/modules/getAnimationPromises.ts
+++ b/src/modules/getAnimationPromises.ts
@@ -1,5 +1,5 @@
-import { queryAll, toMs } from '../utils';
-import Swup from '../Swup';
+import { queryAll, toMs } from '../utils.js';
+import Swup from '../Swup.js';
 
 // Transition property/event sniffing
 let transitionProp = 'transition';

--- a/src/modules/getPageData.ts
+++ b/src/modules/getPageData.ts
@@ -1,6 +1,6 @@
-import { getDataFromHtml } from '../helpers';
-import Swup from '../Swup';
-import { PageHtmlData } from '../helpers/getDataFromHtml';
+import { getDataFromHtml } from '../helpers.js';
+import Swup from '../Swup.js';
+import { PageHtmlData } from '../helpers/getDataFromHtml.js';
 
 export type PageData = PageHtmlData & {
 	responseURL: string;

--- a/src/modules/leavePage.ts
+++ b/src/modules/leavePage.ts
@@ -1,5 +1,5 @@
-import Swup from '../Swup';
-import { PageRenderOptions } from './renderPage';
+import Swup from '../Swup.js';
+import { PageRenderOptions } from './renderPage.js';
 
 export const leavePage = function (this: Swup, { event, skipTransition }: PageRenderOptions = {}) {
 	const isHistoryVisit = event instanceof PopStateEvent;

--- a/src/modules/loadPage.ts
+++ b/src/modules/loadPage.ts
@@ -1,6 +1,6 @@
-import { classify, createHistoryRecord, getCurrentUrl } from '../helpers';
-import Swup from '../Swup';
-import { PageRecord } from './Cache';
+import { classify, createHistoryRecord, getCurrentUrl } from '../helpers.js';
+import Swup from '../Swup.js';
+import { PageRecord } from './Cache.js';
 
 export type TransitionOptions = {
 	url: string;

--- a/src/modules/plugins.ts
+++ b/src/modules/plugins.ts
@@ -1,4 +1,4 @@
-import Swup from '../Swup';
+import Swup from '../Swup.js';
 
 export type Plugin = {
 	name: string;

--- a/src/modules/renderPage.ts
+++ b/src/modules/renderPage.ts
@@ -1,6 +1,6 @@
-import { Location, updateHistoryRecord, getCurrentUrl } from '../helpers';
-import Swup from '../Swup';
-import { PageRecord } from './Cache';
+import { Location, updateHistoryRecord, getCurrentUrl } from '../helpers.js';
+import Swup from '../Swup.js';
+import { PageRecord } from './Cache.js';
 
 export type PageRenderOptions = {
 	event?: PopStateEvent;

--- a/src/modules/transitions.ts
+++ b/src/modules/transitions.ts
@@ -1,4 +1,4 @@
-import Swup from '../Swup';
+import Swup from '../Swup.js';
 
 export function updateTransition(this: Swup, from: string, to: string, custom?: string): void {
 	this.transition = { from, to, custom };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
 // Re-export all utils to allow custom package export path
 // e.g. import { queryAll } from 'swup/utils'
 
-export * from './utils/index';
+export * from './utils/index.js';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,7 +28,7 @@
     /* Modules */
     "module": "esnext",                                  /* Specify what module code is generated. */
     "rootDir": "./src",                                  /* Specify the root folder within your source files. */
-    "moduleResolution": "node",                      /* Specify how TypeScript looks up a file from a given module specifier. */
+    "moduleResolution": "node16",                      /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,7 +28,7 @@
     /* Modules */
     "module": "esnext",                                  /* Specify what module code is generated. */
     "rootDir": "./src",                                  /* Specify the root folder within your source files. */
-    "moduleResolution": "node16",                      /* Specify how TypeScript looks up a file from a given module specifier. */
+    "moduleResolution": "node16",                        /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */


### PR DESCRIPTION
Fixes #637

**Description**

Switched all imports to fully qualified to support `node16` module resolution. This also automatically generates the right `d.ts` files through microbundle.

**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [ ] ~All tests are passing (`npm run test`)~
  jest ist not picking up the new moduleResolution, yet. More googling required...

