### PR TITLE
Rename animation context

### DIFF
--- a/cypress/e2e/main.spec.js
+++ b/cypress/e2e/main.spec.js
@@ -660,7 +660,7 @@ describe('Context', function () {
 
 	it('should allow disabling animations', function () {
 		this.swup.hooks.before('transitionStart', (context) => {
-			context.transition.animate = false;
+			context.animation.animate = false;
 		});
 		cy.transitionWithExpectedDuration(0, '/page-2.html');
 	});

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import type {
 	Context,
 	FromContext,
 	ToContext,
-	TransitionContext,
+	AnimationContext,
 	ScrollContext,
 	HistoryContext
 } from './modules/Context.js';
@@ -24,7 +24,7 @@ export type {
 	Context,
 	FromContext,
 	ToContext,
-	TransitionContext,
+	AnimationContext,
 	ScrollContext,
 	HistoryContext,
 	HookDefinitions,

--- a/src/modules/Classes.ts
+++ b/src/modules/Classes.ts
@@ -11,7 +11,7 @@ export class Classes {
 	}
 
 	get selectors(): string[] {
-		const { scope } = this.swup.context.transition;
+		const { scope } = this.swup.context.animation;
 		return scope === 'containers' ? this.swup.context.containers : ['html'];
 	}
 

--- a/src/modules/Context.ts
+++ b/src/modules/Context.ts
@@ -5,7 +5,7 @@ export interface Context<TEvent = Event> {
 	from: FromContext;
 	to: ToContext;
 	containers: Options['containers'];
-	transition: TransitionContext;
+	animation: AnimationContext;
 	trigger: TriggerContext<TEvent>;
 	history: HistoryContext;
 	scroll: ScrollContext;
@@ -20,7 +20,7 @@ export interface ToContext {
 	html?: string;
 }
 
-export interface TransitionContext {
+export interface AnimationContext {
 	animate: boolean;
 	wait: boolean;
 	name?: string;
@@ -77,7 +77,7 @@ export function createContext(
 		from: { url: from },
 		to: { url: to },
 		containers: this.options.containers,
-		transition: {
+		animation: {
 			animate,
 			wait: false,
 			name: transition,

--- a/src/modules/enterPage.ts
+++ b/src/modules/enterPage.ts
@@ -2,13 +2,13 @@ import Swup from '../Swup.js';
 import { nextTick } from '../utils.js';
 
 export const enterPage = async function (this: Swup) {
-	if (this.context.transition.animate) {
+	if (this.context.animation.animate) {
 		const animation = this.hooks.trigger(
 			'awaitAnimation',
 			{ direction: 'in' },
 			async (context, { direction }) => {
 				await Promise.all(
-					this.getAnimationPromises({ selector: context.transition.selector, direction })
+					this.getAnimationPromises({ selector: context.animation.selector, direction })
 				);
 			}
 		);

--- a/src/modules/leavePage.ts
+++ b/src/modules/leavePage.ts
@@ -2,7 +2,7 @@ import Swup from '../Swup.js';
 import { classify } from '../helpers.js';
 
 export const leavePage = async function (this: Swup) {
-	if (!this.context.transition.animate) {
+	if (!this.context.animation.animate) {
 		await this.hooks.trigger('animationSkipped');
 		return;
 	}
@@ -12,8 +12,8 @@ export const leavePage = async function (this: Swup) {
 		if (this.context.history.popstate) {
 			this.classes.add('is-popstate');
 		}
-		if (this.context.transition.name) {
-			this.classes.add(`to-${classify(this.context.transition.name)}`);
+		if (this.context.animation.name) {
+			this.classes.add(`to-${classify(this.context.animation.name)}`);
 		}
 	});
 
@@ -22,7 +22,7 @@ export const leavePage = async function (this: Swup) {
 		{ direction: 'out' },
 		async (context, { direction }) => {
 			await Promise.all(
-				this.getAnimationPromises({ selector: context.transition.selector, direction })
+				this.getAnimationPromises({ selector: context.animation.selector, direction })
 			);
 		}
 	);

--- a/src/modules/loadPage.ts
+++ b/src/modules/loadPage.ts
@@ -41,17 +41,17 @@ export async function performPageLoad(
 	options.referrer = options.referrer || this.currentPageUrl;
 
 	if (animate === false) {
-		this.context.transition.animate = false;
+		this.context.animation.animate = false;
 	}
 	if (historyAction) {
 		this.context.history.action = historyAction;
 	}
 
 	// Clean up old transition classes and set custom transition name
-	if (!this.context.transition.animate) {
+	if (!this.context.animation.animate) {
 		this.classes.clear();
 	} else if (transition) {
-		this.context.transition.name = transition;
+		this.context.animation.name = transition;
 	}
 
 	try {
@@ -77,7 +77,7 @@ export async function performPageLoad(
 		this.currentPageUrl = getCurrentUrl();
 
 		// Wait for page before starting to animate out?
-		if (this.context.transition.wait) {
+		if (this.context.animation.wait) {
 			const { html } = await pagePromise;
 			this.context.to.html = html;
 		}

--- a/src/modules/renderPage.ts
+++ b/src/modules/renderPage.ts
@@ -20,7 +20,7 @@ export const renderPage = async function (this: Swup, requestedUrl: string, page
 	}
 
 	// only add for page loads with transitions
-	if (this.context.transition.animate) {
+	if (this.context.animation.animate) {
 		this.classes.add('is-rendering');
 	}
 
@@ -36,11 +36,11 @@ export const renderPage = async function (this: Swup, requestedUrl: string, page
 			if (!success) {
 				throw new Error('[swup] Container mismatch, aborting');
 			}
-			if (this.context.transition.animate) {
+			if (this.context.animation.animate) {
 				// Make sure to add these classes to new containers as well
 				this.classes.add('is-animating', 'is-changing', 'is-rendering');
-				if (this.context.transition.name) {
-					this.classes.add(`to-${classify(this.context.transition.name)}`);
+				if (this.context.animation.name) {
+					this.classes.add(`to-${classify(this.context.animation.name)}`);
 				}
 			}
 		}


### PR DESCRIPTION
**Description**

- Rename `context.transition` to `context.animation` to better communicate intent
- This is a bit confusing as we use transition and animation almost completely interchangeably, e.g. in `data-swup-transition`, so it might not make things much clearer anyway?

**Checks**

- [x] The PR is submitted to the `next` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [x] New or updated tests are included
- [ ] The documentation was updated as required

**Additional information**

Closes #715 