### PR TITLE
Rename `leavePage` and `enterPage`

### DIFF
--- a/src/Swup.ts
+++ b/src/Swup.ts
@@ -13,9 +13,9 @@ import { getAnchorElement } from './modules/getAnchorElement.js';
 import { awaitAnimations } from './modules/awaitAnimations.js';
 import { visit, performVisit, HistoryAction } from './modules/visit.js';
 import { fetchPage } from './modules/fetchPage.js';
-import { leavePage } from './modules/leavePage.js';
+import { animatePageOut } from './modules/animatePageOut.js';
 import { replaceContent } from './modules/replaceContent.js';
-import { enterPage } from './modules/enterPage.js';
+import { animatePageIn } from './modules/animatePageIn.js';
 import { renderPage } from './modules/renderPage.js';
 import { use, unuse, findPlugin, Plugin } from './modules/plugins.js';
 import { nextTick } from './utils.js';
@@ -69,10 +69,10 @@ export default class Swup {
 
 	visit = visit;
 	performVisit = performVisit;
-	leavePage = leavePage;
+	animatePageOut = animatePageOut;
 	renderPage = renderPage;
 	replaceContent = replaceContent;
-	enterPage = enterPage;
+	animatePageIn = animatePageIn;
 	delegateEvent = delegateEvent;
 	fetchPage = fetchPage;
 	awaitAnimations = awaitAnimations;

--- a/src/modules/animatePageIn.ts
+++ b/src/modules/animatePageIn.ts
@@ -5,7 +5,7 @@ import { nextTick } from '../utils.js';
  * Perform the in/enter animation of the next page.
  * @returns Promise<void>
  */
-export const enterPage = async function (this: Swup) {
+export const animatePageIn = async function (this: Swup) {
 	if (!this.context.animation.animate) {
 		return;
 	}

--- a/src/modules/animatePageOut.ts
+++ b/src/modules/animatePageOut.ts
@@ -5,7 +5,7 @@ import { classify } from '../helpers.js';
  * Perform the out/leave animation of the current page.
  * @returns Promise<void>
  */
-export const leavePage = async function (this: Swup) {
+export const animatePageOut = async function (this: Swup) {
 	if (!this.context.animation.animate) {
 		await this.hooks.trigger('animation:skip');
 		return;

--- a/src/modules/visit.ts
+++ b/src/modules/visit.ts
@@ -113,14 +113,14 @@ export async function performVisit(
 		}
 
 		// Wait for page to load and leave animation to finish
-		const animationPromise = this.leavePage();
+		const animationPromise = this.animatePageOut();
 		const [page] = await Promise.all([pagePromise, animationPromise]);
 
 		// Render page: replace content and scroll to top/fragment
 		await this.renderPage(this.context.to.url, page);
 
 		// Wait for enter animation
-		await this.enterPage();
+		await this.animatePageIn();
 
 		// Finalize visit
 		await this.hooks.trigger('visit:end', undefined, () => this.classes.clear());


### PR DESCRIPTION
**Description**

The names of `leavePage` and `enterPage` are hard for me to understand without looking at the implementation. I'd like to rename them so they describe as clearly as possible what they do:

- `leavePage` ➡️ `animatePageOut`
- `enterPage` ➡️ `animatePageIn`

**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `next` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- ~The documentation was updated as required~
