### PR TITLE
Check direction of travel on history visits

### DIFF
--- a/cypress/e2e/main.spec.js
+++ b/cypress/e2e/main.spec.js
@@ -541,6 +541,42 @@ describe('History', function () {
 		});
 	});
 
+	it('should calculate the travel direction of history visits', function () {
+		let direction = null;
+		this.swup.hooks.on('history:popstate', (context) => {
+			direction = context.history.direction;
+		});
+
+		cy.triggerClickOnLink('/page-2.html');
+		cy.shouldBeAtPage('/page-2.html');
+
+		cy.window().then((window) => {
+			window.history.back();
+			cy.window().should(() => {
+				expect(direction).to.equal('backward');
+			});
+		});
+
+		cy.shouldBeAtPage('/page-1.html');
+
+		cy.window().then((window) => {
+			window.history.forward();
+			cy.window().should(() => {
+				expect(direction).to.equal('forward');
+			});
+		});
+
+		cy.triggerClickOnLink('/page-3.html');
+		cy.shouldBeAtPage('/page-3.html');
+
+		cy.window().then((window) => {
+			window.history.go(-2);
+			cy.window().should(() => {
+				expect(direction).to.equal('backward');
+			});
+		});
+	});
+
 	it('should trigger a custom popstate event', function () {
 		const handlers = { popstate() {} };
 		cy.spy(handlers, 'popstate');

--- a/src/__test__/index.test.ts
+++ b/src/__test__/index.test.ts
@@ -38,7 +38,7 @@ describe('Exports', () => {
 			resolveUrl: (url) => url,
 			requestHeaders: {
 				'X-Requested-With': 'swup',
-				Accept: 'text/html, application/xhtml+xml'
+				'Accept': 'text/html, application/xhtml+xml'
 			},
 			skipPopStateHandling: (event) => event.state?.source !== 'swup'
 		};

--- a/src/modules/Context.ts
+++ b/src/modules/Context.ts
@@ -1,5 +1,5 @@
 import Swup, { Options } from '../Swup.js';
-import { HistoryAction } from './visit.js';
+import { HistoryAction, HistoryDirection } from './visit.js';
 
 export interface Context<TEvent = Event> {
 	/** The previous page, about to leave */
@@ -62,7 +62,8 @@ export interface HistoryContext {
 	action: HistoryAction;
 	/** Whether this visit was triggered by a browser history navigation. */
 	popstate: boolean;
-	// direction: 'forward' | 'backward' | undefined
+	/** The direction of travel in case of a browser history navigation: backward or forward. */
+	direction: HistoryDirection | undefined;
 }
 
 export interface ContextInitOptions {
@@ -74,7 +75,6 @@ export interface ContextInitOptions {
 	targets?: string[];
 	el?: Element;
 	event?: Event;
-	popstate?: boolean;
 	action?: HistoryAction;
 	resetScroll?: boolean;
 }
@@ -89,7 +89,6 @@ export function createContext(
 		animation: name,
 		el,
 		event,
-		popstate = false,
 		action = 'push',
 		resetScroll: reset = true
 	}: ContextInitOptions
@@ -111,8 +110,8 @@ export function createContext(
 		},
 		history: {
 			action,
-			popstate
-			// direction: undefined
+			popstate: false,
+			direction: undefined
 		},
 		scroll: {
 			reset,

--- a/src/modules/Hooks.ts
+++ b/src/modules/Hooks.ts
@@ -17,8 +17,8 @@ export interface HookDefinitions {
 	'cache:set': { page: PageData };
 	'content:replace': { page: PageData };
 	'content:scroll': { options: ScrollIntoViewOptions };
-	enable: undefined;
-	disable: undefined;
+	'enable': undefined;
+	'disable': undefined;
 	'fetch:request': { url: string; options: FetchOptions };
 	'fetch:error': { url: string; status: number; response: Response };
 	'history:popstate': { event: PopStateEvent };

--- a/src/modules/visit.ts
+++ b/src/modules/visit.ts
@@ -4,6 +4,7 @@ import { FetchOptions } from './fetchPage.js';
 import { ContextInitOptions } from './Context.js';
 
 export type HistoryAction = 'push' | 'replace';
+export type HistoryDirection = 'forward' | 'backward';
 
 export type PageLoadOptions = {
 	/** Whether this visit is animated. Default: `true` */
@@ -74,7 +75,8 @@ export async function performVisit(
 			if (this.context.history.action === 'replace') {
 				updateHistoryRecord(newUrl);
 			} else {
-				createHistoryRecord(newUrl);
+				const index = this.currentHistoryIndex + 1;
+				createHistoryRecord(newUrl, { index });
 			}
 		}
 


### PR DESCRIPTION
**Description**

- Calculate the direction of travel for history visits: `forward` or `backward` or undefined
- Available in `context.history.direction`
- Is this useful? Is this worth the 70 bytes? I'd say yes
- Alternative API: numerical delta in `context.history.delta`: `-4`, `0`, `1`, and so on

**Checks**

- [x] The PR is submitted to the `next` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [x] New or updated tests are included
- [ ] The documentation was updated as required
