### PR TITLE
Allow replacing the current history entry

### DIFF
--- a/cypress/e2e/main.spec.js
+++ b/cypress/e2e/main.spec.js
@@ -345,6 +345,22 @@ describe('History', function () {
 		cy.wrapSwupInstance();
 	});
 
+	it('should create a new history state on visit', function () {
+		cy.visit('/history.html');
+
+		cy.triggerClickOnLink('/page-2.html');
+		cy.shouldBeAtPage('/page-2.html');
+
+		cy.get('[data-cy=create-link]').first().click();
+		cy.shouldBeAtPage('/page-3.html');
+		cy.window().then((window) => {
+			window.history.back();
+			cy.window().should(() => {
+				expect(window.history.state.url).to.equal('/page-2.html');
+			});
+		});
+	});
+
 	it('should transition to previous page on popstate', function () {
 		cy.triggerClickOnLink('/page-2.html');
 		cy.shouldBeAtPage('/page-2.html');

--- a/cypress/e2e/main.spec.js
+++ b/cypress/e2e/main.spec.js
@@ -361,6 +361,39 @@ describe('History', function () {
 		});
 	});
 
+	it('should replace the current history state via data attribute', function () {
+		cy.visit('/history.html');
+
+		cy.triggerClickOnLink('/page-2.html');
+		cy.shouldBeAtPage('/page-2.html');
+
+		cy.get('[data-cy=update-link]').first().click();
+		cy.shouldBeAtPage('/page-3.html');
+		cy.window().then((window) => {
+			window.history.back();
+			cy.window().should(() => {
+				expect(window.history.state.url).to.equal('/history.html');
+			});
+		});
+	});
+
+	it('should replace the current history state via API', function () {
+		cy.window().then(() => {
+			this.swup.loadPage({ url: '/page-2.html' });
+		});
+		cy.shouldBeAtPage('/page-2.html');
+		cy.window().then(() => {
+			this.swup.loadPage({ url: '/page-3.html', history: 'replace' });
+		});
+		cy.shouldBeAtPage('/page-3.html');
+		cy.window().then((window) => {
+			window.history.back();
+			cy.window().should(() => {
+				expect(window.history.state.url).to.equal('/page-1.html');
+			});
+		});
+	});
+
 	it('should transition to previous page on popstate', function () {
 		cy.triggerClickOnLink('/page-2.html');
 		cy.shouldBeAtPage('/page-2.html');
@@ -395,23 +428,6 @@ describe('History', function () {
 			cy.window().should(() => {
 				expect(window.history.state.url, 'page url not saved').to.equal('/page-1.html');
 				expect(window.history.state.source, 'state source not saved').to.equal('swup');
-			});
-		});
-	});
-
-	it('should replace history state via API', function () {
-		cy.window().then(() => {
-			this.swup.loadPage({ url: '/page-2.html' });
-		});
-		cy.shouldBeAtPage('/page-2.html');
-		cy.window().then(() => {
-			this.swup.loadPage({ url: '/page-3.html', history: 'replace' });
-		});
-		cy.shouldBeAtPage('/page-3.html');
-		cy.window().then((window) => {
-			window.history.back();
-			cy.window().should(() => {
-				expect(window.history.state.url).to.equal('/page-1.html');
 			});
 		});
 	});

--- a/cypress/e2e/main.spec.js
+++ b/cypress/e2e/main.spec.js
@@ -383,6 +383,23 @@ describe('History', function () {
 		});
 	});
 
+	it('should replace history state via API', function () {
+		cy.window().then(() => {
+			this.swup.loadPage({ url: '/page-2.html' });
+		});
+		cy.shouldBeAtPage('/page-2.html');
+		cy.window().then(() => {
+			this.swup.loadPage({ url: '/page-3.html', history: 'replace' });
+		});
+		cy.shouldBeAtPage('/page-3.html');
+		cy.window().then((window) => {
+			window.history.back();
+			cy.window().should(() => {
+				expect(window.history.state.url).to.equal('/page-1.html');
+			});
+		});
+	});
+
 	it('should trigger a custom popState event', function () {
 		const handlers = { popstate() {} };
 		cy.spy(handlers, 'popstate');

--- a/cypress/fixtures/history.html
+++ b/cypress/fixtures/history.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>History</title>
+    <link rel="stylesheet" href="/assets/main.css">
+    <script src="/dist/Swup.umd.js"></script>
+</head>
+<body>
+    <header class="header">
+        <ul>
+            <li><a href="/page-2.html">Page 2</a></li>
+            <li><a href="/page-3.html" data-cy="create-link">Page 3: create</a></li>
+            <li><a href="/page-3.html" data-swup-history="replace" data-cy="update-link">Page 3: update</a></li>
+        </ul>
+    </header>
+    <main id="swup" class="wrapper transition-default">
+        <h1>History</h1>
+        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+        Alias assumenda consectetur consequatur enim esse incidunt iusto, magnam
+        maxime molestias nisi perferendis perspiciatis quibusdam quos repellat,
+        vel veniam vero voluptate voluptatem.</p>
+    </main>
+    <script>
+        window._swup = new Swup();
+    </script>
+</body>
+</html>

--- a/src/Swup.ts
+++ b/src/Swup.ts
@@ -19,7 +19,7 @@ import { getAnimationPromises } from './modules/getAnimationPromises.js';
 import { getPageData } from './modules/getPageData.js';
 import { fetchPage } from './modules/fetchPage.js';
 import { leavePage } from './modules/leavePage.js';
-import { loadPage, performPageLoad } from './modules/loadPage.js';
+import { HistoryAction, loadPage, performPageLoad } from './modules/loadPage.js';
 import { replaceContent } from './modules/replaceContent.js';
 import { on, off, triggerEvent, Handlers } from './modules/events.js';
 import { use, unuse, findPlugin, Plugin } from './modules/plugins.js';
@@ -275,8 +275,15 @@ export default class Swup {
 		// Get the custom transition name, if present
 		const customTransition = linkEl.getAttribute('data-swup-transition') || undefined;
 
+		// Get the history action, if set
+		let history: HistoryAction | undefined;
+		const historyAttr = linkEl.getAttribute('data-swup-history');
+		if (historyAttr && ['push', 'replace'].includes(historyAttr)) {
+			history = historyAttr as HistoryAction;
+		}
+
 		// Finally, proceed with loading the page
-		this.performPageLoad({ url, customTransition });
+		this.performPageLoad({ url, customTransition, history });
 	}
 
 	handleLinkToSamePage(url: string, hash: string, event: DelegateEvent<MouseEvent>) {

--- a/src/modules/loadPage.ts
+++ b/src/modules/loadPage.ts
@@ -1,16 +1,20 @@
-import { classify, createHistoryRecord, getCurrentUrl } from '../helpers.js';
+import { classify, createHistoryRecord, updateHistoryRecord, getCurrentUrl } from '../helpers.js';
 import Swup from '../Swup.js';
 import { PageRecord } from './Cache.js';
+
+export type HistoryAction = 'push' | 'replace';
 
 export type TransitionOptions = {
 	url: string;
 	customTransition?: string;
+	history?: HistoryAction;
 };
 
 export type PageLoadOptions = {
 	url: string;
-	event?: PopStateEvent;
 	customTransition?: string;
+	history?: HistoryAction;
+	event?: PopStateEvent;
 };
 
 export function loadPage(this: Swup, data: TransitionOptions) {
@@ -25,7 +29,7 @@ export function loadPage(this: Swup, data: TransitionOptions) {
 }
 
 export function performPageLoad(this: Swup, data: PageLoadOptions) {
-	const { url, event, customTransition } = data ?? {};
+	const { url, event, customTransition, history: historyAction = 'push' } = data ?? {};
 
 	const isHistoryVisit = event instanceof PopStateEvent;
 	const skipTransition = this.shouldSkipTransition({ url, event });
@@ -46,7 +50,12 @@ export function performPageLoad(this: Swup, data: PageLoadOptions) {
 
 	// create history record if this is not a popstate call (with or without anchor)
 	if (!isHistoryVisit) {
-		createHistoryRecord(url + (this.scrollToElement || ''));
+		const historyUrl = url + (this.scrollToElement || '');
+		if (historyAction === 'replace') {
+			updateHistoryRecord(historyUrl);
+		} else {
+			createHistoryRecord(historyUrl);
+		}
 	}
 
 	this.currentPageUrl = getCurrentUrl();


### PR DESCRIPTION
Implement a way of telling swup to update the current history entry, instead of creating a new one. Solves #668

API

```js
swup.loadPage({ url: '/about', history: 'replace' })
```

HTML

```html
<a href="/about" data-swup-history="replace">About</a>
```

**Checks**

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [x] New or updated tests are included
- [ ] The documentation was updated as required
