### PR TITLE
Allow awaiting page load before starting animations

### DIFF
--- a/src/modules/Context.ts
+++ b/src/modules/Context.ts
@@ -17,6 +17,7 @@ export interface PageContext {
 
 export interface TransitionContext {
 	animate: boolean;
+	wait: boolean;
 	name?: string;
 	scope: 'html' | 'containers';
 	selector: Options['animationSelector'];
@@ -73,6 +74,7 @@ export function createContext(
 		containers: this.options.containers,
 		transition: {
 			animate,
+			wait: false,
 			name: transition,
 			scope: this.options.animationScope,
 			selector: this.options.animationSelector

--- a/src/modules/loadPage.ts
+++ b/src/modules/loadPage.ts
@@ -1,6 +1,6 @@
 import Swup from '../Swup.js';
 import { createHistoryRecord, updateHistoryRecord, getCurrentUrl, Location } from '../helpers.js';
-import { FetchOptions, PageData } from '../modules/fetchPage.js';
+import { FetchOptions } from '../modules/fetchPage.js';
 import { ContextInitOptions, PageContext } from './Context.js';
 
 export type HistoryAction = 'push' | 'replace';


### PR DESCRIPTION
**Description**

- Add a new flag to the context object: `transition.wait`
- Determines whether to wait for the next page to finish loading before starting the out-animation
- Defaults to `false` and the current behavior: start page load and out-animation at the same time
- Use case: in the upcoming parallel plugin, we need to wait for the page to load before starting both in- and out-animation at the same time

**Checks**

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [ ] New or updated tests are included
- [ ] The documentation was updated as required
