### PR TITLE
Accept #top as a special fragment identifier

### DIFF
--- a/cypress/e2e/main.spec.js
+++ b/cypress/e2e/main.spec.js
@@ -493,6 +493,15 @@ describe('Scroll Plugin', function () {
 		cy.shouldHaveElementInViewport('[data-cy=anchor]');
 	});
 
+	it('should scroll to top', function () {
+		cy.get('[data-cy=link-to-self-anchor]').click();
+		cy.shouldHaveElementInViewport('[data-cy=anchor]');
+		cy.get('[data-cy=link-to-top]').click();
+		cy.window().should((window) => {
+			expect(window.scrollY).equal(0);
+		});
+	});
+
 	it('should scroll to id-based anchor', function () {
 		cy.get('[data-cy=link-to-anchor-by-id]').click();
 		cy.shouldHaveElementInViewport('[data-cy=anchor-by-id]');

--- a/cypress/fixtures/plugins/scroll-plugin-1.html
+++ b/cypress/fixtures/plugins/scroll-plugin-1.html
@@ -57,6 +57,9 @@
                 <a href="#anchor" data-cy="link-to-anchor">Link to anchor</a>
             </li>
             <li>
+                <a href="#top" data-cy="link-to-top">Link to top</a>
+            </li>
+            <li>
                 <a href="/plugins/scroll-plugin-1.html#anchor" data-cy="link-to-self-anchor">Link to self with anchor</a>
             </li>
             <li>
@@ -84,7 +87,7 @@
     </main>
     <script>
         window._swup = new Swup({
-            plugins: [new SwupScrollPlugin()]
+            plugins: [new SwupScrollPlugin({ acceleration: 10, friction: 0 })]
         });
     </script>
 </body>

--- a/src/modules/getAnchorElement.ts
+++ b/src/modules/getAnchorElement.ts
@@ -17,11 +17,15 @@ export const getAnchorElement = (hash: string): Element | null => {
 	}
 
 	const decoded = decodeURIComponent(hash);
-
-	return (
+	let element =
 		document.getElementById(hash) ||
 		document.getElementById(decoded) ||
 		query(`a[name='${escape(hash)}']`) ||
-		query(`a[name='${escape(decoded)}']`)
-	);
+		query(`a[name='${escape(decoded)}']`);
+
+	if (!element && hash === 'top') {
+		element = document.body;
+	}
+
+	return element;
 };


### PR DESCRIPTION
**Description**

Accept the special fragment `#top` to scroll to the top of the document, whether or not an element with the id `top` exists anywhere in the document. Quoting the HTML spec on [scrolling to a fragment](https://html.spec.whatwg.org/#scrolling-to-a-fragment):

> If *decodedFragment* is an ASCII case-insensitive match for the string `top`, then return the top of the document.

**Checks**

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [x] New or updated tests are included
- [ ] ~~The documentation was updated as required~~

Closes #674 