### PR TITLE
Namespace `animation:await` hook with direction

### DIFF
--- a/src/modules/Hooks.ts
+++ b/src/modules/Hooks.ts
@@ -4,15 +4,15 @@ import Swup from '../Swup.js';
 import { isPromise, runAsPromise } from '../utils.js';
 import { Context } from './Context.js';
 import { FetchOptions, PageData } from './fetchPage.js';
-import { AnimationDirection } from './awaitAnimations.js';
 
 export interface HookDefinitions {
 	'animation:out:start': undefined;
+	'animation:out:await': { skip: boolean };
 	'animation:out:end': undefined;
 	'animation:in:start': undefined;
+	'animation:in:await': { skip: boolean };
 	'animation:in:end': undefined;
 	'animation:skip': undefined;
-	'animation:await': { direction: AnimationDirection; skip: boolean };
 	'cache:clear': undefined;
 	'cache:set': { page: PageData };
 	'content:replace': { page: PageData };
@@ -90,11 +90,12 @@ export class Hooks {
 	// https://stackoverflow.com/questions/53387838/how-to-ensure-an-arrays-values-the-keys-of-a-typescript-interface/53395649
 	readonly hooks: HookName[] = [
 		'animation:out:start',
+		'animation:out:await',
 		'animation:out:end',
 		'animation:in:start',
+		'animation:in:await',
 		'animation:in:end',
 		'animation:skip',
-		'animation:await',
 		'cache:clear',
 		'cache:set',
 		'content:replace',
@@ -403,8 +404,8 @@ export class Hooks {
 	}
 
 	/**
-	 * Trigger a custom event on the `document`. Prefixed with `swup:`
-	 * @param hook Name of the hook to trigger.
+	 * Dispatch a custom event on the `document` for a hook. Prefixed with `swup:`
+	 * @param hook Name of the hook.
 	 */
 	dispatchDomEvent<T extends HookName>(hook: T, args?: HookArguments<T>): void {
 		const detail = { hook, args, context: this.swup.context };

--- a/src/modules/animatePageIn.ts
+++ b/src/modules/animatePageIn.ts
@@ -11,11 +11,11 @@ export const animatePageIn = async function (this: Swup) {
 	}
 
 	const animation = this.hooks.trigger(
-		'animation:await',
-		{ direction: 'in', skip: false },
-		async (context, { direction, skip }) => {
+		'animation:in:await',
+		{ skip: false },
+		async (context, { skip }) => {
 			if (skip) return;
-			await this.awaitAnimations({ selector: context.animation.selector, direction });
+			await this.awaitAnimations({ selector: context.animation.selector });
 		}
 	);
 

--- a/src/modules/animatePageOut.ts
+++ b/src/modules/animatePageOut.ts
@@ -21,14 +21,10 @@ export const animatePageOut = async function (this: Swup) {
 		}
 	});
 
-	await this.hooks.trigger(
-		'animation:await',
-		{ direction: 'out', skip: false },
-		async (context, { direction, skip }) => {
-			if (skip) return;
-			await this.awaitAnimations({ selector: context.animation.selector, direction });
-		}
-	);
+	await this.hooks.trigger('animation:out:await', { skip: false }, async (context, { skip }) => {
+		if (skip) return;
+		await this.awaitAnimations({ selector: context.animation.selector });
+	});
 
 	await this.hooks.trigger('animation:out:end');
 };

--- a/src/modules/awaitAnimations.ts
+++ b/src/modules/awaitAnimations.ts
@@ -12,9 +12,8 @@ type AnimationStyleDeclarations = Pick<CSSStyleDeclaration, AnimationStyleKeys>;
 export type AnimationDirection = 'in' | 'out';
 
 /**
- * Return a Promise that resolves when all animations are done on the page.
- *
- * @note We don't make use of the `direction` argument, but it's required by JS plugin
+ * Return a Promise that resolves when all CSS animations and transitions
+ * are done on the page. Filters by selector or takes elements directly.
  */
 export async function awaitAnimations(
 	this: Swup,
@@ -24,10 +23,9 @@ export async function awaitAnimations(
 	}: {
 		selector: Options['animationSelector'];
 		elements?: NodeListOf<HTMLElement> | HTMLElement[];
-		direction?: AnimationDirection;
 	}
 ): Promise<void> {
-	// Allow usage of swup without animations
+	// Allow usage of swup without animations: { animationSelector: false }
 	if (selector === false && !elements) {
 		return;
 	}


### PR DESCRIPTION
**Description**

- Instead of one `animation:await` hook with a `{ direction: 'out' | 'in' }` argument, create one hook per direction
- Now there's `animation:out:await` and `animation:in:await`
- This makes skipping one phase much easier (e.g. in fragment and parallel plugin)
- Shaves off 14 bytes 🎉

**Checks**

- [x] The PR is submitted to the `next` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [ ] New or updated tests are included
- [ ] The documentation was updated as required
