### PR TITLE
Fix redirect handling

### DIFF
--- a/cypress/e2e/main.spec.js
+++ b/cypress/e2e/main.spec.js
@@ -38,17 +38,13 @@ describe('Cache', function () {
 	it('should cache pages', function () {
 		this.swup.loadPage({ url: '/page-2.html' });
 		cy.shouldBeAtPage('/page-2.html');
-		cy.window().should(() => {
-			expect(this.swup.cache.getCurrentPage()).not.to.be.undefined;
-		});
+		cy.shouldHaveCacheEntry('/page-2.html');
 	});
 
 	it('should cache pages from absolute URLs', function () {
 		this.swup.loadPage({ url: `${baseUrl}/page-2.html` });
 		cy.shouldBeAtPage('/page-2.html');
-		cy.window().should(() => {
-			expect(this.swup.cache.getCurrentPage()).not.to.be.undefined;
-		});
+		cy.shouldHaveCacheEntry('/page-2.html');
 	});
 });
 
@@ -236,6 +232,33 @@ describe('Link resolution', function () {
 		cy.shouldBeAtPage('/nested/nested-2.html');
 		cy.shouldHaveH1('Nested Page 2');
 	});
+});
+
+describe.only('Redirects', function () {
+	beforeEach(() => {
+		cy.visit('/page-1.html');
+	});
+
+	it('should follow redirects', function () {
+		cy.intercept('GET', '/page-2.html', (req) => {
+			req.redirect('/page-3.html', 302);
+		});
+		cy.triggerClickOnLink('/page-2.html');
+		cy.shouldBeAtPage('/page-3.html');
+		cy.shouldHaveH1('Page 3');
+	});
+
+	// it('should not cache 302 redirects', function () {
+	// 	this.swup.loadPage({ url: '/page-2.html' });
+	// 	cy.shouldBeAtPage('/page-2.html');
+	// 	cy.shouldHaveCacheEntries(['/page-3.html']);
+	// });
+
+	// it('should cache 301 redirects', function () {
+	// 	this.swup.loadPage({ url: '/page-2.html' });
+	// 	cy.shouldBeAtPage('/page-2.html');
+	// 	cy.shouldHaveCacheEntries(['/page-2.html', '/page-3.html']);
+	// });
 });
 
 describe('Ignoring visits', function () {

--- a/cypress/e2e/main.spec.js
+++ b/cypress/e2e/main.spec.js
@@ -234,7 +234,7 @@ describe('Link resolution', function () {
 	});
 });
 
-describe.only('Redirects', function () {
+describe('Redirects', function () {
 	beforeEach(() => {
 		cy.visit('/page-1.html');
 		cy.intercept('GET', '/page-2.html', (req) => {

--- a/cypress/e2e/main.spec.js
+++ b/cypress/e2e/main.spec.js
@@ -237,28 +237,22 @@ describe('Link resolution', function () {
 describe.only('Redirects', function () {
 	beforeEach(() => {
 		cy.visit('/page-1.html');
-	});
-
-	it('should follow redirects', function () {
 		cy.intercept('GET', '/page-2.html', (req) => {
 			req.redirect('/page-3.html', 302);
 		});
+	});
+
+	it('should follow redirects', function () {
 		cy.triggerClickOnLink('/page-2.html');
 		cy.shouldBeAtPage('/page-3.html');
 		cy.shouldHaveH1('Page 3');
 	});
 
-	// it('should not cache 302 redirects', function () {
-	// 	this.swup.loadPage({ url: '/page-2.html' });
-	// 	cy.shouldBeAtPage('/page-2.html');
-	// 	cy.shouldHaveCacheEntries(['/page-3.html']);
-	// });
-
-	// it('should cache 301 redirects', function () {
-	// 	this.swup.loadPage({ url: '/page-2.html' });
-	// 	cy.shouldBeAtPage('/page-2.html');
-	// 	cy.shouldHaveCacheEntries(['/page-2.html', '/page-3.html']);
-	// });
+	it('should not cache redirects', function () {
+		cy.triggerClickOnLink('/page-2.html');
+		cy.shouldBeAtPage('/page-3.html');
+		cy.shouldHaveCacheEntries([]);
+	});
 });
 
 describe('Ignoring visits', function () {

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -42,6 +42,25 @@ Cypress.Commands.add('shouldBeAtPage', (href) => {
 	});
 });
 
+Cypress.Commands.add('shouldHaveCacheEntries', (urls) => {
+	cy.window().should((window) => {
+		const { cache } = window._swup;
+		const pages = Array.from(cache.pages.keys());
+		expect(pages).to.equal(urls);
+	});
+});
+
+Cypress.Commands.add('shouldHaveCacheEntry', (url) => {
+	cy.window().should((window) => {
+		const { cache } = window._swup;
+		const exists = cache.exists(url);
+		const page = cache.getPage(url);
+		expect(url).to.be.a('string');
+		expect(exists).to.be.true;
+		expect(page).not.to.be.undefined;
+	});
+});
+
 Cypress.Commands.add('shouldHaveReloadedAfterAction', (action) => {
 	cy.window().then((window) => (window.beforeReload = true));
 	cy.window().should('have.prop', 'beforeReload', true);

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -46,7 +46,7 @@ Cypress.Commands.add('shouldHaveCacheEntries', (urls) => {
 	cy.window().should((window) => {
 		const { cache } = window._swup;
 		const pages = Array.from(cache.pages.keys());
-		expect(pages).to.equal(urls);
+		expect(pages).to.have.members(urls);
 	});
 });
 

--- a/src/modules/Cache.ts
+++ b/src/modules/Cache.ts
@@ -18,9 +18,7 @@ export class Cache {
 
 	save(url: string, page: PageData) {
 		url = this.resolve(url);
-		if (!this.exists(url)) {
-			this.pages.set(url, page);
-		}
+		this.pages.set(url, page);
 		this.last = this.get(url);
 		this.swup.log(`Cache (${this.pages.size})`, this.pages);
 	}

--- a/src/modules/Cache.ts
+++ b/src/modules/Cache.ts
@@ -11,29 +11,30 @@ export class Cache {
 		this.swup = swup;
 	}
 
-	getCacheUrl(url: string): string {
-		return this.swup.resolveUrl(Location.fromUrl(url).url);
+	resolve(urlToResolve: string): string {
+		const { url } = Location.fromUrl(urlToResolve);
+		return this.swup.resolveUrl(url);
 	}
 
-	cacheUrl(page: PageData) {
-		page.url = this.getCacheUrl(page.url);
-		if (!this.exists(page.url)) {
-			this.pages.set(page.url, page);
+	save(url: string, page: PageData) {
+		url = this.resolve(url);
+		if (!this.exists(url)) {
+			this.pages.set(url, page);
 		}
-		this.last = this.getPage(page.url);
+		this.last = this.get(url);
 		this.swup.log(`Cache (${this.pages.size})`, this.pages);
 	}
 
-	getPage(url: string): PageData | undefined {
-		return this.pages.get(this.getCacheUrl(url));
+	get(url: string): PageData | undefined {
+		return this.pages.get(this.resolve(url));
 	}
 
 	getCurrentPage(): PageData | undefined {
-		return this.getPage(getCurrentUrl());
+		return this.get(getCurrentUrl());
 	}
 
 	exists(url: string): boolean {
-		return this.pages.has(this.getCacheUrl(url));
+		return this.pages.has(this.resolve(url));
 	}
 
 	empty(): void {
@@ -43,6 +44,6 @@ export class Cache {
 	}
 
 	remove(url: string): void {
-		this.pages.delete(this.getCacheUrl(url));
+		this.pages.delete(this.resolve(url));
 	}
 }

--- a/src/modules/Cache.ts
+++ b/src/modules/Cache.ts
@@ -11,28 +11,28 @@ export class Cache {
 		this.swup = swup;
 	}
 
-	resolve(urlToResolve: string): string {
+	getCacheUrl(urlToResolve: string): string {
 		const { url } = Location.fromUrl(urlToResolve);
 		return this.swup.resolveUrl(url);
 	}
 
-	save(url: string, page: PageData) {
-		url = this.resolve(url);
-		this.pages.set(url, page);
-		this.last = this.get(url);
+	cacheUrl(page: PageData) {
+		page.url = this.getCacheUrl(page.url);
+		this.pages.set(page.url, page);
+		this.last = this.getPage(page.url);
 		this.swup.log(`Cache (${this.pages.size})`, this.pages);
 	}
 
-	get(url: string): PageData | undefined {
-		return this.pages.get(this.resolve(url));
+	getPage(url: string): PageData | undefined {
+		return this.pages.get(this.getCacheUrl(url));
 	}
 
 	getCurrentPage(): PageData | undefined {
-		return this.get(getCurrentUrl());
+		return this.getPage(getCurrentUrl());
 	}
 
 	exists(url: string): boolean {
-		return this.pages.has(this.resolve(url));
+		return this.pages.has(this.getCacheUrl(url));
 	}
 
 	empty(): void {
@@ -42,6 +42,6 @@ export class Cache {
 	}
 
 	remove(url: string): void {
-		this.pages.delete(this.resolve(url));
+		this.pages.delete(this.getCacheUrl(url));
 	}
 }

--- a/src/modules/fetchPage.ts
+++ b/src/modules/fetchPage.ts
@@ -1,17 +1,18 @@
 import Swup from '../Swup.js';
-import { fetch } from '../helpers.js';
+import { Location, fetch } from '../helpers.js';
 import { TransitionOptions } from './loadPage.js';
 
 export type PageData = {
 	url: string;
+	redirect?: string | false;
 	html: string;
 };
 
 export function fetchPage(this: Swup, data: TransitionOptions): Promise<PageData> {
 	const headers = this.options.requestHeaders;
-	const { url } = data;
+	const { url: requestURL } = data;
 
-	const cachedPage = this.cache.getPage(url);
+	const cachedPage = this.cache.getPage(requestURL);
 	if (cachedPage) {
 		this.triggerEvent('pageRetrievedFromCache');
 		return Promise.resolve(cachedPage);
@@ -19,21 +20,23 @@ export function fetchPage(this: Swup, data: TransitionOptions): Promise<PageData
 
 	return new Promise((resolve, reject) => {
 		fetch({ ...data, headers }, (response) => {
-			const {
-				status,
-				responseText: html,
-				responseURL: url = window.location.href
-			} = response;
+			const { status, responseText, responseURL } = response;
+
 			if (status === 500) {
 				this.triggerEvent('serverError');
-				reject(url);
+				reject(requestURL);
 				return;
 			}
-			if (!html) {
-				reject(url);
+
+			if (!responseText) {
+				reject(requestURL);
 				return;
 			}
-			const page = { url, html };
+
+			const html = responseText;
+			const { url } = Location.fromUrl(responseURL || requestURL);
+			const redirect = requestURL !== url ? url : false;
+			const page: PageData = { url, redirect, html };
 			this.cache.cacheUrl(page);
 			this.triggerEvent('pageLoaded');
 			resolve(page);

--- a/src/modules/fetchPage.ts
+++ b/src/modules/fetchPage.ts
@@ -11,7 +11,7 @@ export function fetchPage(this: Swup, data: TransitionOptions): Promise<PageData
 	const headers = this.options.requestHeaders;
 	const { url: requestURL } = Location.fromUrl(data.url);
 
-	const cachedPage = this.cache.get(requestURL);
+	const cachedPage = this.cache.getPage(requestURL);
 	if (cachedPage) {
 		this.triggerEvent('pageRetrievedFromCache');
 		return Promise.resolve(cachedPage);
@@ -38,7 +38,7 @@ export function fetchPage(this: Swup, data: TransitionOptions): Promise<PageData
 
 			// Only save cache entry for non-redirects
 			if (requestURL === url) {
-				this.cache.save(url, page);
+				this.cache.cacheUrl(page);
 			}
 
 			this.triggerEvent('pageLoaded');

--- a/src/modules/loadPage.ts
+++ b/src/modules/loadPage.ts
@@ -52,9 +52,9 @@ export function performPageLoad(this: Swup, data: PageLoadOptions) {
 	this.currentPageUrl = getCurrentUrl();
 
 	// when everything is ready, render the page
-	Promise.all<PageData | void>([fetchPromise, ...animationPromises])
+	Promise.all([fetchPromise, ...animationPromises])
 		.then(([pageData]) => {
-			this.renderPage(pageData as PageData, { event, skipTransition });
+			this.renderPage(url, pageData, { event, skipTransition });
 		})
 		.catch((errorUrl) => {
 			// Return early if errorUrl is not defined (probably aborted preload request)

--- a/src/modules/renderPage.ts
+++ b/src/modules/renderPage.ts
@@ -21,9 +21,9 @@ export const renderPage = function (
 
 	const { url } = Location.fromUrl(page.url);
 
-	// update cache and state if the url was redirected
+	// update state if the url was redirected
 	if (!this.isSameResolvedUrl(getCurrentUrl(), url)) {
-		this.cache.cacheUrl({ ...page, url });
+		this.cache.save(url, { ...page, url });
 		this.currentPageUrl = getCurrentUrl();
 		updateHistoryRecord(url);
 	}

--- a/src/modules/renderPage.ts
+++ b/src/modules/renderPage.ts
@@ -23,7 +23,6 @@ export const renderPage = function (
 
 	// update state if the url was redirected
 	if (!this.isSameResolvedUrl(getCurrentUrl(), url)) {
-		this.cache.save(url, { ...page, url });
 		this.currentPageUrl = getCurrentUrl();
 		updateHistoryRecord(url);
 	}

--- a/src/modules/renderPage.ts
+++ b/src/modules/renderPage.ts
@@ -9,17 +9,18 @@ export type PageRenderOptions = {
 
 export const renderPage = function (
 	this: Swup,
+	requestedUrl: string,
 	page: PageData,
 	{ event, skipTransition }: PageRenderOptions = {}
 ) {
 	document.documentElement.classList.remove('is-leaving');
 
 	// do nothing if another page was requested in the meantime
-	if (!this.isSameResolvedUrl(getCurrentUrl(), page.url)) {
+	if (!this.isSameResolvedUrl(getCurrentUrl(), requestedUrl)) {
 		return;
 	}
 
-	const { url } = Location.fromUrl(page.url);
+	const { url } = page;
 
 	// update state if the url was redirected
 	if (!this.isSameResolvedUrl(getCurrentUrl(), url)) {


### PR DESCRIPTION
**Description**

- The recent changes in #665 broke redirects
- This reverses things to correctly redirect & adds necessary tests to catch errors
- I've switched the behavior in one important aspect: to never cache redirects
  - Currently, we handle 302 redirects incorrectly: they aren't cached by the browser, but swup caches them
  - Ideally, we could cache permanent 301 redirects and not cache temporary 302 redirects
  - However, we can't get the redirect type: ajax requests only report the final 200 code
  - The next-best solution is to not cache redirects at all, to avoid caching temporary 302 redirects

**Checks**

- [x] The PR is submitted to the `next` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [x] New or updated tests are included
- [ ] ~~The documentation was updated as required~~