### PR TITLE
Allow skipping animation hook

### DIFF
--- a/src/modules/Hooks.ts
+++ b/src/modules/Hooks.ts
@@ -12,7 +12,7 @@ export interface HookDefinitions {
 	'animation:in:start': undefined;
 	'animation:in:end': undefined;
 	'animation:skip': undefined;
-	'animation:await': { direction: AnimationDirection };
+	'animation:await': { direction: AnimationDirection; skip: boolean };
 	'cache:clear': undefined;
 	'cache:set': { page: PageData };
 	'content:replace': { page: PageData };

--- a/src/modules/animatePageIn.ts
+++ b/src/modules/animatePageIn.ts
@@ -12,8 +12,9 @@ export const animatePageIn = async function (this: Swup) {
 
 	const animation = this.hooks.trigger(
 		'animation:await',
-		{ direction: 'in' },
-		async (context, { direction }) => {
+		{ direction: 'in', skip: false },
+		async (context, { direction, skip }) => {
+			if (skip) return;
 			await this.awaitAnimations({ selector: context.animation.selector, direction });
 		}
 	);

--- a/src/modules/animatePageOut.ts
+++ b/src/modules/animatePageOut.ts
@@ -23,8 +23,9 @@ export const animatePageOut = async function (this: Swup) {
 
 	await this.hooks.trigger(
 		'animation:await',
-		{ direction: 'out' },
-		async (context, { direction }) => {
+		{ direction: 'out', skip: false },
+		async (context, { direction, skip }) => {
+			if (skip) return;
 			await this.awaitAnimations({ selector: context.animation.selector, direction });
 		}
 	);


### PR DESCRIPTION
**Description**

- Add `skip` arg to `animation:await` hook
- Setting it to false in a `before` hook allows skipping a specific in/out animation

```js
swup.hooks.before('animation:await', (context, args) => {
  if (args.direction === 'out') {
    args.skip = true;
  }
});
```

**Checks**

- [x] The PR is submitted to the `next` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [ ] New or updated tests are included
- [ ] The documentation was updated as required

**Additional information**

<!--
Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc.
-->
