### PR TITLE
feat: re-export path-to-regexp `match`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@cypress/code-coverage": "^3.10.0",
         "@swup/browserslist-config": "^1.0.0",
         "@swup/prettier-config": "^1.0.0",
-        "cypress": "^12.3.0",
+        "cypress": "^12.16.0",
         "http-server": "^14.1.1",
         "husky": "^8.0.0",
         "istanbul-lib-coverage": "^3.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "license": "MIT",
       "dependencies": {
         "delegate-it": "^6.0.0",
-        "opencollective-postinstall": "^2.0.2"
+        "opencollective-postinstall": "^2.0.2",
+        "path-to-regexp": "^6.2.1"
       },
       "devDependencies": {
         "@babel/preset-typescript": "^7.18.6",
@@ -8373,6 +8374,11 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
+      "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw=="
     },
     "node_modules/path-type": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
     "test:e2e:instrument": "nyc instrument --compact=false dist cypress/fixtures/dist",
     "test:e2e:server": "http-server --silent --port 8274 cypress/fixtures",
     "test:e2e:start": "npm run test:e2e:instrument && npm run test:e2e:server",
-    "cy:run": "cypress run",
-    "cy:run:record": "cypress run --record",
+    "cy:run": "npm run build && cypress run",
+    "cy:run:record": "npm run build && cypress run --record",
     "cy:open": "cypress open",
     "prepare": "husky install"
   },

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@cypress/code-coverage": "^3.10.0",
     "@swup/browserslist-config": "^1.0.0",
     "@swup/prettier-config": "^1.0.0",
-    "cypress": "^12.3.0",
+    "cypress": "^12.16.0",
     "http-server": "^14.1.1",
     "husky": "^8.0.0",
     "istanbul-lib-coverage": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
   ],
   "dependencies": {
     "delegate-it": "^6.0.0",
-    "opencollective-postinstall": "^2.0.2"
+    "opencollective-postinstall": "^2.0.2",
+    "path-to-regexp": "^6.2.1"
   },
   "devDependencies": {
     "@babel/preset-typescript": "^7.18.6",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "test": "npm run test:unit && npm run test:e2e",
     "test:ci": "npm run test:unit && npm run test:e2e:ci",
     "test:unit": "vitest run --config ./vitest/vitest.config.ts",
+    "test:unit:watch": "vitest --config ./vitest/vitest.config.ts",
     "test:e2e": "start-server-and-test test:e2e:start 8274 cy:run",
     "test:e2e:ci": "start-server-and-test test:e2e:start 8274 cy:run:record",
     "test:e2e:dev": "start-server-and-test test:e2e:start 8274 cy:open",

--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
     "test:e2e:instrument": "nyc instrument --compact=false dist cypress/fixtures/dist",
     "test:e2e:server": "http-server --silent --port 8274 cypress/fixtures",
     "test:e2e:start": "npm run test:e2e:instrument && npm run test:e2e:server",
-    "cy:run": "npm run build && cypress run",
-    "cy:run:record": "npm run build && cypress run --record",
+    "cy:run": "cypress run",
+    "cy:run:record": "cypress run --record",
     "cy:open": "cypress open",
     "prepare": "husky install"
   },

--- a/src/Swup.ts
+++ b/src/Swup.ts
@@ -14,8 +14,8 @@ import { Unsubscribe } from './helpers/delegateEvent.js';
 /**
  * re-export matchPath
  */
-// import { matchPath } from './helpers/matchPath.js';
-// export { matchPath };
+import { matchPath } from './helpers/matchPath.js';
+export { matchPath };
 
 import { Cache } from './modules/Cache.js';
 import { Context, createContext } from './modules/Context.js';

--- a/src/Swup.ts
+++ b/src/Swup.ts
@@ -11,6 +11,12 @@ import {
 } from './helpers.js';
 import { Unsubscribe } from './helpers/delegateEvent.js';
 
+/**
+ * re-export matchPath
+ */
+import { matchPath, Path } from './helpers/matchPath.js';
+export { matchPath, Path };
+
 import { Cache } from './modules/Cache.js';
 import { Context, createContext } from './modules/Context.js';
 import { enterPage } from './modules/enterPage.js';

--- a/src/Swup.ts
+++ b/src/Swup.ts
@@ -14,8 +14,8 @@ import { Unsubscribe } from './helpers/delegateEvent.js';
 /**
  * re-export matchPath
  */
-import { matchPath, Path } from './helpers/matchPath.js';
-export { matchPath, Path };
+import { matchPath } from './helpers/matchPath.js';
+export { matchPath };
 
 import { Cache } from './modules/Cache.js';
 import { Context, createContext } from './modules/Context.js';

--- a/src/Swup.ts
+++ b/src/Swup.ts
@@ -14,8 +14,8 @@ import { Unsubscribe } from './helpers/delegateEvent.js';
 /**
  * re-export matchPath
  */
-import { matchPath } from './helpers/matchPath.js';
-export { matchPath };
+// import { matchPath } from './helpers/matchPath.js';
+// export { matchPath };
 
 import { Cache } from './modules/Cache.js';
 import { Context, createContext } from './modules/Context.js';

--- a/src/Swup.ts
+++ b/src/Swup.ts
@@ -11,12 +11,6 @@ import {
 } from './helpers.js';
 import { Unsubscribe } from './helpers/delegateEvent.js';
 
-/**
- * re-export matchPath
- */
-import { matchPath } from './helpers/matchPath.js';
-export { matchPath };
-
 import { Cache } from './modules/Cache.js';
 import { Context, createContext } from './modules/Context.js';
 import { enterPage } from './modules/enterPage.js';

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -8,4 +8,4 @@ export { delegateEvent } from './helpers/delegateEvent.js';
 export { getCurrentUrl } from './helpers/getCurrentUrl.js';
 export { Location } from './helpers/Location.js';
 export { cleanupAnimationClasses } from './helpers/cleanupAnimationClasses.js';
-export { matchPath, Path } from './helpers/matchPath.js';
+export { matchPath } from './helpers/matchPath.js';

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -8,3 +8,4 @@ export { delegateEvent } from './helpers/delegateEvent.js';
 export { getCurrentUrl } from './helpers/getCurrentUrl.js';
 export { Location } from './helpers/Location.js';
 export { cleanupAnimationClasses } from './helpers/cleanupAnimationClasses.js';
+export { matchPath, Path } from './helpers/matchPath.js';

--- a/src/helpers/__test__/matchPath.test.ts
+++ b/src/helpers/__test__/matchPath.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { matchPath } from '../matchPath.js';
+import { matchPath } from '../../index.js';
 import { pathToRegexp } from 'path-to-regexp';
 
 /**

--- a/src/helpers/__test__/matchPath.test.ts
+++ b/src/helpers/__test__/matchPath.test.ts
@@ -1,7 +1,10 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { matchPath } from '../../Swup.js';
-import { pathToRegexp, Key } from 'path-to-regexp';
+import { pathToRegexp } from 'path-to-regexp';
 
+/**
+ * Tests to ensure the match function keeps working as expected
+ */
 describe('matchPath', () => {
 	it('should return false if not matching', () => {
 		const urlMatch = matchPath('/users/:user');

--- a/src/helpers/__test__/matchPath.test.ts
+++ b/src/helpers/__test__/matchPath.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { matchPath } from '../../Swup.js';
+import { matchPath } from '../matchPath.js';
 import { pathToRegexp } from 'path-to-regexp';
 
 /**

--- a/src/helpers/__test__/matchPath.test.ts
+++ b/src/helpers/__test__/matchPath.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from 'vitest';
+import { matchPath } from '../../Swup.js';
+import { pathToRegexp, Key } from 'path-to-regexp';
+
+describe('matchPath', () => {
+	it('should return false if not matching', () => {
+		const urlMatch = matchPath('/users/:user');
+		const match = urlMatch('/posts/');
+		expect(match).toBe(false);
+	});
+
+	it('should return an object if matching', () => {
+		const urlMatch = matchPath('/users/:user');
+		const match = urlMatch('/users/bob');
+		expect(match).toEqual({
+			path: '/users/bob',
+			index: 0,
+			params: { user: 'bob' }
+		});
+	});
+
+	it('should work with primitive strings', () => {
+		const urlMatch = matchPath<{ user: string }>('/users/:user');
+		const match = urlMatch('/users/bob');
+		const params = !match ? false : match.params;
+		expect(params).toEqual({ user: 'bob' });
+	});
+
+	it('should work with an array of paths', () => {
+		const urlMatch = matchPath<{ user: string }>(['/users/', '/users/:user']);
+
+		const { params: withParams } = urlMatch('/users/bob') || {};
+		expect(withParams).toEqual({ user: 'bob' });
+
+		const { params: withoutParams } = urlMatch('/users/') || {};
+		expect(withoutParams).toEqual({});
+	});
+
+	/**
+	 * When passing a regex to `match`, the params in the response are sorted by appearance.
+	 * Only helpful for falsy/truthy detection
+	 */
+	it('should work with regex', () => {
+		const re = pathToRegexp('/users/:user');
+		const urlMatch = matchPath(re);
+		const { params } = urlMatch('/users/bob') || {};
+		expect(params).toEqual({ '0': 'bob' });
+	});
+
+	it('should throw with malformed paths', () => {
+		// prettier-ignore
+		expect(() => matchPath('/\?user=:user')).toThrowError('[swup] Error parsing path');
+	});
+});

--- a/src/helpers/matchPath.ts
+++ b/src/helpers/matchPath.ts
@@ -8,8 +8,6 @@ import type {
 	MatchFunction
 } from 'path-to-regexp';
 
-export { Path };
-
 export const matchPath = <P extends object = object>(
 	path: Path,
 	options?: ParseOptions & TokensToRegexpOptions & RegexpToFunctionOptions

--- a/src/helpers/matchPath.ts
+++ b/src/helpers/matchPath.ts
@@ -1,0 +1,22 @@
+import { match } from 'path-to-regexp';
+
+import type {
+	Path,
+	ParseOptions,
+	TokensToRegexpOptions,
+	RegexpToFunctionOptions,
+	MatchFunction
+} from 'path-to-regexp';
+
+export { Path };
+
+export const matchPath = <P extends object = object>(
+	path: Path,
+	options?: ParseOptions & TokensToRegexpOptions & RegexpToFunctionOptions
+): MatchFunction<P> => {
+	try {
+		return match<P>(path, options);
+	} catch (error) {
+		throw new Error(`[swup] Error parsing path "${path}":\n${error}`);
+	}
+};


### PR DESCRIPTION
Closes #662 

**Description**

Exports a thin wrapper around [path-to-regexp/match](https://github.com/pillarjs/path-to-regexp/tree/master#match)

That function can then be used by plugins or even swup end-users like this:

```js
import Swup, { matchPath } from 'swup';
const urlMatch = matchPath('/users/:user');
const isMatch = urlMatch('/users/bob');
if (isMatch) // do something...
```

**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [x] New or updated tests are included
- [ ] The documentation was updated as required

