### PR TITLE
Add `animationSelector` to context

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "swup",
-  "version": "4.0.0-rc.15",
+  "version": "4.0.0-rc.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "swup",
-      "version": "4.0.0-rc.15",
+      "version": "4.0.0-rc.18",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/src/modules/Context.ts
+++ b/src/modules/Context.ts
@@ -19,6 +19,7 @@ export interface TransitionContext {
 	animate: boolean;
 	name?: string;
 	scope: 'html' | 'containers';
+	selector: Options['animationSelector'];
 }
 
 export interface ScrollContext {
@@ -77,7 +78,8 @@ export function createContext(
 		transition: {
 			animate,
 			name: transition,
-			scope
+			scope,
+			selector: this.options.animationSelector
 		},
 		trigger: {
 			el,

--- a/src/modules/Context.ts
+++ b/src/modules/Context.ts
@@ -42,8 +42,6 @@ export interface ContextInitOptions {
 	to: string | undefined;
 	from?: string;
 	hash?: string;
-	containers?: Options['containers'];
-	scope?: Options['animationScope'];
 	animate?: boolean;
 	transition?: string;
 	targets?: string[];
@@ -60,8 +58,6 @@ export function createContext(
 		to,
 		from = this.currentPageUrl,
 		hash: target,
-		containers = this.options.containers,
-		scope = this.options.animationScope,
 		animate = true,
 		transition,
 		el,
@@ -74,11 +70,11 @@ export function createContext(
 	return {
 		from: { url: from },
 		to: to !== undefined ? { url: to } : undefined,
-		containers,
+		containers: this.options.containers,
 		transition: {
 			animate,
 			name: transition,
-			scope,
+			scope: this.options.animationScope,
 			selector: this.options.animationSelector
 		},
 		trigger: {

--- a/src/modules/Hooks.ts
+++ b/src/modules/Hooks.ts
@@ -12,7 +12,7 @@ export interface HookDefinitions {
 	animationOutDone: undefined;
 	animationOutStart: undefined;
 	animationSkipped: undefined;
-	awaitAnimation: { selector: Options['animationSelector']; direction: AnimationDirection };
+	awaitAnimation: { direction: AnimationDirection };
 	cacheCleared: undefined;
 	clickLink: { el: HTMLAnchorElement; event: DelegateEvent<MouseEvent> };
 	disabled: undefined;

--- a/src/modules/enterPage.ts
+++ b/src/modules/enterPage.ts
@@ -5,9 +5,11 @@ export const enterPage = async function (this: Swup) {
 	if (this.context.transition.animate) {
 		const animation = this.hooks.trigger(
 			'awaitAnimation',
-			{ selector: this.options.animationSelector, direction: 'in' },
-			async (context, { selector, direction }) => {
-				await Promise.all(this.getAnimationPromises({ selector, direction }));
+			{ direction: 'in' },
+			async (context, { direction }) => {
+				await Promise.all(
+					this.getAnimationPromises({ selector: context.transition.selector, direction })
+				);
 			}
 		);
 		await nextTick();

--- a/src/modules/leavePage.ts
+++ b/src/modules/leavePage.ts
@@ -19,9 +19,11 @@ export const leavePage = async function (this: Swup) {
 
 	await this.hooks.trigger(
 		'awaitAnimation',
-		{ selector: this.options.animationSelector, direction: 'out' },
-		async (context, { selector, direction }) => {
-			await Promise.all(this.getAnimationPromises({ selector, direction }));
+		{ direction: 'out' },
+		async (context, { direction }) => {
+			await Promise.all(
+				this.getAnimationPromises({ selector: context.transition.selector, direction })
+			);
 		}
 	);
 


### PR DESCRIPTION
Closes #711 

**Description**

Add `context.transition.selector`, populated from the swup option `animationSelector`.

**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `next` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [ ] New or updated tests are included
- [ ] The documentation was updated as required
