### PR TITLE
Only warn if *no* animated element has a transition or animation defined

### DIFF
--- a/cypress/e2e/main.spec.js
+++ b/cypress/e2e/main.spec.js
@@ -149,6 +149,26 @@ describe('Transition timing', function () {
 		cy.transitionWithExpectedDuration(600);
 	});
 
+	it('should warn about missing transition timing', function () {
+		cy.visit('/transition-none.html', {
+			onBeforeLoad: (win) =>  cy.stub(win.console, 'warn').as('consoleWarn')
+		});
+		cy.triggerClickOnLink('/page-2.html');
+		cy.shouldBeAtPage('/page-2.html');
+		cy.shouldHaveH1('Page 2');
+		cy.get('@consoleWarn').should('be.calledOnceWith', '[swup] No CSS animation duration defined on elements matching `[class*=\"transition-\"]`');
+	});
+
+	it('should not warn about partial transition timing', function () {
+		cy.visit('/transition-partial.html', {
+			onBeforeLoad: (win) =>  cy.stub(win.console, 'warn').as('consoleWarn')
+		});
+		cy.triggerClickOnLink('/page-2.html');
+		cy.shouldBeAtPage('/page-2.html');
+		cy.shouldHaveH1('Page 2');
+		cy.get('@consoleWarn').should('have.callCount', 0);
+	});
+
 	it('should detect keyframe timing', function () {
 		cy.visit('/transition-keyframes.html');
 		cy.transitionWithExpectedDuration(700);

--- a/cypress/fixtures/transition-partial.html
+++ b/cypress/fixtures/transition-partial.html
@@ -3,12 +3,16 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Transition duration: none</title>
+    <title>Transition duration: partial</title>
     <link rel="stylesheet" href="/assets/main.css">
     <script src="/dist/Swup.umd.js"></script>
     <style>
-        .transition-none {
-            transition: none;
+        .transition-default {
+            transition: 0.4s opacity;
+            opacity: 1;
+        }
+        html.is-animating .transition-default {
+            opacity: 0;
         }
     </style>
 </head>
@@ -20,9 +24,10 @@
             <li><a href="/page-3.html">Page 3</a></li>
         </ul>
     </header>
-    <main id="swup" class="wrapper transition-none">
-        <h1>Transition duration: none</h1>
+    <main id="swup" class="wrapper transition-default">
+        <h1>Transition duration: partial</h1>
     </main>
+    <aside class="transition-none"></aside>
     <script>
         window._swup = new Swup();
     </script>

--- a/src/modules/getAnimationPromises.ts
+++ b/src/modules/getAnimationPromises.ts
@@ -37,7 +37,7 @@ export function getAnimationPromises(
 
 	// Warn if no elements match the animationSelector, but keep things going
 	if (!animatedElements.length) {
-		console.warn(`[swup] No elements found for animationSelector \`${selector}\``);
+		console.warn(`[swup] No elements found matching animationSelector \`${selector}\``);
 		return [Promise.resolve()];
 	}
 
@@ -47,7 +47,7 @@ export function getAnimationPromises(
 
 	if (!animationPromises.length) {
 		console.warn(
-			`[swup] No CSS transition or animation duration defined for any of the elements matching ${selector}`
+			`[swup] No CSS animation duration defined on elements matching \`${selector}\``
 		);
 		return [Promise.resolve()];
 	}

--- a/src/modules/getAnimationPromises.ts
+++ b/src/modules/getAnimationPromises.ts
@@ -42,7 +42,7 @@ export function getAnimationPromises(
 	}
 
 	const animationPromises = animatedElements
-		.map((element) => getAnimationPromiseForElement(element, selector))
+		.map((element) => getAnimationPromiseForElement(element))
 		.filter(Boolean) as Promise<void>[];
 
 	if (!animationPromises.length) {
@@ -58,12 +58,8 @@ export function getAnimationPromises(
 const isTransitionOrAnimationEvent = (event: any): event is TransitionEvent | AnimationEvent =>
 	[transitionEndEvent, animationEndEvent].includes(event.type);
 
-function getAnimationPromiseForElement(
-	element: Element,
-	selector: string,
-	expectedType: 'animation' | 'transition' | null = null
-): Promise<void> | undefined {
-	const { type, timeout, propCount } = getTransitionInfo(element, expectedType);
+function getAnimationPromiseForElement(element: Element): Promise<void> | undefined {
+	const { type, timeout, propCount } = getTransitionInfo(element);
 
 	// Resolve immediately if no transition defined
 	if (!type || !timeout) {

--- a/src/modules/getAnimationPromises.ts
+++ b/src/modules/getAnimationPromises.ts
@@ -46,7 +46,9 @@ export function getAnimationPromises(
 		.filter(Boolean) as Promise<void>[];
 
 	if (!animationPromises.length) {
-		console.warn(`[swup] No CSS transition or animation duration defined for any of the elements matching ${selector}`);
+		console.warn(
+			`[swup] No CSS transition or animation duration defined for any of the elements matching ${selector}`
+		);
 		return [Promise.resolve()];
 	}
 


### PR DESCRIPTION
**Description**

Right now, swup warns the user if *any* of the elements on the page matching the `animationSelector` don't have a transition duration. This creates unnecessary warnings, especially in the Fragment Plugin. This PR changes that behavior so that swup only warns if *none* of the elements has a transition duration defined.

**Checks**

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [x] New or updated tests are included
- [x] ~The documentation was updated as required~ (no need)

**Additional information**

<!--
Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc.
-->
