### PR TITLE
Remove css prefixes

### DIFF
--- a/src/modules/getAnimationPromises.ts
+++ b/src/modules/getAnimationPromises.ts
@@ -47,9 +47,6 @@ export function getAnimationPromises(
 	return animationPromises;
 }
 
-const isTransitionOrAnimationEvent = (event: any): event is TransitionEvent | AnimationEvent =>
-	[`${TRANSITION}end`, `${ANIMATION}end`].includes(event.type);
-
 function getAnimationPromiseForElement(element: Element): Promise<void> | undefined {
 	const { type, timeout, propCount } = getTransitionInfo(element);
 
@@ -100,10 +97,6 @@ function getAnimationPromiseForElement(element: Element): Promise<void> | undefi
 	});
 }
 
-function getStyleProperties(styles: AnimationStyleDeclarations, key: AnimationStyleKeys) {
-	return (styles[key] || '').split(', ');
-}
-
 export function getTransitionInfo(element: Element, expectedType?: AnimationTypes) {
 	const styles = window.getComputedStyle(element) as AnimationStyleDeclarations;
 
@@ -145,6 +138,14 @@ export function getTransitionInfo(element: Element, expectedType?: AnimationType
 		timeout,
 		propCount
 	};
+}
+
+function isTransitionOrAnimationEvent(event: any): event is TransitionEvent | AnimationEvent {
+	return [`${TRANSITION}end`, `${ANIMATION}end`].includes(event.type);
+}
+
+function getStyleProperties(styles: AnimationStyleDeclarations, key: AnimationStyleKeys) {
+	return (styles[key] || '').split(', ');
 }
 
 function calculateTimeout(delays: string[], durations: string[]): number {

--- a/src/modules/getAnimationPromises.ts
+++ b/src/modules/getAnimationPromises.ts
@@ -1,13 +1,13 @@
 import { queryAll, toMs } from '../utils.js';
 import Swup from '../Swup.js';
 
-// Transition property/event sniffing
-let transitionProp = 'transition';
-let transitionEndEvent = 'transitionend';
-let animationProp = 'animation';
-let animationEndEvent = 'animationend';
+const TRANSITION = 'transition';
+const ANIMATION = 'animation';
 
-
+type AnimationTypes = typeof TRANSITION | typeof ANIMATION;
+type AnimationProperties = 'Delay' | 'Duration';
+type AnimationStyleKeys = `${AnimationTypes}${AnimationProperties}` | 'transitionProperty';
+type AnimationStyleDeclarations = Pick<CSSStyleDeclaration, AnimationStyleKeys>;
 
 export function getAnimationPromises(
 	this: Swup,
@@ -48,7 +48,7 @@ export function getAnimationPromises(
 }
 
 const isTransitionOrAnimationEvent = (event: any): event is TransitionEvent | AnimationEvent =>
-	[transitionEndEvent, animationEndEvent].includes(event.type);
+	[`${TRANSITION}end`, `${ANIMATION}end`].includes(event.type);
 
 function getAnimationPromiseForElement(element: Element): Promise<void> | undefined {
 	const { type, timeout, propCount } = getTransitionInfo(element);
@@ -59,7 +59,7 @@ function getAnimationPromiseForElement(element: Element): Promise<void> | undefi
 	}
 
 	return new Promise((resolve) => {
-		const endEvent = type === 'transition' ? transitionEndEvent : animationEndEvent;
+		const endEvent = `${type}end`;
 		const startTime = performance.now();
 		let propsTransitioned = 0;
 
@@ -100,60 +100,41 @@ function getAnimationPromiseForElement(element: Element): Promise<void> | undefi
 	});
 }
 
-export function getTransitionInfo(
-	element: Element,
-	expectedType: 'animation' | 'transition' | null = null
-) {
-	const styles = window.getComputedStyle(element);
+function getStyleProperties(styles: AnimationStyleDeclarations, key: AnimationStyleKeys) {
+	return (styles[key] || '').split(', ');
+}
 
-	// not sure what to do about the below mess other than casting, but it's a mess
-	const transitionDelay = `${transitionProp}Delay` as keyof CSSStyleDeclaration;
-	const transitionDuration = `${transitionProp}Duration` as keyof CSSStyleDeclaration;
-	const animationDelay = `${animationProp}Delay` as keyof CSSStyleDeclaration;
-	const animationDuration = `${animationProp}Duration` as keyof CSSStyleDeclaration;
+export function getTransitionInfo(element: Element, expectedType?: AnimationTypes) {
+	const styles = window.getComputedStyle(element) as AnimationStyleDeclarations;
 
-	const transitionDelays = (
-		styles[transitionDelay] as CSSStyleDeclaration['transitionDelay']
-	).split(', ');
-	const transitionDurations = (
-		(styles[transitionDuration] || '') as CSSStyleDeclaration['transitionDuration']
-	).split(', ');
+	const transitionDelays = getStyleProperties(styles, `${TRANSITION}Delay`);
+	const transitionDurations = getStyleProperties(styles, `${TRANSITION}Duration`);
 	const transitionTimeout = calculateTimeout(transitionDelays, transitionDurations);
-
-	const animationDelays = (
-		(styles[animationDelay] || '') as CSSStyleDeclaration['animationDelay']
-	).split(', ');
-	const animationDurations = (
-		(styles[animationDuration] || '') as CSSStyleDeclaration['animationDuration']
-	).split(', ');
+	const animationDelays = getStyleProperties(styles, `${ANIMATION}Delay`);
+	const animationDurations = getStyleProperties(styles, `${ANIMATION}Duration`);
 	const animationTimeout = calculateTimeout(animationDelays, animationDurations);
 
-	let type: string | null = '';
+	let type: AnimationTypes | null = null;
 	let timeout = 0;
 	let propCount = 0;
 
-	if (expectedType === 'transition') {
+	if (expectedType === TRANSITION) {
 		if (transitionTimeout > 0) {
-			type = 'transition';
+			type = TRANSITION;
 			timeout = transitionTimeout;
 			propCount = transitionDurations.length;
 		}
-	} else if (expectedType === 'animation') {
+	} else if (expectedType === ANIMATION) {
 		if (animationTimeout > 0) {
-			type = 'animation';
+			type = ANIMATION;
 			timeout = animationTimeout;
 			propCount = animationDurations.length;
 		}
 	} else {
 		timeout = Math.max(transitionTimeout, animationTimeout);
-		type =
-			timeout > 0
-				? transitionTimeout > animationTimeout
-					? 'transition'
-					: 'animation'
-				: null;
+		type = timeout > 0 ? (transitionTimeout > animationTimeout ? TRANSITION : ANIMATION) : null;
 		propCount = type
-			? type === 'transition'
+			? type === TRANSITION
 				? transitionDurations.length
 				: animationDurations.length
 			: 0;
@@ -166,7 +147,7 @@ export function getTransitionInfo(
 	};
 }
 
-function calculateTimeout(delays: string[], durations: string[]) {
+function calculateTimeout(delays: string[], durations: string[]): number {
 	while (delays.length < durations.length) {
 		delays = delays.concat(delays);
 	}

--- a/src/modules/getAnimationPromises.ts
+++ b/src/modules/getAnimationPromises.ts
@@ -7,15 +7,7 @@ let transitionEndEvent = 'transitionend';
 let animationProp = 'animation';
 let animationEndEvent = 'animationend';
 
-if (window.ontransitionend === undefined && window.onwebkittransitionend !== undefined) {
-	transitionProp = 'WebkitTransition';
-	transitionEndEvent = 'webkitTransitionEnd';
-}
 
-if (window.onanimationend === undefined && window.onwebkitanimationend !== undefined) {
-	animationProp = 'WebkitAnimation';
-	animationEndEvent = 'webkitAnimationEnd';
-}
 
 export function getAnimationPromises(
 	this: Swup,


### PR DESCRIPTION
**Description**

- Remove support for prefixed `-webkit-transition` properties
- Unprefixed support for these exists since 2015 across all browsers
- Decrease bundle size a tiny bit
- Currently not passing tests, waiting for #675 
- Breaking change

**Checks**

- [x] The PR is submitted to the `next` branch
- [x] The code was linted before pushing (`npm run lint`)
- [ ] All tests are passing (`npm run test`)
- [ ] ~~New or updated tests are included~~
- [ ] ~~The documentation was updated as required~~