### PR TITLE
Force reflow

### DIFF
--- a/cypress/fixtures/animation-keyframes.html
+++ b/cypress/fixtures/animation-keyframes.html
@@ -9,8 +9,6 @@
     <style>
         html.is-changing .transition-default {
             transition: none;
-        }
-        html.is-animating .transition-default {
             animation: test-animation 400ms 300ms;
         }
         html.is-rendering .transition-default {

--- a/cypress/fixtures/animation-keyframes.html
+++ b/cypress/fixtures/animation-keyframes.html
@@ -8,8 +8,10 @@
     <script src="/dist/Swup.umd.js"></script>
     <style>
         html.is-changing .transition-default {
-            transition: none;
             animation: test-animation 400ms 300ms;
+            animation-fill-mode: both;
+            transition: none;
+            opacity: initial
         }
         html.is-rendering .transition-default {
             animation-direction: reverse;
@@ -36,7 +38,13 @@
         </ul>
     </header>
     <main id="swup" class="wrapper transition-default">
-        <h1>Animation duration: keyframes</h1>
+        <div class="wrapper-inner">
+            <h1>Animation duration: keyframes</h1>
+            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+                Alias assumenda consectetur consequatur enim esse incidunt iusto, magnam
+                maxime molestias nisi perferendis perspiciatis quibusdam quos repellat,
+                vel veniam vero voluptate voluptatem.</p>
+        </div>
     </main>
     <script>
         window._swup = new Swup();

--- a/src/modules/animatePageIn.ts
+++ b/src/modules/animatePageIn.ts
@@ -1,5 +1,5 @@
 import Swup from '../Swup.js';
-import { nextTick } from '../utils.js';
+import { forceReflow } from '../utils.js';
 
 /**
  * Perform the in/enter animation of the next page.
@@ -10,21 +10,19 @@ export const animatePageIn = async function (this: Swup) {
 		return;
 	}
 
-	const animation = this.hooks.trigger(
+	await this.hooks.trigger('animation:in:start', undefined, () => {
+		this.classes.remove('is-animating');
+	});
+
+	forceReflow();
+
+	await this.hooks.trigger(
 		'animation:await',
 		{ direction: 'in' },
 		async (context, { direction }) => {
 			await this.awaitAnimations({ selector: context.animation.selector, direction });
 		}
 	);
-
-	await nextTick();
-
-	await this.hooks.trigger('animation:in:start', undefined, () => {
-		this.classes.remove('is-animating');
-	});
-
-	await animation;
 
 	await this.hooks.trigger('animation:in:end');
 };

--- a/src/modules/animatePageOut.ts
+++ b/src/modules/animatePageOut.ts
@@ -1,5 +1,6 @@
 import Swup from '../Swup.js';
 import { classify } from '../helpers.js';
+import { forceReflow } from '../utils.js';
 
 /**
  * Perform the out/leave animation of the current page.
@@ -20,6 +21,8 @@ export const animatePageOut = async function (this: Swup) {
 			this.classes.add(`to-${classify(this.context.animation.name)}`);
 		}
 	});
+
+	forceReflow();
 
 	await this.hooks.trigger(
 		'animation:await',

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -38,6 +38,11 @@ export function runAsPromise(func: Function, args: any[] = [], ctx: any = {}): P
 	});
 }
 
+/**
+ * Force a layout reflow, e.g. after adding classnames
+ * @returns The offset height, just here so it doesn't get optimized away by the JS engine
+ * @see https://stackoverflow.com/a/21665117/3759615
+ */
 export function forceReflow(element?: HTMLElement) {
 	element = element || document.body;
 	return element?.offsetHeight;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -38,6 +38,11 @@ export function runAsPromise(func: Function, args: any[] = [], ctx: any = {}): P
 	});
 }
 
+export function forceReflow(element?: HTMLElement) {
+	element = element || document.body;
+	return element?.offsetHeight;
+}
+
 export const escapeCssIdentifier = (ident: string) => {
 	// @ts-ignore this is for support check, so it's correct that TS complains
 	if (window.CSS && window.CSS.escape) {


### PR DESCRIPTION
**Description**

- Switch to [forcing reflow](https://stackoverflow.com/a/21665117/3759615) after toggling animation classes, instead of awaiting the next tick
- Continues immediately and avoids some weird race conditions
- More noticable when used with parallel animations
- Trick is battle-tested in Vue's transitions ([source](https://github.com/vuejs/core/blob/a3dddd62059f4a7a762046c1e7f01485b96e737d/packages/runtime-dom/src/components/Transition.ts#L240))

**Checks**

- [x] The PR is submitted to the `next` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [x] New or updated tests are included
- [ ] ~~The documentation was updated as required~~
