### PR TITLE
Feat: Normalize and compare URLs

### DIFF
--- a/cypress/e2e/main.spec.js
+++ b/cypress/e2e/main.spec.js
@@ -336,7 +336,7 @@ describe('Link selector', function () {
 	});
 });
 
-describe.only('Resolve URLs', function () {
+describe('Resolve and normalize URLs', function () {
 	beforeEach(() => {
 		cy.visit('/page-1.html');
 		cy.wrapSwupInstance();

--- a/cypress/e2e/main.spec.js
+++ b/cypress/e2e/main.spec.js
@@ -21,11 +21,13 @@ describe('Request', function () {
 		const expected = this.swup.options.requestHeaders;
 		cy.intercept('GET', '/page-3.html').as('request');
 		cy.triggerClickOnLink('/page-3.html');
-		cy.wait('@request').its('request.headers').then((headers) => {
-			Object.entries(expected).forEach(([header, value]) => {
-				cy.wrap(headers).its(header.toLowerCase()).should('eq', value);
+		cy.wait('@request')
+			.its('request.headers')
+			.then((headers) => {
+				Object.entries(expected).forEach(([header, value]) => {
+					cy.wrap(headers).its(header.toLowerCase()).should('eq', value);
+				});
 			});
-		});
 	});
 });
 
@@ -143,17 +145,20 @@ describe('Transition timing', function () {
 
 	it('should warn about missing transition timing', function () {
 		cy.visit('/transition-none.html', {
-			onBeforeLoad: (win) =>  cy.stub(win.console, 'warn').as('consoleWarn')
+			onBeforeLoad: (win) => cy.stub(win.console, 'warn').as('consoleWarn')
 		});
 		cy.triggerClickOnLink('/page-2.html');
 		cy.shouldBeAtPage('/page-2.html');
 		cy.shouldHaveH1('Page 2');
-		cy.get('@consoleWarn').should('be.calledOnceWith', '[swup] No CSS animation duration defined on elements matching `[class*=\"transition-\"]`');
+		cy.get('@consoleWarn').should(
+			'be.calledOnceWith',
+			'[swup] No CSS animation duration defined on elements matching `[class*="transition-"]`'
+		);
 	});
 
 	it('should not warn about partial transition timing', function () {
 		cy.visit('/transition-partial.html', {
-			onBeforeLoad: (win) =>  cy.stub(win.console, 'warn').as('consoleWarn')
+			onBeforeLoad: (win) => cy.stub(win.console, 'warn').as('consoleWarn')
 		});
 		cy.triggerClickOnLink('/page-2.html');
 		cy.shouldBeAtPage('/page-2.html');
@@ -209,6 +214,7 @@ describe('Navigation', function () {
 describe('Link resolution', function () {
 	beforeEach(() => {
 		cy.visit('/link-resolution.html');
+		cy.wrapSwupInstance();
 	});
 
 	it('should skip links to different origins', function () {
@@ -232,7 +238,9 @@ describe('Link resolution', function () {
 		cy.shouldBeAtPage('/nested/nested-2.html');
 		cy.shouldHaveH1('Nested Page 2');
 	});
+
 });
+
 
 describe('Redirects', function () {
 	beforeEach(() => {
@@ -328,7 +336,7 @@ describe('Link selector', function () {
 	});
 });
 
-describe('Resolve URLs', function () {
+describe.only('Resolve URLs', function () {
 	beforeEach(() => {
 		cy.visit('/page-1.html');
 		cy.wrapSwupInstance();
@@ -349,6 +357,14 @@ describe('Resolve URLs', function () {
 			window.history.back();
 			cy.shouldBeAtPage('/pushed-page-1/');
 			cy.shouldHaveH1('Page 1');
+		});
+	});
+
+	it('should normalize the current URL', function () {
+		cy.pushHistoryState('/page-1.html?foo=bar&baz=bat#hash');
+		cy.window().then((window) => {
+			expect(this.swup.getCurrentUrl()).to.equal('/page-1.html?baz=bat&foo=bar');
+			expect(this.swup.getCurrentUrl({hash: true})).to.equal('/page-1.html?baz=bat&foo=bar#hash');
 		});
 	});
 });
@@ -537,8 +553,8 @@ describe('Context', function () {
 		});
 		cy.triggerClickOnLink('/page-2.html');
 		cy.window().should((win) => {
-			expect(el).to.be.instanceof(win.HTMLAnchorElement)
-			expect(event).to.be.instanceof(win.MouseEvent)
+			expect(el).to.be.instanceof(win.HTMLAnchorElement);
+			expect(event).to.be.instanceof(win.MouseEvent);
 		});
 	});
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "test": "npm run test:unit && npm run test:e2e",
     "test:ci": "npm run test:unit && npm run test:e2e:ci",
     "test:unit": "vitest run --config ./vitest/vitest.config.ts",
+    "test:unit:watch": "vitest --config ./vitest/vitest.config.ts",
     "test:e2e": "start-server-and-test test:e2e:start 8274 cy:run",
     "test:e2e:ci": "start-server-and-test test:e2e:start 8274 cy:run:record",
     "test:e2e:dev": "start-server-and-test test:e2e:start 8274 cy:open",

--- a/src/Swup.ts
+++ b/src/Swup.ts
@@ -353,8 +353,6 @@ export default class Swup {
 
 	/**
 	 * Utility function to validate and run the global option 'resolveUrl'
-	 * @param {string} url
-	 * @returns {string} the resolved url
 	 */
 	resolveUrl(url: string) {
 		if (typeof this.options.resolveUrl !== 'function') {
@@ -375,9 +373,6 @@ export default class Swup {
 
 	/**
 	 * Compares the resolved version of two paths and returns true if they are the same
-	 * @param {string} url1
-	 * @param {string} url2
-	 * @returns {boolean}
 	 */
 	isSameResolvedUrl(url1: string, url2: string) {
 		return this.resolveUrl(url1) === this.resolveUrl(url2);

--- a/src/__test__/index.test.ts
+++ b/src/__test__/index.test.ts
@@ -57,10 +57,10 @@ describe('ignoreVisit', () => {
 	it('should be called with relative URL', () => {
 		const ignoreVisit = vi.fn(() => true);
 		const swup = new Swup({ ignoreVisit });
-		swup.shouldIgnoreVisit(`${baseUrl}/path/?query#hash`);
+		swup.shouldIgnoreVisit(`${baseUrl}/path?foo=bar#hash`);
 
 		expect(ignoreVisit.mock.calls).toHaveLength(1);
-		expect((ignoreVisit.mock.lastCall as any)[0]).toEqual('/path/?query#hash');
+		expect((ignoreVisit.mock.lastCall as any)[0]).toEqual('/path?foo=bar#hash');
 	});
 
 	it('should have access to element and event params', () => {

--- a/src/helpers/Location.ts
+++ b/src/helpers/Location.ts
@@ -3,14 +3,25 @@
  * or a URL object/string
  *
  */
-
 export class Location extends URL {
 	constructor(url: string, base: string = document.baseURI) {
-		super(url.toString(), base);
+		super(url, base);
+		this.normalize();
 	}
 
 	get url() {
 		return this.pathname + this.search;
+	}
+
+	/**
+	 * Normalizes the location. Invoked every time a Location is created
+	 *
+	 * - sort the searchParams
+	 * - remove the trailing slash from the pathname
+	 */
+	normalize() {
+		this.searchParams.sort();
+		this.pathname = removeTrailingSlash(this.pathname);
 	}
 
 	/**
@@ -32,3 +43,11 @@ export class Location extends URL {
 		return new Location(url);
 	}
 }
+
+export const removeTrailingSlash = (str: string) => {
+	return str.endsWith('/') ? str.slice(0, -1) : str;
+};
+
+export const addTrailingSlash = (str: string) => {
+	return removeTrailingSlash(str) + '/';
+};

--- a/src/helpers/__test__/location.test.ts
+++ b/src/helpers/__test__/location.test.ts
@@ -1,0 +1,24 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import Swup from '../../Swup.js';
+import { Location } from '../Location.js';
+
+const swup = new Swup();
+
+describe('Location', () => {
+	beforeEach(() => {});
+
+	it('should return only the pathname and searchParams', () => {
+		const { url } = Location.fromUrl('https://example.com/test-path?foo=bar');
+		expect(url).toEqual('/test-path?foo=bar');
+	});
+
+	it('should remove the trailing slash from the pathname', () => {
+		const { url } = Location.fromUrl('/test-path/');
+		expect(url).toEqual('/test-path');
+	});
+
+	it('should sort searchParams', () => {
+		const { url } = Location.fromUrl('/test-path?foo=bar&baz=bat');
+		expect(url).toEqual('/test-path?baz=bat&foo=bar');
+	});
+});

--- a/src/helpers/getCurrentUrl.ts
+++ b/src/helpers/getCurrentUrl.ts
@@ -1,3 +1,6 @@
+import { Location } from './Location.js';
+
 export const getCurrentUrl = ({ hash }: { hash?: boolean } = {}): string => {
-	return location.pathname + location.search + (hash ? location.hash : '');
+	const { pathname, search } = window.location;
+	return Location.fromUrl(pathname + search).url + (hash ? window.location.hash : '');
 };

--- a/src/modules/__test__/cache.test.ts
+++ b/src/modules/__test__/cache.test.ts
@@ -127,6 +127,14 @@ describe('Cache', () => {
 
 		expect(cache.size).toBe(2);
 	});
+
+	it('should handle different URLs', () => {
+		cache.set(`${page2.url}?foo=bar`, page2);
+		cache.set(`${page2.url}/?foo=bar&baz=bat`, page2);
+		cache.set(`${page2.url}?baz=bat`, page2);
+
+		expect(cache.size).toBe(3);
+	});
 });
 
 describe('Types', () => {

--- a/src/modules/__test__/cache.test.ts
+++ b/src/modules/__test__/cache.test.ts
@@ -116,6 +116,17 @@ describe('Cache', () => {
 		expect(cache.has(page2.url)).toBe(true);
 		expect(cache.has(page3.url)).toBe(false);
 	});
+
+	it('should handle equal URLs', () => {
+		cache.set(page1.url, page1);
+		cache.set(page1.url + '/', page1);
+
+		cache.set(`${page2.url}?foo=bar&baz=bat`, page2);
+		cache.set(`${page2.url}/?foo=bar&baz=bat`, page2);
+		cache.set(`${page2.url}?baz=bat&foo=bar`, page2);
+
+		expect(cache.size).toBe(2);
+	});
 });
 
 describe('Types', () => {


### PR DESCRIPTION
Closes #690 

**Description**

Normalize URLs to make them comparable: 

- Remove possible trailing slash from `pathname`
- Sort `searchParams`

**Tasks**

- [x] Normalize URLs in the `Location` helper
- [x] Normalize `getCurrentUrl()`
- [ ] Add method to check two locations for equality

**Checks**


- [x] The PR is submitted to the `next` branch, since normalized URLs could break external expectations
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [x] New or updated tests are included
- [ ] The documentation was updated as required
