### PR TITLE
Fix anchor selector for scroll target

### DIFF
--- a/cypress/e2e/main.spec.js
+++ b/cypress/e2e/main.spec.js
@@ -434,6 +434,16 @@ describe('Scroll Plugin', function () {
 		cy.shouldHaveElementInViewport('[data-cy=anchor-by-name]');
 	});
 
+	it('should prefer undecoded id attributes', function () {
+		cy.get('[data-cy=link-to-anchor-encoded]').click();
+		cy.shouldHaveElementInViewport('[data-cy=anchor-encoded]');
+	});
+
+	it('should accept unencoded anchor links', function () {
+		cy.get('[data-cy=link-to-anchor-unencoded]').click();
+		cy.shouldHaveElementInViewport('[data-cy=anchor-unencoded]');
+	});
+
 	it('should scroll to anchor with special characters', function () {
 		cy.get('[data-cy=link-to-anchor-with-colon]').click();
 		cy.shouldHaveElementInViewport('[data-cy=anchor-with-colon]');

--- a/cypress/fixtures/plugins/scroll-plugin-1.html
+++ b/cypress/fixtures/plugins/scroll-plugin-1.html
@@ -36,6 +36,8 @@
             <div id="anchor" data-cy="anchor">Anchor</div>
             <div id="anchor-by-id" data-cy="anchor-by-id">Anchor by id</div>
             <a name="anchor-by-name" data-cy="anchor-by-name">Anchor by name</a>
+            <div id="anchor-%21" data-cy="anchor-encoded">Anchor with encoded ID</div>
+            <div id="anchor-!" data-cy="anchor-unencoded">Anchor with unencoded ID</div>
             <div id="anchor:with:colon" data-cy="anchor-with-colon">Anchor with colon</div>
             <div id="anchor-with-unicode-テスト" data-cy="anchor-with-unicode">Anchor with unicode</div>
         </div>
@@ -65,6 +67,12 @@
             </li>
             <li>
                 <a href="#anchor-by-name" data-cy="link-to-anchor-by-name">Link to anchor by name</a>
+            </li>
+            <li>
+                <a href="#anchor-%21" data-cy="link-to-anchor-encoded">Link to anchor with url-encoding</a>
+            </li>
+            <li>
+                <a href="#anchor-!" data-cy="link-to-anchor-unencoded">Link to anchor without url-encoding</a>
             </li>
             <li>
                 <a href="#anchor:with:colon" data-cy="link-to-anchor-with-colon">Link to anchor with colon</a>

--- a/src/modules/getAnchorElement.ts
+++ b/src/modules/getAnchorElement.ts
@@ -1,17 +1,27 @@
-import { escapeCssIdentifier, query } from '../utils.js';
+import { escapeCssIdentifier as escape, query } from '../utils.js';
 
+/**
+ * Find the anchor element for a given hash.
+ * @see https://html.spec.whatwg.org/#find-a-potential-indicated-element
+ *
+ * @param hash Hash with or without leading '#'
+ * @returns The element, if found, or null.
+ */
 export const getAnchorElement = (hash: string): Element | null => {
+	if (hash && hash.charAt(0) === '#') {
+		hash = hash.substring(1);
+	}
+
 	if (!hash) {
 		return null;
 	}
 
-	if (hash.charAt(0) === '#') {
-		hash = hash.substring(1);
-	}
+	const decoded = decodeURIComponent(hash);
 
-	hash = decodeURIComponent(hash);
-	hash = escapeCssIdentifier(hash);
-
-	// https://html.spec.whatwg.org/#find-a-potential-indicated-element
-	return query(`#${hash}`) || query(`a[name='${hash}']`);
+	return (
+		document.getElementById(hash) ||
+		document.getElementById(decoded) ||
+		query(`a[name='${escape(hash)}']`) ||
+		query(`a[name='${escape(decoded)}']`)
+	);
 };


### PR DESCRIPTION
Fix for #652 to deal with encoded and unencoded hashes for finding a scroll target.

Tries to mimic WebKit behavior by looking for the raw value of the hash in any `[id]` or `a[name]` attribute, then checking for the url-decoded value.

New tests added.