### PR TITLE
Make API surface in `replaceContent` clearer

### DIFF
--- a/cypress/e2e/main.spec.js
+++ b/cypress/e2e/main.spec.js
@@ -682,7 +682,7 @@ describe('Containers', function () {
 	});
 
 	it('should be customizable from hook context', function () {
-		this.swup.hooks.before('replaceContent', (context, args) => {
+		this.swup.hooks.before('replaceContent', (context) => {
 			context.containers = ['#main'];
 		});
 		this.swup.loadPage('/containers-2.html', { animate: false });

--- a/cypress/e2e/main.spec.js
+++ b/cypress/e2e/main.spec.js
@@ -681,9 +681,9 @@ describe('Containers', function () {
 		cy.get('h2').should('contain', 'Heading 2');
 	});
 
-	it('should be customizable from hook params', function () {
+	it('should be customizable from hook context', function () {
 		this.swup.hooks.before('replaceContent', (context, args) => {
-			args.containers = ['#main'];
+			context.containers = ['#main'];
 		});
 		this.swup.loadPage('/containers-2.html', { animate: false });
 		cy.get('h1').should('contain', 'Containers 2');

--- a/src/modules/Hooks.ts
+++ b/src/modules/Hooks.ts
@@ -24,7 +24,7 @@ export interface HookDefinitions {
 	pageLoaded: { page: PageData; cache?: boolean };
 	pageView: { url: string; title: string };
 	popState: { event: PopStateEvent };
-	replaceContent: { page: PageData; containers: Options['containers'] };
+	replaceContent: { page: PageData };
 	samePage: undefined;
 	samePageWithHash: { hash: string; options: ScrollIntoViewOptions };
 	scrollToContent: { options: ScrollIntoViewOptions };

--- a/src/modules/renderPage.ts
+++ b/src/modules/renderPage.ts
@@ -28,23 +28,19 @@ export const renderPage = async function (this: Swup, requestedUrl: string, page
 	this.context.to.html = html;
 
 	// replace content: allow handlers and plugins to overwrite paga data and containers
-	await this.hooks.trigger(
-		'replaceContent',
-		{ page, containers: this.context.containers },
-		(context, { page, containers }) => {
-			const success = this.replaceContent(page, { containers });
-			if (!success) {
-				throw new Error('[swup] Container mismatch, aborting');
-			}
-			if (this.context.transition.animate) {
-				// Make sure to add these classes to new containers as well
-				this.classes.add('is-animating', 'is-changing', 'is-rendering');
-				if (this.context.transition.name) {
-					this.classes.add(`to-${classify(this.context.transition.name)}`);
-				}
+	await this.hooks.trigger('replaceContent', { page }, (context, { page }) => {
+		const success = this.replaceContent(page, { containers: context.containers });
+		if (!success) {
+			throw new Error('[swup] Container mismatch, aborting');
+		}
+		if (this.context.transition.animate) {
+			// Make sure to add these classes to new containers as well
+			this.classes.add('is-animating', 'is-changing', 'is-rendering');
+			if (this.context.transition.name) {
+				this.classes.add(`to-${classify(this.context.transition.name)}`);
 			}
 		}
-	);
+	});
 
 	await this.hooks.trigger(
 		'scrollToContent',


### PR DESCRIPTION
**Description**

Right now, the `containers` in `replaceContent` can't be modified in the `context` object, even though that property exists. They must be changed in the second `args` object. This PR fixes this.

In general I think this is a good way to go:

- If a property exists in the `context` object, that property should be used in the hook callback
- The second `args` object should only be used for things that aren't already in the `context` object

**TODO**

Parallel plugin will need adjustments after this is merged.

**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [ ] All tests are passing (`npm run test`)
