### PR TITLE
Add token to `create-pull-request`

### DIFF
--- a/.github/workflows/version-update.yml
+++ b/.github/workflows/version-update.yml
@@ -33,4 +33,4 @@ jobs:
           title: 'Update package version (automated)'
           commit-message: 'Update package version'
           body: 'Automated update to ${{ inputs.segment }} version'
-          token: GH_TOKEN
+          token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/version-update.yml
+++ b/.github/workflows/version-update.yml
@@ -33,3 +33,4 @@ jobs:
           title: 'Update package version (automated)'
           commit-message: 'Update package version'
           body: 'Automated update to ${{ inputs.segment }} version'
+          token: GH_TOKEN


### PR DESCRIPTION
Fixes #642 (hopefully, hard to test...)

From https://github.com/peter-evans/create-pull-request#action-inputs:

> Note: If you want pull requests created by this action to trigger an `on: push` or `on: pull_request` workflow then you cannot use the default `GITHUB_TOKEN`.
