### PR TITLE
Implement basic scroll behavior

### DIFF
--- a/cypress/e2e/main.spec.js
+++ b/cypress/e2e/main.spec.js
@@ -595,3 +595,67 @@ describe('Containers', function () {
 		cy.get('h2').should('contain', 'Heading 1');
 	});
 });
+
+describe('Scrolling', function () {
+	beforeEach(() => {
+		cy.visit('/scrolling-1.html');
+	});
+
+	it('should scroll to hash element and back to top', function () {
+		cy.get('[data-cy=link-to-anchor]').click();
+		cy.shouldHaveElementInViewport('[data-cy=anchor]');
+
+		cy.triggerClickOnLink('/page-1.html');
+		cy.window().should((window) => {
+			expect(window.scrollY).equal(0);
+		});
+	});
+
+	it('should scroll to anchor with path', function () {
+		cy.get('[data-cy=link-to-self-anchor]').click();
+		cy.shouldHaveElementInViewport('[data-cy=anchor]');
+	});
+
+	it('should scroll to top', function () {
+		cy.get('[data-cy=link-to-self-anchor]').click();
+		cy.shouldHaveElementInViewport('[data-cy=anchor]');
+		cy.get('[data-cy=link-to-top]').click();
+		cy.window().should((window) => {
+			expect(window.scrollY).equal(0);
+		});
+	});
+
+	it('should scroll to id-based anchor', function () {
+		cy.get('[data-cy=link-to-anchor-by-id]').click();
+		cy.shouldHaveElementInViewport('[data-cy=anchor-by-id]');
+	});
+
+	it('should scroll to name-based anchor', function () {
+		cy.get('[data-cy=link-to-anchor-by-name]').click();
+		cy.shouldHaveElementInViewport('[data-cy=anchor-by-name]');
+	});
+
+	it('should prefer undecoded id attributes', function () {
+		cy.get('[data-cy=link-to-anchor-encoded]').click();
+		cy.shouldHaveElementInViewport('[data-cy=anchor-encoded]');
+	});
+
+	it('should accept unencoded anchor links', function () {
+		cy.get('[data-cy=link-to-anchor-unencoded]').click();
+		cy.shouldHaveElementInViewport('[data-cy=anchor-unencoded]');
+	});
+
+	it('should scroll to anchor with special characters', function () {
+		cy.get('[data-cy=link-to-anchor-with-colon]').click();
+		cy.shouldHaveElementInViewport('[data-cy=anchor-with-colon]');
+		cy.get('[data-cy=link-to-anchor-with-unicode]').click();
+		cy.shouldHaveElementInViewport('[data-cy=anchor-with-unicode]');
+	});
+
+	it('should transition page and scroll on link with hash', function () {
+		cy.get('[data-cy=link-to-page-anchor]').click();
+		cy.shouldBeAtPage('/scrolling-2.html#anchor');
+		cy.shouldHaveH1('Scrolling 2');
+		cy.shouldHaveElementInViewport('[data-cy=anchor]');
+	});
+});

--- a/cypress/e2e/main.spec.js
+++ b/cypress/e2e/main.spec.js
@@ -587,7 +587,7 @@ describe('Containers', function () {
 	});
 
 	it('should be customizable from hook params', function () {
-		this.swup.hooks.before('replaceContent', (_, args) => {
+		this.swup.hooks.before('replaceContent', (context, args) => {
 			args.containers = ['#main'];
 		});
 		this.swup.loadPage('/containers-2.html', { animate: false });

--- a/cypress/fixtures/assets/main.css
+++ b/cypress/fixtures/assets/main.css
@@ -107,7 +107,7 @@ html.is-animating .transition-default {
   padding: 40px 20px;
 }
 .wrapper-inner {
-  max-width: 480px;
+  max-width: 600px;
   margin: 0 auto;
 }
 .button {

--- a/cypress/fixtures/page-1.html
+++ b/cypress/fixtures/page-1.html
@@ -16,11 +16,41 @@
         </ul>
     </header>
     <main id="swup" class="wrapper transition-default" data-cy="container">
-        <h1>Page 1</h1>
-        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.
-        Alias assumenda consectetur consequatur enim esse incidunt iusto, magnam
-        maxime molestias nisi perferendis perspiciatis quibusdam quos repellat,
-        vel veniam vero voluptate voluptatem.</p>
+        <div class="wrapper-inner">
+            <h1>Page 1</h1>
+            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+            Alias assumenda consectetur consequatur enim esse incidunt iusto, magnam
+            maxime molestias nisi perferendis perspiciatis quibusdam quos repellat,
+            vel veniam vero voluptate voluptatem.</p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+            Alias assumenda consectetur consequatur enim esse incidunt iusto, magnam
+            maxime molestias nisi perferendis perspiciatis quibusdam quos repellat,
+            vel veniam vero voluptate voluptatem.</p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+            Alias assumenda consectetur consequatur enim esse incidunt iusto, magnam
+            maxime molestias nisi perferendis perspiciatis quibusdam quos repellat,
+            vel veniam vero voluptate voluptatem.</p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+            Alias assumenda consectetur consequatur enim esse incidunt iusto, magnam
+            maxime molestias nisi perferendis perspiciatis quibusdam quos repellat,
+            vel veniam vero voluptate voluptatem.</p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+            Alias assumenda consectetur consequatur enim esse incidunt iusto, magnam
+            maxime molestias nisi perferendis perspiciatis quibusdam quos repellat,
+            vel veniam vero voluptate voluptatem.</p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+            Alias assumenda consectetur consequatur enim esse incidunt iusto, magnam
+            maxime molestias nisi perferendis perspiciatis quibusdam quos repellat,
+            vel veniam vero voluptate voluptatem.</p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+            Alias assumenda consectetur consequatur enim esse incidunt iusto, magnam
+            maxime molestias nisi perferendis perspiciatis quibusdam quos repellat,
+            vel veniam vero voluptate voluptatem.</p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+            Alias assumenda consectetur consequatur enim esse incidunt iusto, magnam
+            maxime molestias nisi perferendis perspiciatis quibusdam quos repellat,
+            vel veniam vero voluptate voluptatem.</p>
+        </div>
     </main>
     <script>
         window._swup = new Swup();

--- a/cypress/fixtures/page-2.html
+++ b/cypress/fixtures/page-2.html
@@ -16,11 +16,41 @@
         </ul>
     </header>
     <main id="swup" class="wrapper transition-default" data-cy="container">
-        <h1>Page 2</h1>
-        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.
-        Alias assumenda consectetur consequatur enim esse incidunt iusto, magnam
-        maxime molestias nisi perferendis perspiciatis quibusdam quos repellat,
-        vel veniam vero voluptate voluptatem.</p>
+        <div class="wrapper-inner">
+            <h1>Page 2</h1>
+            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+            Alias assumenda consectetur consequatur enim esse incidunt iusto, magnam
+            maxime molestias nisi perferendis perspiciatis quibusdam quos repellat,
+            vel veniam vero voluptate voluptatem.</p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+            Alias assumenda consectetur consequatur enim esse incidunt iusto, magnam
+            maxime molestias nisi perferendis perspiciatis quibusdam quos repellat,
+            vel veniam vero voluptate voluptatem.</p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+            Alias assumenda consectetur consequatur enim esse incidunt iusto, magnam
+            maxime molestias nisi perferendis perspiciatis quibusdam quos repellat,
+            vel veniam vero voluptate voluptatem.</p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+            Alias assumenda consectetur consequatur enim esse incidunt iusto, magnam
+            maxime molestias nisi perferendis perspiciatis quibusdam quos repellat,
+            vel veniam vero voluptate voluptatem.</p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+            Alias assumenda consectetur consequatur enim esse incidunt iusto, magnam
+            maxime molestias nisi perferendis perspiciatis quibusdam quos repellat,
+            vel veniam vero voluptate voluptatem.</p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+            Alias assumenda consectetur consequatur enim esse incidunt iusto, magnam
+            maxime molestias nisi perferendis perspiciatis quibusdam quos repellat,
+            vel veniam vero voluptate voluptatem.</p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+            Alias assumenda consectetur consequatur enim esse incidunt iusto, magnam
+            maxime molestias nisi perferendis perspiciatis quibusdam quos repellat,
+            vel veniam vero voluptate voluptatem.</p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+            Alias assumenda consectetur consequatur enim esse incidunt iusto, magnam
+            maxime molestias nisi perferendis perspiciatis quibusdam quos repellat,
+            vel veniam vero voluptate voluptatem.</p>
+        </div>
     </main>
     <script>
         window._swup = new Swup();

--- a/cypress/fixtures/page-3.html
+++ b/cypress/fixtures/page-3.html
@@ -16,11 +16,41 @@
         </ul>
     </header>
     <main id="swup" class="wrapper transition-default" data-cy="container">
-        <h1>Page 3</h1>
-        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.
-        Alias assumenda consectetur consequatur enim esse incidunt iusto, magnam
-        maxime molestias nisi perferendis perspiciatis quibusdam quos repellat,
-        vel veniam vero voluptate voluptatem.</p>
+        <div class="wrapper-inner">
+            <h1>Page 3</h1>
+            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+            Alias assumenda consectetur consequatur enim esse incidunt iusto, magnam
+            maxime molestias nisi perferendis perspiciatis quibusdam quos repellat,
+            vel veniam vero voluptate voluptatem.</p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+            Alias assumenda consectetur consequatur enim esse incidunt iusto, magnam
+            maxime molestias nisi perferendis perspiciatis quibusdam quos repellat,
+            vel veniam vero voluptate voluptatem.</p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+            Alias assumenda consectetur consequatur enim esse incidunt iusto, magnam
+            maxime molestias nisi perferendis perspiciatis quibusdam quos repellat,
+            vel veniam vero voluptate voluptatem.</p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+            Alias assumenda consectetur consequatur enim esse incidunt iusto, magnam
+            maxime molestias nisi perferendis perspiciatis quibusdam quos repellat,
+            vel veniam vero voluptate voluptatem.</p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+            Alias assumenda consectetur consequatur enim esse incidunt iusto, magnam
+            maxime molestias nisi perferendis perspiciatis quibusdam quos repellat,
+            vel veniam vero voluptate voluptatem.</p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+            Alias assumenda consectetur consequatur enim esse incidunt iusto, magnam
+            maxime molestias nisi perferendis perspiciatis quibusdam quos repellat,
+            vel veniam vero voluptate voluptatem.</p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+            Alias assumenda consectetur consequatur enim esse incidunt iusto, magnam
+            maxime molestias nisi perferendis perspiciatis quibusdam quos repellat,
+            vel veniam vero voluptate voluptatem.</p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+            Alias assumenda consectetur consequatur enim esse incidunt iusto, magnam
+            maxime molestias nisi perferendis perspiciatis quibusdam quos repellat,
+            vel veniam vero voluptate voluptatem.</p>
+        </div>
     </main>
     <script>
         window._swup = new Swup();

--- a/cypress/fixtures/plugins/body-class-plugin-1.html
+++ b/cypress/fixtures/plugins/body-class-plugin-1.html
@@ -29,7 +29,7 @@
             name = 'CustomBodyClassPlugin';
             isSwupPlugin = true;
             mount() {
-                this.swup.hooks.on('replaceContent', (_, { page: { html } }) => {
+                this.swup.hooks.on('replaceContent', (context, { page: { html } }) => {
                     const doc = new DOMParser().parseFromString(html, 'text/html');
                     const body = doc.querySelector('body');
                     if (body) {

--- a/cypress/fixtures/scrolling-1.html
+++ b/cypress/fixtures/scrolling-1.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Scrolling 1</title>
+    <link rel="stylesheet" href="/assets/main.css">
+    <script src="/dist/Swup.umd.js"></script>
+    <style>
+        .scroll-anchors > * {
+            display: block;
+            margin: 1000px 0;
+        }
+    </style>
+</head>
+<body>
+    <header class="header">
+        <ul>
+            <li><a href="/page-1.html">Page 1</a></li>
+            <li><a href="/page-2.html">Page 2</a></li>
+        </ul>
+    </header>
+    <main id="swup" class="wrapper transition-default">
+        <h1>Scrolling 1</h1>
+
+        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+        Alias assumenda consectetur consequatur enim esse incidunt iusto, magnam
+        maxime molestias nisi perferendis perspiciatis quibusdam quos repellat,
+        vel veniam vero voluptate voluptatem.</p>
+
+        <h2>Anchors</h2>
+
+        <div class="scroll-anchors">
+            <div id="anchor" data-cy="anchor">Anchor</div>
+            <div id="anchor-by-id" data-cy="anchor-by-id">Anchor by id</div>
+            <a name="anchor-by-name" data-cy="anchor-by-name">Anchor by name</a>
+            <div id="anchor-%21" data-cy="anchor-encoded">Anchor with encoded ID</div>
+            <div id="anchor-!" data-cy="anchor-unencoded">Anchor with unencoded ID</div>
+            <div id="anchor:with:colon" data-cy="anchor-with-colon">Anchor with colon</div>
+            <div id="anchor-with-unicode-テスト" data-cy="anchor-with-unicode">Anchor with unicode</div>
+        </div>
+
+        Lorem ipsum dolor sit amet, consectetur adipisicing elit. Alias
+        assumenda consectetur consequatur enim esse incidunt iusto, magnam
+        maxime molestias nisi perferendis perspiciatis quibusdam quos repellat,
+        vel veniam vero voluptate voluptatem.
+
+        <h2>Links</h2>
+
+        <ul>
+            <li>
+                <a href="/scrolling-2.html" data-cy="link-to-page">Link to page</a>
+            </li>
+            <li>
+                <a href="#anchor" data-cy="link-to-anchor">Link to anchor</a>
+            </li>
+            <li>
+                <a href="#top" data-cy="link-to-top">Link to top</a>
+            </li>
+            <li>
+                <a href="/scrolling-1.html#anchor" data-cy="link-to-self-anchor">Link to self with anchor</a>
+            </li>
+            <li>
+                <a href="/scrolling-2.html#anchor" data-cy="link-to-page-anchor">Link to page with anchor</a>
+            </li>
+            <li>
+                <a href="#anchor-by-id" data-cy="link-to-anchor-by-id">Link to anchor by id</a>
+            </li>
+            <li>
+                <a href="#anchor-by-name" data-cy="link-to-anchor-by-name">Link to anchor by name</a>
+            </li>
+            <li>
+                <a href="#anchor-%21" data-cy="link-to-anchor-encoded">Link to anchor with url-encoding</a>
+            </li>
+            <li>
+                <a href="#anchor-!" data-cy="link-to-anchor-unencoded">Link to anchor without url-encoding</a>
+            </li>
+            <li>
+                <a href="#anchor:with:colon" data-cy="link-to-anchor-with-colon">Link to anchor with colon</a>
+            </li>
+            <li>
+                <a href="#anchor-with-unicode-テスト" data-cy="link-to-anchor-with-unicode">Link to anchor with unicode</a>
+            </li>
+        </ul>
+    </main>
+    <script>
+        window._swup = new Swup();
+    </script>
+</body>
+</html>

--- a/cypress/fixtures/scrolling-2.html
+++ b/cypress/fixtures/scrolling-2.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Scrolling 2</title>
+    <link rel="stylesheet" href="/assets/main.css">
+    <script src="/dist/Swup.umd.js"></script>
+</head>
+<body>
+    <header class="header">
+        <ul>
+            <li><a href="/page-1.html">Page 1</a></li>
+            <li><a href="/page-2.html">Page 2</a></li>
+        </ul>
+    </header>
+    <main id="swup" class="wrapper transition-default">
+        <h1>Scrolling 2</h1>
+
+        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+        Alias assumenda consectetur consequatur enim esse incidunt iusto, magnam
+        maxime molestias nisi perferendis perspiciatis quibusdam quos repellat,
+        vel veniam vero voluptate voluptatem.</p>
+
+        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+        Alias assumenda consectetur consequatur enim esse incidunt iusto, magnam
+        maxime molestias nisi perferendis perspiciatis quibusdam quos repellat,
+        vel veniam vero voluptate voluptatem.</p>
+
+        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+        Alias assumenda consectetur consequatur enim esse incidunt iusto, magnam
+        maxime molestias nisi perferendis perspiciatis quibusdam quos repellat,
+        vel veniam vero voluptate voluptatem.</p>
+
+        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+        Alias assumenda consectetur consequatur enim esse incidunt iusto, magnam
+        maxime molestias nisi perferendis perspiciatis quibusdam quos repellat,
+        vel veniam vero voluptate voluptatem.</p>
+
+        <h2>Anchor</h2>
+
+        <div class="scroll-anchors">
+            <div id="anchor" data-cy="anchor">Anchor</div>
+        </div>
+
+        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+        Alias assumenda consectetur consequatur enim esse incidunt iusto, magnam
+        maxime molestias nisi perferendis perspiciatis quibusdam quos repellat,
+        vel veniam vero voluptate voluptatem.</p>
+    </main>
+</body>
+</html>

--- a/src/Swup.ts
+++ b/src/Swup.ts
@@ -266,34 +266,42 @@ export default class Swup {
 		}
 
 		this.hooks.triggerSync('clickLink', { event }, () => {
-			event.preventDefault();
+			const from = this.context.from?.url ?? '';
 
-			const from = this.context.from?.url;
-
-			// Handle links to the same page and exit early, where applicable
+			// Handle links to the same page: with or without hash
 			if (!url || url === from) {
-				this.handleLinkToSamePage(url, hash);
+				if (hash) {
+					this.hooks.triggerSync(
+						'samePageWithHash',
+						{ hash, options: { behavior: 'auto' } },
+						(_, { hash, options }) => {
+							event.preventDefault();
+							updateHistoryRecord(url + hash);
+							const target = this.getAnchorElement(hash);
+							if (target) {
+								target.scrollIntoView(options);
+							}
+						}
+					);
+				} else {
+					this.hooks.triggerSync('samePage', undefined, () => {
+						event.preventDefault();
+						window.scroll({ top: 0, left: 0, behavior: 'auto' });
+					});
+				}
 				return;
 			}
 
+			event.preventDefault();
+
 			// Exit early if the resolved path hasn't changed
-			if (this.isSameResolvedUrl(url, from ?? '')) {
+			if (this.isSameResolvedUrl(url, from)) {
 				return;
 			}
 
 			// Finally, proceed with loading the page
 			this.performPageLoad(url, { transition, history: historyAction });
 		});
-	}
-
-	async handleLinkToSamePage(url: string, hash: string) {
-		if (hash) {
-			await this.hooks.trigger('samePageWithHash', { hash }, (_, { hash }) => {
-				updateHistoryRecord(url + hash);
-			});
-		} else {
-			await this.hooks.trigger('samePage');
-		}
 	}
 
 	triggerWillOpenNewWindow(triggerEl: Element) {

--- a/src/Swup.ts
+++ b/src/Swup.ts
@@ -274,7 +274,7 @@ export default class Swup {
 					this.hooks.triggerSync(
 						'samePageWithHash',
 						{ hash, options: { behavior: 'auto' } },
-						(_, { hash, options }) => {
+						(context, { hash, options }) => {
 							event.preventDefault();
 							updateHistoryRecord(url + hash);
 							const target = this.getAnchorElement(hash);

--- a/src/modules/Hooks.ts
+++ b/src/modules/Hooks.ts
@@ -22,7 +22,8 @@ export interface HookDefinitions {
 	popState: { event: PopStateEvent };
 	replaceContent: { page: PageData; containers: Options['containers'] };
 	samePage: undefined;
-	samePageWithHash: { hash: string };
+	samePageWithHash: { hash: string; options: ScrollIntoViewOptions };
+	scrollToContent: { options: ScrollIntoViewOptions };
 	serverError: { url: string; status: number; request: XMLHttpRequest };
 	transitionStart: undefined;
 	transitionEnd: undefined;
@@ -92,6 +93,7 @@ export class Hooks {
 		'replaceContent',
 		'samePage',
 		'samePageWithHash',
+		'scrollToContent',
 		'serverError',
 		'transitionStart',
 		'transitionEnd',

--- a/src/modules/enterPage.ts
+++ b/src/modules/enterPage.ts
@@ -5,7 +5,7 @@ export const enterPage = async function (this: Swup) {
 		const animation = this.hooks.trigger(
 			'awaitAnimation',
 			{ selector: this.options.animationSelector },
-			async (_, { selector }) => {
+			async (context, { selector }) => {
 				await Promise.all(this.getAnimationPromises({ selector, direction: 'in' }));
 			}
 		);

--- a/src/modules/leavePage.ts
+++ b/src/modules/leavePage.ts
@@ -20,7 +20,7 @@ export const leavePage = async function (this: Swup) {
 	await this.hooks.trigger(
 		'awaitAnimation',
 		{ selector: this.options.animationSelector },
-		async (_, { selector }) => {
+		async (context, { selector }) => {
 			await Promise.all(this.getAnimationPromises({ selector, direction: 'out' }));
 		}
 	);

--- a/src/modules/renderPage.ts
+++ b/src/modules/renderPage.ts
@@ -35,6 +35,23 @@ export const renderPage = async function (this: Swup, requestedUrl: string, page
 		}
 	);
 
+	await this.hooks.trigger(
+		'scrollToContent',
+		{ options: { behavior: 'auto' } },
+		(_, { options }) => {
+			if (this.context.scroll.target) {
+				const target = this.getAnchorElement(this.context.scroll.target);
+				if (target) {
+					target.scrollIntoView(options);
+					return;
+				}
+			}
+			if (this.context.scroll.reset) {
+				window.scrollTo(0, 0);
+			}
+		}
+	);
+
 	await this.hooks.trigger('pageView', { url: this.currentPageUrl, title: document.title });
 
 	// empty cache if it's disabled (in case preload plugin filled it)

--- a/src/modules/renderPage.ts
+++ b/src/modules/renderPage.ts
@@ -30,7 +30,7 @@ export const renderPage = async function (this: Swup, requestedUrl: string, page
 	await this.hooks.trigger(
 		'replaceContent',
 		{ page, containers: this.context.containers },
-		(_, { page, containers }) => {
+		(context, { page, containers }) => {
 			this.replaceContent(page, { containers });
 		}
 	);
@@ -38,7 +38,7 @@ export const renderPage = async function (this: Swup, requestedUrl: string, page
 	await this.hooks.trigger(
 		'scrollToContent',
 		{ options: { behavior: 'auto' } },
-		(_, { options }) => {
+		(context, { options }) => {
 			if (this.context.scroll.target) {
 				const target = this.getAnchorElement(this.context.scroll.target);
 				if (target) {


### PR DESCRIPTION
**Description**

Very basic, non-animated simulation of standard browser scroll behavior to make sure a default swup installation doesn't break scrolling. Currently, we're basically forcing people to install the scroll plugin. For anything more advanced, users can and should still install the scroll plugin.

- Reset scroll position to the top on page visits inside a new hook `scrollToContent`
- Jump to anchors on the same page inside existing hook `samePageWithHash`
- The scroll plugin can replace those handlers to implement its functionality
- Increases bundle size by 93 bytes 🌝

**Checks**

- [x] The PR is submitted to the `next` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [x] New or updated tests are included
- [ ] The documentation was updated as required

**Additional information**

Closes #672