### PR TITLE
Return single animation promise

### DIFF
--- a/src/Swup.ts
+++ b/src/Swup.ts
@@ -10,7 +10,7 @@ import { Classes } from './modules/Classes.js';
 import { Context, createContext } from './modules/Context.js';
 import { Hooks } from './modules/Hooks.js';
 import { getAnchorElement } from './modules/getAnchorElement.js';
-import { getAnimationPromises } from './modules/getAnimationPromises.js';
+import { awaitAnimations } from './modules/awaitAnimations.js';
 import { visit, performVisit, HistoryAction } from './modules/visit.js';
 import { fetchPage } from './modules/fetchPage.js';
 import { leavePage } from './modules/leavePage.js';
@@ -61,7 +61,7 @@ export default class Swup {
 	enterPage = enterPage;
 	delegateEvent = delegateEvent;
 	fetchPage = fetchPage;
-	getAnimationPromises = getAnimationPromises;
+	awaitAnimations = awaitAnimations;
 	getAnchorElement = getAnchorElement;
 	use = use;
 	unuse = unuse;

--- a/src/modules/Hooks.ts
+++ b/src/modules/Hooks.ts
@@ -4,7 +4,7 @@ import Swup, { Options } from '../Swup.js';
 import { isPromise, runAsPromise } from '../utils.js';
 import { Context } from './Context.js';
 import { FetchOptions, PageData } from './fetchPage.js';
-import { AnimationDirection } from './getAnimationPromises.js';
+import { AnimationDirection } from './awaitAnimations.js';
 
 export interface HookDefinitions {
 	animationInDone: undefined;

--- a/src/modules/enterPage.ts
+++ b/src/modules/enterPage.ts
@@ -7,9 +7,7 @@ export const enterPage = async function (this: Swup) {
 			'awaitAnimation',
 			{ direction: 'in' },
 			async (context, { direction }) => {
-				await Promise.all(
-					this.getAnimationPromises({ selector: context.animation.selector, direction })
-				);
+				await this.awaitAnimations({ selector: context.animation.selector, direction });
 			}
 		);
 		await nextTick();

--- a/src/modules/leavePage.ts
+++ b/src/modules/leavePage.ts
@@ -21,9 +21,7 @@ export const leavePage = async function (this: Swup) {
 		'awaitAnimation',
 		{ direction: 'out' },
 		async (context, { direction }) => {
-			await Promise.all(
-				this.getAnimationPromises({ selector: context.animation.selector, direction })
-			);
+			await this.awaitAnimations({ selector: context.animation.selector, direction });
 		}
 	);
 


### PR DESCRIPTION
**Description**

- Return a single Promise for awaiting animations on the page
- The previous `Promise.all()` is now implied
- Rename methods to clarify intention

**Checks**

- [x] The PR is submitted to the `next` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [ ] ~~New or updated tests are included~~
- [ ] The documentation was updated as required
