### PR TITLE
Run build on prepublish only

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -16,10 +16,10 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 16
-      - run: npm run build
       - name: Run cypress tests
         uses: cypress-io/github-action@v5
         with:
+          build: npm run build
           command: npm run test:ci
           record: true
         env:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -16,8 +16,9 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 16
+      - run: npm run build
       - name: Run cypress tests
-        uses: cypress-io/github-action@v4.2.2
+        uses: cypress-io/github-action@v5
         with:
           command: npm run test:ci
           record: true

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "format": "npm run lint:ts && npm run lint:prettier -- --write",
     "lint:ts": "tsc --noEmit --skipLibCheck",
     "lint:prettier": "prettier 'src/**/*.ts'",
-    "prepublish": "npm run build",
+    "prepublishOnly": "npm run build",
     "postinstall": "opencollective-postinstall || true",
     "test": "npm run test:unit && npm run test:e2e",
     "test:ci": "npm run test:unit && npm run test:e2e:ci",


### PR DESCRIPTION
**Description**

- Run build script on `prepublishOnly` instead of `prepublish`
- Currently, it auto-runs the build script on every local install
- That doubles the build time of most of our GitHub actions as these will first install (& build), then manually build again
- Need to check if we need to edit some GitHub actions

**Checks**

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [ ] ~New or updated tests are included~
- [ ] ~The documentation was updated as required~
