### PR TITLE
Make check for valid `transitionend`/ `animationevent` more robust

### DIFF
--- a/src/modules/getAnimationPromises.ts
+++ b/src/modules/getAnimationPromises.ts
@@ -79,7 +79,7 @@ function getAnimationPromiseForElement(
 			}
 
 			if (!isTransitionOrAnimationEvent(event)) {
-				throw new Error('Not a transition or animation event.');
+				return console.warn('Not a transition or animation event', event);
 			}
 
 			// Skip transitions that happened before we started listening

--- a/src/modules/getAnimationPromises.ts
+++ b/src/modules/getAnimationPromises.ts
@@ -45,7 +45,7 @@ export function getAnimationPromises(
 }
 
 const isTransitionOrAnimationEvent = (event: any): event is TransitionEvent | AnimationEvent =>
-	event.elapsedTime === 0 || !!event.elapsedTime;
+	[transitionEndEvent, animationEndEvent].includes(event.type);
 
 function getAnimationPromiseForElement(
 	element: Element,

--- a/src/modules/getAnimationPromises.ts
+++ b/src/modules/getAnimationPromises.ts
@@ -45,7 +45,7 @@ export function getAnimationPromises(
 }
 
 const isTransitionOrAnimationEvent = (event: any): event is TransitionEvent | AnimationEvent =>
-	!!event.elapsedTime;
+	event.elapsedTime === 0 || !!event.elapsedTime;
 
 function getAnimationPromiseForElement(
 	element: Element,


### PR DESCRIPTION
### Problem

Sometimes the value of `elapsedTime` of a `transitionend`/`animationend` event can be `0`. With the current implementation this will lead to swup throwing an error, because it thinks it's not one of these two events:

```js
const isTransitionOrAnimationEvent = (event: any): event is TransitionEvent | AnimationEvent =>
	!!event.elapsedTime;
// ...
if (!isTransitionOrAnimationEvent(event)) {
    throw new Error('Not a transition or animation event.');
}
```

### Solution

I changed the check to test for the `event.type` instead:

```js
const isTransitionOrAnimationEvent = (event: any): event is TransitionEvent | AnimationEvent =>
	[transitionEndEvent, animationEndEvent].includes(event.type);
```

I also don't think a `new Error` should ever be thrown by swup. So this PR also changes that to a `console.warn` with the`event` as second param for debugging.

**Checks**


- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
