### PR TITLE
Allow setting transition class targets

### DIFF
--- a/cypress/e2e/main.spec.js
+++ b/cypress/e2e/main.spec.js
@@ -21,11 +21,13 @@ describe('Request', function () {
 		const expected = this.swup.options.requestHeaders;
 		cy.intercept('GET', '/page-3.html').as('request');
 		cy.triggerClickOnLink('/page-3.html');
-		cy.wait('@request').its('request.headers').then((headers) => {
-			Object.entries(expected).forEach(([header, value]) => {
-				cy.wrap(headers).its(header.toLowerCase()).should('eq', value);
+		cy.wait('@request')
+			.its('request.headers')
+			.then((headers) => {
+				Object.entries(expected).forEach(([header, value]) => {
+					cy.wrap(headers).its(header.toLowerCase()).should('eq', value);
+				});
 			});
-		});
 	});
 
 	it('should force-load on server error', function () {
@@ -58,7 +60,10 @@ describe('Fetch', function () {
 		});
 
 		this.swup.hooks.before('loadPage', (context, args) => {
-			args.page = { url: '/page-3.html', html: '<html><body><div id="swup"><h1>Page 3</h1></div></body></html>' };
+			args.page = {
+				url: '/page-3.html',
+				html: '<html><body><div id="swup"><h1>Page 3</h1></div></body></html>'
+			};
 		});
 		this.swup.loadPage('/page-2.html');
 
@@ -119,7 +124,7 @@ describe('Markup', function () {
 	});
 
 	it('should add transition classes to containers', function () {
-		this.swup.options.transitionRoot = "containers";
+		this.swup.options.animationScope = 'containers';
 		cy.triggerClickOnLink('/page-2.html');
 		cy.shouldHaveTransitionLeaveClasses('#swup');
 		cy.shouldNotHaveTransitionClasses('html'); // making sure
@@ -204,17 +209,20 @@ describe('Transition timing', function () {
 
 	it('should warn about missing transition timing', function () {
 		cy.visit('/transition-none.html', {
-			onBeforeLoad: (win) =>  cy.stub(win.console, 'warn').as('consoleWarn')
+			onBeforeLoad: (win) => cy.stub(win.console, 'warn').as('consoleWarn')
 		});
 		cy.triggerClickOnLink('/page-2.html');
 		cy.shouldBeAtPage('/page-2.html');
 		cy.shouldHaveH1('Page 2');
-		cy.get('@consoleWarn').should('be.calledOnceWith', '[swup] No CSS animation duration defined on elements matching `[class*=\"transition-\"]`');
+		cy.get('@consoleWarn').should(
+			'be.calledOnceWith',
+			'[swup] No CSS animation duration defined on elements matching `[class*="transition-"]`'
+		);
 	});
 
 	it('should not warn about partial transition timing', function () {
 		cy.visit('/transition-partial.html', {
-			onBeforeLoad: (win) =>  cy.stub(win.console, 'warn').as('consoleWarn')
+			onBeforeLoad: (win) => cy.stub(win.console, 'warn').as('consoleWarn')
 		});
 		cy.triggerClickOnLink('/page-2.html');
 		cy.shouldBeAtPage('/page-2.html');
@@ -598,8 +606,8 @@ describe('Context', function () {
 		});
 		cy.triggerClickOnLink('/page-2.html');
 		cy.window().should((win) => {
-			expect(el).to.be.instanceof(win.HTMLAnchorElement)
-			expect(event).to.be.instanceof(win.MouseEvent)
+			expect(el).to.be.instanceof(win.HTMLAnchorElement);
+			expect(event).to.be.instanceof(win.MouseEvent);
 		});
 	});
 

--- a/cypress/e2e/main.spec.js
+++ b/cypress/e2e/main.spec.js
@@ -110,11 +110,21 @@ describe('Markup', function () {
 		cy.shouldHaveH1('Page 1');
 	});
 
-	it('should process transition classes', function () {
+	it('should add transition classes to html', function () {
 		cy.triggerClickOnLink('/page-2.html');
-		cy.shouldHaveTransitionLeaveClasses();
-		cy.shouldHaveTransitionEnterClasses();
-		cy.shouldNotHaveTransitionClasses();
+		cy.shouldHaveTransitionLeaveClasses('html');
+		cy.shouldNotHaveTransitionClasses('#swup'); // making sure
+		cy.shouldHaveTransitionEnterClasses('html');
+		cy.shouldNotHaveTransitionClasses('html');
+	});
+
+	it('should add transition classes to containers', function () {
+		this.swup.options.transitionRoot = false;
+		cy.triggerClickOnLink('/page-2.html');
+		cy.shouldHaveTransitionLeaveClasses('#swup');
+		cy.shouldNotHaveTransitionClasses('html'); // making sure
+		cy.shouldHaveTransitionEnterClasses('#swup');
+		cy.shouldNotHaveTransitionClasses('#swup');
 	});
 
 	it('should remove swup class from html tag', function () {

--- a/cypress/e2e/main.spec.js
+++ b/cypress/e2e/main.spec.js
@@ -119,7 +119,7 @@ describe('Markup', function () {
 	});
 
 	it('should add transition classes to containers', function () {
-		this.swup.options.transitionRoot = false;
+		this.swup.options.transitionRoot = "containers";
 		cy.triggerClickOnLink('/page-2.html');
 		cy.shouldHaveTransitionLeaveClasses('#swup');
 		cy.shouldNotHaveTransitionClasses('html'); // making sure

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -72,21 +72,21 @@ Cypress.Commands.add('shouldHaveH1', (str) => {
 	cy.get('h1').should('contain', str);
 });
 
-Cypress.Commands.add('shouldHaveTransitionLeaveClasses', () => {
-	cy.get('html').should('have.class', 'is-changing');
-	cy.get('html').should('have.class', 'is-leaving');
+Cypress.Commands.add('shouldHaveTransitionLeaveClasses', (selector = 'html') => {
+	cy.get(selector).should('have.class', 'is-changing');
+	cy.get(selector).should('have.class', 'is-leaving');
 });
 
-Cypress.Commands.add('shouldHaveTransitionEnterClasses', () => {
-	cy.get('html').should('have.class', 'is-changing');
-	cy.get('html').should('have.class', 'is-rendering');
-	cy.get('html').should('not.have.class', 'is-leaving');
+Cypress.Commands.add('shouldHaveTransitionEnterClasses', (selector = 'html') => {
+	cy.get(selector).should('have.class', 'is-changing');
+	cy.get(selector).should('have.class', 'is-rendering');
+	cy.get(selector).should('not.have.class', 'is-leaving');
 });
 
-Cypress.Commands.add('shouldNotHaveTransitionClasses', () => {
-	cy.get('html').should('not.have.class', 'is-changing');
-	cy.get('html').should('not.have.class', 'is-rendering');
-	cy.get('html').should('not.have.class', 'is-leaving');
+Cypress.Commands.add('shouldNotHaveTransitionClasses', (selector = 'html') => {
+	cy.get(selector).should('not.have.class', 'is-changing');
+	cy.get(selector).should('not.have.class', 'is-rendering');
+	cy.get(selector).should('not.have.class', 'is-leaving');
 });
 
 Cypress.Commands.add('shouldHaveElementInViewport', (element) => {

--- a/src/Swup.ts
+++ b/src/Swup.ts
@@ -41,7 +41,7 @@ export type Options = {
 	skipPopStateHandling: (event: any) => boolean;
 	ignoreVisit: (url: string, { el, event }: { el?: Element; event?: Event }) => boolean;
 	resolveUrl: (url: string) => string;
-	transitionRoot: boolean;
+	transitionRoot: 'html' | 'containers';
 };
 
 export default class Swup {
@@ -94,7 +94,7 @@ export default class Swup {
 			Accept: 'text/html, application/xhtml+xml'
 		},
 		skipPopStateHandling: (event) => event.state?.source !== 'swup',
-		transitionRoot: true
+		transitionRoot: 'html'
 	};
 
 	constructor(options: Partial<Options> = {}) {

--- a/src/Swup.ts
+++ b/src/Swup.ts
@@ -33,6 +33,7 @@ type DelegatedListeners = {
 export type Options = {
 	animateHistoryBrowsing: boolean;
 	animationSelector: string | false;
+	animationScope: 'html' | 'containers';
 	linkSelector: string;
 	cache: boolean;
 	containers: string[];
@@ -41,7 +42,6 @@ export type Options = {
 	skipPopStateHandling: (event: any) => boolean;
 	ignoreVisit: (url: string, { el, event }: { el?: Element; event?: Event }) => boolean;
 	resolveUrl: (url: string) => string;
-	transitionRoot: 'html' | 'containers';
 };
 
 export default class Swup {
@@ -83,6 +83,7 @@ export default class Swup {
 	defaults: Options = {
 		animateHistoryBrowsing: false,
 		animationSelector: '[class*="transition-"]',
+		animationScope: 'html',
 		cache: true,
 		containers: ['#swup'],
 		ignoreVisit: (url, { el, event } = {}) => !!el?.closest('[data-no-swup]'),
@@ -93,8 +94,7 @@ export default class Swup {
 			'X-Requested-With': 'swup',
 			Accept: 'text/html, application/xhtml+xml'
 		},
-		skipPopStateHandling: (event) => event.state?.source !== 'swup',
-		transitionRoot: 'html'
+		skipPopStateHandling: (event) => event.state?.source !== 'swup'
 	};
 
 	constructor(options: Partial<Options> = {}) {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -7,5 +7,4 @@ export { updateHistoryRecord } from './helpers/updateHistoryRecord.js';
 export { delegateEvent } from './helpers/delegateEvent.js';
 export { getCurrentUrl } from './helpers/getCurrentUrl.js';
 export { Location } from './helpers/Location.js';
-export { cleanupAnimationClasses } from './helpers/cleanupAnimationClasses.js';
 export { matchPath } from './helpers/matchPath.js';

--- a/src/helpers/cleanupAnimationClasses.ts
+++ b/src/helpers/cleanupAnimationClasses.ts
@@ -1,8 +1,0 @@
-export const isSwupClass = (className: string): boolean =>
-	/^to-/.test(className) || ['is-changing', 'is-rendering', 'is-popstate'].includes(className);
-
-export const cleanupAnimationClasses = (): void => {
-	const htmlClasses = document.documentElement.className.split(' ');
-	const removeClasses = htmlClasses.filter(isSwupClass);
-	document.documentElement.classList.remove(...removeClasses);
-};

--- a/src/modules/Classes.ts
+++ b/src/modules/Classes.ts
@@ -1,0 +1,39 @@
+import Swup from '../Swup.js';
+
+export class Classes {
+	public swup: Swup;
+
+	swupClasses = ['to-', 'is-changing', 'is-rendering', 'is-popstate'];
+
+	constructor(swup: Swup) {
+		this.swup = swup;
+	}
+
+	get selectors(): string[] {
+		const { targets } = this.swup.context.transition;
+		return targets || ['html'];
+	}
+
+	get targets(): Element[] {
+		return Array.from(document.querySelectorAll(this.selectors.join(',')));
+	}
+
+	public add(...classes: string[]): void {
+		this.targets.forEach((target) => target.classList.add(...classes));
+	}
+
+	public remove(...classes: string[]): void {
+		this.targets.forEach((target) => target.classList.remove(...classes));
+	}
+
+	public clear(): void {
+		this.targets.forEach((target) => {
+			const remove = target.className.split(' ').filter((c) => this.isSwupClass(c));
+			target.classList.remove(...remove);
+		});
+	}
+
+	private isSwupClass(className: string): boolean {
+		return this.swupClasses.some((c) => className.startsWith(c));
+	}
+}

--- a/src/modules/Classes.ts
+++ b/src/modules/Classes.ts
@@ -3,7 +3,7 @@ import Swup from '../Swup.js';
 export class Classes {
 	public swup: Swup;
 
-	swupClasses = ['to-', 'is-changing', 'is-rendering', 'is-popstate'];
+	swupClasses = ['to-', 'is-changing', 'is-rendering', 'is-popstate', 'is-animating'];
 
 	constructor(swup: Swup) {
 		this.swup = swup;

--- a/src/modules/Classes.ts
+++ b/src/modules/Classes.ts
@@ -15,7 +15,14 @@ export class Classes {
 	}
 
 	get targets(): Element[] {
-		return Array.from(document.querySelectorAll(this.selectors.join(',')));
+		const elements: Element[] = [];
+
+		this.selectors.forEach((selector) => {
+			const el = document.querySelector(selector);
+			if (el) elements.push(el as Element);
+		});
+
+		return elements;
 	}
 
 	public add(...classes: string[]): void {

--- a/src/modules/Context.ts
+++ b/src/modules/Context.ts
@@ -76,7 +76,7 @@ export function createContext(
 			animate,
 			name: transition,
 			targets:
-				this.options.transitionRoot === 'containers' ? this.options.containers : ['html']
+				this.options.animationScope === 'containers' ? this.options.containers : ['html']
 		},
 		trigger: {
 			el,

--- a/src/modules/Context.ts
+++ b/src/modules/Context.ts
@@ -59,7 +59,6 @@ export function createContext(
 		from = this.currentPageUrl,
 		hash: target,
 		containers = this.options.containers,
-		targets,
 		animate = true,
 		transition,
 		el,
@@ -76,7 +75,8 @@ export function createContext(
 		transition: {
 			animate,
 			name: transition,
-			targets
+			targets:
+				this.options.transitionRoot === 'containers' ? this.options.containers : ['html']
 		},
 		trigger: {
 			el,

--- a/src/modules/Context.ts
+++ b/src/modules/Context.ts
@@ -18,6 +18,7 @@ export interface PageContext {
 export interface TransitionContext {
 	animate: boolean;
 	name?: string;
+	targets?: string[];
 }
 
 export interface ScrollContext {
@@ -43,6 +44,7 @@ export interface ContextInitOptions {
 	containers?: Options['containers'];
 	animate?: boolean;
 	transition?: string;
+	targets?: string[];
 	el?: Element;
 	event?: Event;
 	popstate?: boolean;
@@ -57,6 +59,7 @@ export function createContext(
 		from = this.currentPageUrl,
 		hash: target,
 		containers = this.options.containers,
+		targets,
 		animate = true,
 		transition,
 		el,
@@ -72,7 +75,8 @@ export function createContext(
 		containers,
 		transition: {
 			animate,
-			name: transition
+			name: transition,
+			targets
 		},
 		trigger: {
 			el,

--- a/src/modules/enterPage.ts
+++ b/src/modules/enterPage.ts
@@ -21,6 +21,4 @@ export const enterPage = async function (this: Swup) {
 	await this.hooks.trigger('transitionEnd', undefined, () => {
 		this.classes.clear();
 	});
-
-	this.context = this.createContext({ to: undefined });
 };

--- a/src/modules/enterPage.ts
+++ b/src/modules/enterPage.ts
@@ -12,14 +12,14 @@ export const enterPage = async function (this: Swup) {
 		);
 		await nextTick();
 		await this.hooks.trigger('animationInStart', undefined, () => {
-			document.documentElement.classList.remove('is-animating');
+			this.classes.remove('is-animating');
 		});
 		await animation;
 		await this.hooks.trigger('animationInDone');
 	}
 
 	await this.hooks.trigger('transitionEnd', undefined, () => {
-		this.cleanupAnimationClasses();
+		this.classes.clear();
 	});
 
 	this.context = this.createContext({ to: undefined });

--- a/src/modules/leavePage.ts
+++ b/src/modules/leavePage.ts
@@ -8,12 +8,12 @@ export const leavePage = async function (this: Swup) {
 	}
 
 	await this.hooks.trigger('animationOutStart', undefined, () => {
-		document.documentElement.classList.add('is-changing', 'is-leaving', 'is-animating');
+		this.classes.add('is-changing', 'is-leaving', 'is-animating');
 		if (this.context.history.popstate) {
-			document.documentElement.classList.add('is-popstate');
+			this.classes.add('is-popstate');
 		}
 		if (this.context.transition.name) {
-			document.documentElement.classList.add(`to-${classify(this.context.transition.name)}`);
+			this.classes.add(`to-${classify(this.context.transition.name)}`);
 		}
 	});
 

--- a/src/modules/loadPage.ts
+++ b/src/modules/loadPage.ts
@@ -48,6 +48,7 @@ export async function performPageLoad(
 	}
 
 	if (!this.context.transition.animate) {
+		// Why is is-animating not cleared in `clearAnimationClasses`?
 		this.classes.remove('is-animating');
 		this.classes.clear();
 	} else if (transition) {
@@ -56,6 +57,10 @@ export async function performPageLoad(
 
 	try {
 		await this.hooks.trigger('transitionStart');
+		if (!this.options.transitionRoot) {
+			this.context.transition.targets = this.context.containers;
+		}
+
 		const animationPromise = this.leavePage();
 		const pagePromise = this.hooks.trigger(
 			'loadPage',

--- a/src/modules/loadPage.ts
+++ b/src/modules/loadPage.ts
@@ -47,6 +47,12 @@ export async function performPageLoad(
 		this.context.history.action = historyAction;
 	}
 
+	// Determine where to add transition classes: html or containers
+	if (!this.options.transitionRoot) {
+		this.context.transition.targets = this.context.containers;
+	}
+
+	// Clean up old transition classes and set custom transition name
 	if (!this.context.transition.animate) {
 		// Why is is-animating not cleared in `clearAnimationClasses`?
 		this.classes.remove('is-animating');
@@ -57,10 +63,8 @@ export async function performPageLoad(
 
 	try {
 		await this.hooks.trigger('transitionStart');
-		if (!this.options.transitionRoot) {
-			this.context.transition.targets = this.context.containers;
-		}
 
+		// Create Promises for animation and page fetch
 		const animationPromise = this.leavePage();
 		const pagePromise = this.hooks.trigger(
 			'loadPage',
@@ -68,7 +72,7 @@ export async function performPageLoad(
 			async (context, { url, options, page }) => await (page || this.fetchPage(url, options))
 		);
 
-		// create history record if this is not a popstate call (with or without anchor)
+		// Create history record if this is not a popstate call (with or without anchor)
 		if (!this.context.history.popstate) {
 			const newUrl = url + (this.context.scroll.target || '');
 			if (this.context.history.action === 'replace') {
@@ -80,7 +84,7 @@ export async function performPageLoad(
 
 		this.currentPageUrl = getCurrentUrl();
 
-		// when everything is ready, render the page
+		// When everything is ready, render the page
 		const [page] = await Promise.all([pagePromise, animationPromise]);
 		this.renderPage(requestedUrl, page);
 	} catch (error: unknown) {

--- a/src/modules/loadPage.ts
+++ b/src/modules/loadPage.ts
@@ -49,8 +49,6 @@ export async function performPageLoad(
 
 	// Clean up old transition classes and set custom transition name
 	if (!this.context.transition.animate) {
-		// Why is is-animating not cleared in `clearAnimationClasses`?
-		this.classes.remove('is-animating');
 		this.classes.clear();
 	} else if (transition) {
 		this.context.transition.name = transition;

--- a/src/modules/loadPage.ts
+++ b/src/modules/loadPage.ts
@@ -48,8 +48,8 @@ export async function performPageLoad(
 	}
 
 	if (!this.context.transition.animate) {
-		document.documentElement.classList.remove('is-animating');
-		this.cleanupAnimationClasses();
+		this.classes.remove('is-animating');
+		this.classes.clear();
 	} else if (transition) {
 		this.context.transition.name = transition;
 	}

--- a/src/modules/loadPage.ts
+++ b/src/modules/loadPage.ts
@@ -47,11 +47,6 @@ export async function performPageLoad(
 		this.context.history.action = historyAction;
 	}
 
-	// Determine where to add transition classes: html or containers
-	if (!this.options.transitionRoot) {
-		this.context.transition.targets = this.context.containers;
-	}
-
 	// Clean up old transition classes and set custom transition name
 	if (!this.context.transition.animate) {
 		// Why is is-animating not cleared in `clearAnimationClasses`?

--- a/src/modules/renderPage.ts
+++ b/src/modules/renderPage.ts
@@ -1,4 +1,4 @@
-import { updateHistoryRecord, getCurrentUrl } from '../helpers.js';
+import { updateHistoryRecord, getCurrentUrl, classify } from '../helpers.js';
 import Swup from '../Swup.js';
 import { PageData } from './fetchPage.js';
 
@@ -23,6 +23,10 @@ export const renderPage = async function (this: Swup, requestedUrl: string, page
 	if (this.context.transition.animate) {
 		this.classes.add('is-rendering');
 	}
+	console.log(this.context.from);
+	// if (this.context.scroll.reset) {
+	// 	console.log(this.context.to!);
+	// }
 
 	// replace content: allow handlers and plugins to overwrite paga data and containers
 	await this.hooks.trigger(
@@ -33,6 +37,9 @@ export const renderPage = async function (this: Swup, requestedUrl: string, page
 			if (this.context.transition.animate) {
 				// Make sure to add these classes to new containers as well
 				this.classes.add('is-animating', 'is-changing', 'is-rendering');
+				if (this.context.transition.name) {
+					this.classes.add(`to-${classify(this.context.transition.name)}`);
+				}
 			}
 		}
 	);

--- a/src/modules/renderPage.ts
+++ b/src/modules/renderPage.ts
@@ -5,7 +5,7 @@ import { PageData } from './fetchPage.js';
 export const renderPage = async function (this: Swup, requestedUrl: string, page: PageData) {
 	const { url } = page;
 
-	document.documentElement.classList.remove('is-leaving');
+	this.classes.remove('is-leaving');
 
 	// do nothing if another page was requested in the meantime
 	if (!this.isSameResolvedUrl(getCurrentUrl(), requestedUrl)) {
@@ -21,7 +21,7 @@ export const renderPage = async function (this: Swup, requestedUrl: string, page
 
 	// only add for page loads with transitions
 	if (this.context.transition.animate) {
-		document.documentElement.classList.add('is-rendering');
+		this.classes.add('is-rendering');
 	}
 
 	// replace content: allow handlers and plugins to overwrite paga data and containers

--- a/src/modules/renderPage.ts
+++ b/src/modules/renderPage.ts
@@ -30,6 +30,10 @@ export const renderPage = async function (this: Swup, requestedUrl: string, page
 		{ page, containers: this.context.containers },
 		(context, { page, containers }) => {
 			this.replaceContent(page, { containers });
+			if (this.context.transition.animate) {
+				// Make sure to add these classes to new containers as well
+				this.classes.add('is-animating', 'is-changing', 'is-rendering');
+			}
 		}
 	);
 

--- a/src/modules/renderPage.ts
+++ b/src/modules/renderPage.ts
@@ -23,10 +23,10 @@ export const renderPage = async function (this: Swup, requestedUrl: string, page
 	if (this.context.transition.animate) {
 		this.classes.add('is-rendering');
 	}
-	console.log(this.context.from);
-	// if (this.context.scroll.reset) {
-	// 	console.log(this.context.to!);
-	// }
+	// console.log(this.context.from);
+	if (this.context.scroll.reset) {
+		console.log(this.context.to!);
+	}
 
 	// replace content: allow handlers and plugins to overwrite paga data and containers
 	await this.hooks.trigger(
@@ -69,5 +69,10 @@ export const renderPage = async function (this: Swup, requestedUrl: string, page
 	}
 
 	// Perform in transition
-	this.enterPage();
+	await this.enterPage();
+
+	// If we ever decide that we want to reset the context after each visit
+	// if (this.context.to && this.isSameResolvedUrl(this.context.to.url, requestedUrl)) {
+	// 	this.createContext({ to: undefined });
+	// }
 };


### PR DESCRIPTION
Allow `html` (default) or the containers themselves to receive `is-animating`, `is-leaving`, etc.

This lead to a new option `animationScope: 'html' | 'containers'` 🛸