### PR TITLE
Cache pruning

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -53,8 +53,8 @@ Cypress.Commands.add('shouldHaveCacheEntries', (urls) => {
 Cypress.Commands.add('shouldHaveCacheEntry', (url) => {
 	cy.window().should((window) => {
 		const { cache } = window._swup;
-		const exists = cache.exists(url);
-		const page = cache.getPage(url);
+		const exists = cache.has(url);
+		const page = cache.get(url);
 		expect(url).to.be.a('string');
 		expect(exists).to.be.true;
 		expect(page).not.to.be.undefined;

--- a/src/Swup.ts
+++ b/src/Swup.ts
@@ -161,7 +161,7 @@ export default class Swup {
 		window.removeEventListener('popstate', this.popStateHandler);
 
 		// empty cache
-		this.cache.empty();
+		this.cache.clear();
 
 		// unmount plugins
 		this.options.plugins.forEach((plugin) => this.unuse(plugin));

--- a/src/modules/Cache.ts
+++ b/src/modules/Cache.ts
@@ -1,47 +1,59 @@
 import Swup from '../Swup.js';
-import { getCurrentUrl, Location } from '../helpers.js';
+import { Location } from '../helpers.js';
 import { PageData } from './fetchPage.js';
 
+export interface CacheData extends PageData {}
+
 export class Cache {
-	swup: Swup;
-	pages: Map<string, PageData> = new Map();
-	last?: PageData;
+	private swup: Swup;
+	private pages: Map<string, CacheData> = new Map();
 
 	constructor(swup: Swup) {
 		this.swup = swup;
 	}
 
-	getCacheUrl(urlToResolve: string): string {
+	get size() {
+		return this.pages.size;
+	}
+
+	get all() {
+		return this.pages;
+	}
+
+	public has(url: string): boolean {
+		return this.pages.has(this.resolve(url));
+	}
+
+	public get(url: string): CacheData | undefined {
+		return this.pages.get(this.resolve(url));
+	}
+
+	public set(url: string, page: CacheData) {
+		url = this.resolve(url);
+		page = { ...page, url };
+		this.pages.set(url, page);
+		this.swup.hooks.triggerSync('pageCached', { page });
+	}
+
+	public delete(url: string): void {
+		this.pages.delete(this.resolve(url));
+	}
+
+	public clear(): void {
+		this.pages.clear();
+		this.swup.hooks.triggerSync('cacheCleared');
+	}
+
+	public prune(predicate: (page: CacheData) => boolean): void {
+		this.pages.forEach((page, url) => {
+			if (predicate(page)) {
+				this.delete(url);
+			}
+		});
+	}
+
+	private resolve(urlToResolve: string): string {
 		const { url } = Location.fromUrl(urlToResolve);
 		return this.swup.resolveUrl(url);
-	}
-
-	cacheUrl(page: PageData) {
-		page.url = this.getCacheUrl(page.url);
-		this.pages.set(page.url, page);
-		this.last = this.getPage(page.url);
-		this.swup.log(`Cache (${this.pages.size})`, this.pages);
-	}
-
-	getPage(url: string): PageData | undefined {
-		return this.pages.get(this.getCacheUrl(url));
-	}
-
-	getCurrentPage(): PageData | undefined {
-		return this.getPage(getCurrentUrl());
-	}
-
-	exists(url: string): boolean {
-		return this.pages.has(this.getCacheUrl(url));
-	}
-
-	empty(): void {
-		this.pages.clear();
-		delete this.last;
-		this.swup.log('Cache cleared');
-	}
-
-	remove(url: string): void {
-		this.pages.delete(this.getCacheUrl(url));
 	}
 }

--- a/src/modules/Cache.ts
+++ b/src/modules/Cache.ts
@@ -35,6 +35,12 @@ export class Cache {
 		this.swup.hooks.triggerSync('pageCached', { page });
 	}
 
+	public update(url: string, page: CacheData) {
+		url = this.resolve(url);
+		page = { ...this.get(url), ...page, url };
+		this.pages.set(url, page);
+	}
+
 	public delete(url: string): void {
 		this.pages.delete(this.resolve(url));
 	}

--- a/src/modules/Cache.ts
+++ b/src/modules/Cache.ts
@@ -50,9 +50,9 @@ export class Cache {
 		this.swup.hooks.triggerSync('cacheCleared');
 	}
 
-	public prune(predicate: (page: CacheData) => boolean): void {
+	public prune(predicate: (url: string, page: CacheData) => boolean): void {
 		this.pages.forEach((page, url) => {
-			if (predicate(page)) {
+			if (predicate(url, page)) {
 				this.delete(url);
 			}
 		});

--- a/src/modules/Hooks.ts
+++ b/src/modules/Hooks.ts
@@ -12,12 +12,14 @@ export interface HookDefinitions {
 	animationOutStart: undefined;
 	animationSkipped: undefined;
 	awaitAnimation: { selector: Options['animationSelector'] };
+	cacheCleared: undefined;
 	clickLink: { event: DelegateEvent<MouseEvent> };
 	disabled: undefined;
 	enabled: undefined;
 	openPageInNewTab: { href: string };
+	pageCached: { page: PageData };
 	pageLoaded: { page: PageData };
-	pageRetrievedFromCache: { page: PageData };
+	pageLoadedFromCache: { page: PageData };
 	pageView: { url: string; title: string };
 	popState: { event: PopStateEvent };
 	replaceContent: { page: PageData; containers: Options['containers'] };
@@ -81,12 +83,14 @@ export class Hooks {
 		'animationOutStart',
 		'animationSkipped',
 		'awaitAnimation',
+		'cacheCleared',
 		'clickLink',
 		'disabled',
 		'enabled',
 		'openPageInNewTab',
+		'pageCached',
 		'pageLoaded',
-		'pageRetrievedFromCache',
+		'pageLoadedFromCache',
 		'pageView',
 		'popState',
 		'replaceContent',

--- a/src/modules/__test__/cache.test.ts
+++ b/src/modules/__test__/cache.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import Swup from '../../Swup.js';
+import { Cache } from '../Cache.js';
+import { Context } from '../Context.js';
+
+const swup = new Swup();
+const cache = new Cache(swup);
+
+describe('Cache', () => {
+	it('should be empty', () => {
+		expect(cache.size).toBe(0);
+	});
+
+	it('should append pages', () => {
+		cache.set('/page-1', { url: '/page-1', html: '' });
+		expect(cache.size).toBe(1);
+	});
+
+	it('should have pages', () => {
+		cache.set('/page-1', { url: '/page-1', html: '' });
+		expect(cache.has('/page-1')).toBe(true);
+	});
+
+	it('should get pages', () => {
+		cache.set('/page-1', { url: '/page-1', html: '' });
+		expect(cache.get('/page-1')).toEqual({ url: '/page-1', html: '' });
+	});
+
+	it('should delete pages', () => {
+		cache.set('/page-1', { url: '/page-1', html: '' });
+		expect(cache.has('/page-1')).toBe(true);
+		cache.delete('/page-1');
+		expect(cache.has('/page-1')).toBe(false);
+	});
+
+	it('should clear', () => {
+		cache.set('/page-1', { url: '/page-1', html: '' });
+		cache.clear();
+		expect(cache.size).toBe(0);
+	});
+
+	it('should overwrite identical pages', () => {
+		cache.set('/page-1', { url: '/page-1', html: '' });
+		expect(cache.size).toBe(1);
+		cache.set('/page-1', { url: '/page-1', html: '' });
+		expect(cache.size).toBe(1);
+	});
+
+	it('should not overwrite different pages', () => {
+		cache.set('/page-1', { url: '/page-1', html: '' });
+		expect(cache.size).toBe(1);
+		cache.set('/page-2', { url: '/page-2', html: '' });
+		expect(cache.size).toBe(2);
+	});
+
+	it('should trigger a hook on set', () => {
+		const handler = vi.fn();
+		swup.hooks.on('pageCached', handler);
+
+		cache.set('/page-1', { url: '/page-1', html: '<div>Test</div>' });
+
+		expect(handler).toBeCalledTimes(1);
+	});
+});
+
+describe('Types', () => {
+	it('error when necessary', async () => {
+		const swup = new Swup();
+		const cache = new Cache(swup);
+
+		// @ts-expect-no-error
+		swup.hooks.on('popState', (ctx: Context, { event: PopStateEvent }) => {});
+		// @ts-expect-no-error
+		await swup.hooks.trigger('popState', { event: new PopStateEvent('') });
+
+		try {
+			// @ts-expect-error
+			cache.set();
+			// @ts-expect-error
+			cache.set(url);
+			// @ts-expect-error
+			cache.set(url, {});
+			// @ts-expect-error
+			cache.set({ url: '/test' });
+		} catch (error) {}
+	});
+});

--- a/src/modules/__test__/cache.test.ts
+++ b/src/modules/__test__/cache.test.ts
@@ -1,10 +1,21 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import Swup from '../../Swup.js';
-import { Cache } from '../Cache.js';
+import { Cache, CacheData } from '../Cache.js';
 import { Context } from '../Context.js';
 
+interface CacheTtlData {
+	ttl: number;
+	created: number;
+}
+
+interface AugmentedCacheData extends CacheData, CacheTtlData {}
+
 const swup = new Swup();
+const ctx = swup.context;
 const cache = new Cache(swup);
+
+const page1 = { url: '/page-1', html: '1' };
+const page2 = { url: '/page-2', html: '2' };
 
 describe('Cache', () => {
 	it('should be empty', () => {
@@ -12,54 +23,71 @@ describe('Cache', () => {
 	});
 
 	it('should append pages', () => {
-		cache.set('/page-1', { url: '/page-1', html: '' });
+		cache.set(page1.url, page1);
 		expect(cache.size).toBe(1);
 	});
 
 	it('should have pages', () => {
-		cache.set('/page-1', { url: '/page-1', html: '' });
-		expect(cache.has('/page-1')).toBe(true);
+		cache.set(page1.url, page1);
+		expect(cache.has(page1.url)).toBe(true);
 	});
 
 	it('should get pages', () => {
-		cache.set('/page-1', { url: '/page-1', html: '' });
-		expect(cache.get('/page-1')).toEqual({ url: '/page-1', html: '' });
+		cache.set(page1.url, page1);
+		expect(cache.get(page1.url)).toEqual(page1);
 	});
 
 	it('should delete pages', () => {
-		cache.set('/page-1', { url: '/page-1', html: '' });
-		expect(cache.has('/page-1')).toBe(true);
-		cache.delete('/page-1');
-		expect(cache.has('/page-1')).toBe(false);
+		cache.set(page1.url, page1);
+		expect(cache.has(page1.url)).toBe(true);
+		cache.delete(page1.url);
+		expect(cache.has(page1.url)).toBe(false);
 	});
 
 	it('should clear', () => {
-		cache.set('/page-1', { url: '/page-1', html: '' });
+		cache.set(page1.url, page1);
 		cache.clear();
 		expect(cache.size).toBe(0);
 	});
 
 	it('should overwrite identical pages', () => {
-		cache.set('/page-1', { url: '/page-1', html: '' });
+		cache.set(page1.url, page1);
 		expect(cache.size).toBe(1);
-		cache.set('/page-1', { url: '/page-1', html: '' });
+		cache.set(page1.url, page1);
 		expect(cache.size).toBe(1);
 	});
 
 	it('should not overwrite different pages', () => {
-		cache.set('/page-1', { url: '/page-1', html: '' });
+		cache.set(page1.url, page1);
 		expect(cache.size).toBe(1);
-		cache.set('/page-2', { url: '/page-2', html: '' });
+		cache.set(page2.url, page2);
 		expect(cache.size).toBe(2);
 	});
 
 	it('should trigger a hook on set', () => {
 		const handler = vi.fn();
+
 		swup.hooks.on('pageCached', handler);
 
-		cache.set('/page-1', { url: '/page-1', html: '<div>Test</div>' });
+		cache.set(page1.url, page1);
 
 		expect(handler).toBeCalledTimes(1);
+		expect(handler).toBeCalledWith(ctx, { page: page1 });
+	});
+
+	it('should allow augmenting cache entries on save', () => {
+		const now = Date.now();
+
+		swup.hooks.on('pageCached', (_, { page }) => {
+			const ttl: CacheTtlData = { ttl: 1000, created: now };
+			cache.update(page.url, ttl as AugmentedCacheData);
+		});
+
+		cache.set('/page', { url: '/page', html: '' });
+
+		const page = cache.get('/page') as AugmentedCacheData;
+
+		expect(page).toEqual({ url: '/page', html: '', ttl: 1000, created: now });
 	});
 });
 

--- a/src/modules/__test__/hooks.test.ts
+++ b/src/modules/__test__/hooks.test.ts
@@ -202,12 +202,14 @@ describe('Types', () => {
 		const swup = new Swup();
 
 		// @ts-expect-no-error
-		swup.hooks.on('popState', (ctx: Context, { event: PopStateEvent }) => {});
+		swup.hooks.on('popState', (ctx: Context, { event }: { event: PopStateEvent }) => {});
 		// @ts-expect-no-error
 		await swup.hooks.trigger('popState', { event: new PopStateEvent('') });
 
 		// @ts-expect-error
 		swup.hooks.on('popState', ({ event: MouseEvent }) => {});
+		// @ts-expect-error
+		swup.hooks.on('popState', (ctx: Context, { event }: { event: MouseEvent }) => {});
 		// @ts-expect-error
 		await swup.hooks.trigger('popState', { event: new MouseEvent('') });
 	});

--- a/src/modules/fetchPage.ts
+++ b/src/modules/fetchPage.ts
@@ -2,10 +2,10 @@ import Swup from '../Swup.js';
 import { Location, fetch } from '../helpers.js';
 import { PageLoadOptions } from './loadPage.js';
 
-export type PageData = {
+export interface PageData {
 	url: string;
 	html: string;
-};
+}
 
 export async function fetchPage(
 	this: Swup,
@@ -15,9 +15,9 @@ export async function fetchPage(
 	const headers = this.options.requestHeaders;
 	const { url: requestURL } = Location.fromUrl(url);
 
-	const cachedPage = this.cache.getPage(requestURL);
+	const cachedPage = this.cache.get(requestURL);
 	if (cachedPage) {
-		await this.hooks.trigger('pageRetrievedFromCache', { page: cachedPage });
+		await this.hooks.trigger('pageLoadedFromCache', { page: cachedPage });
 		return Promise.resolve(cachedPage);
 	}
 
@@ -42,7 +42,7 @@ export async function fetchPage(
 
 			// Only save cache entry for non-redirects
 			if (requestURL === url) {
-				this.cache.cacheUrl(page);
+				this.cache.set(url, page);
 			}
 
 			this.hooks.trigger('pageLoaded', { page });

--- a/src/modules/renderPage.ts
+++ b/src/modules/renderPage.ts
@@ -39,7 +39,7 @@ export const renderPage = async function (this: Swup, requestedUrl: string, page
 
 	// empty cache if it's disabled (in case preload plugin filled it)
 	if (!this.options.cache) {
-		this.cache.empty();
+		this.cache.clear();
 	}
 
 	// Perform in transition


### PR DESCRIPTION
**Description**

Refactor the cache to allow customisable invalidation/pruning.

- Add a `pageCached` hook to allow augmenting cache entries with e.g. a counter, timestamp, etc.
- Simplify the Cache API by staying close to ES Map syntax: has, get, set, delete, clear, size
- Add an `update` method to allow inserting arbitrary data to existing entries
- Add a `prune` method to allow removing entries that match a predicate function
- Removes 4 bytes from the bundle size 🌝

**Pruning**

By default, the new implementation won't add any new data to entries, nor prune it automatically. For consumers that want this, they can use hooks to do that. Or we can create a more sophisticated plugin for cache invalidation.

```js
swup.hooks.on('pageCached', (ctx, { page }) => {

  // When a page is cached, add a timestamp and a TTL
  swup.cache.update(page.url, { ttl: 1000, created: Date.now() });

  // Every ten requests, prune the cache by checking the timestamp
  if (Math.random() < 0.1) {
    swup.cache.prune((url, page) => page.ttl < Date.now() - page.created);
  }

});
```

**Other drive-by improvements**

- Rename `pageLoadedFromCache` for simplicity
- Remove `cache.getCurrentPage`: we now have the page object in the `replaceContent` hook

**Checks**

- [x] The PR is submitted to the `next` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [x] New or updated tests are included
- [x] The documentation was updated as required

**Additional information**

Closes #602