### PR TITLE
Migrate `CacheData` to `PageData`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,6 @@ import type { Path } from 'path-to-regexp';
 
 import Swup, { type Options } from './Swup.js';
 import type { PageData } from './modules/fetchPage.js';
-import type { CacheData } from './modules/Cache.js';
 import type {
 	Visit,
 	VisitFrom,
@@ -28,7 +27,6 @@ export * from './utils.js';
 export type {
 	Options,
 	Plugin,
-	CacheData,
 	PageData,
 	Visit,
 	VisitFrom,

--- a/src/modules/Cache.ts
+++ b/src/modules/Cache.ts
@@ -2,8 +2,6 @@ import Swup from '../Swup.js';
 import { Location } from '../helpers.js';
 import { PageData } from './fetchPage.js';
 
-export interface CacheData extends PageData {}
-
 /**
  * In-memory page cache.
  */
@@ -12,7 +10,7 @@ export class Cache {
 	private swup: Swup;
 
 	/** Cached pages, indexed by URL */
-	private pages: Map<string, CacheData> = new Map();
+	private pages: Map<string, PageData> = new Map();
 
 	constructor(swup: Swup) {
 		this.swup = swup;
@@ -34,12 +32,12 @@ export class Cache {
 	}
 
 	/** Return the cached page object if cached. */
-	public get(url: string): CacheData | undefined {
+	public get(url: string): PageData | undefined {
 		return this.pages.get(this.resolve(url));
 	}
 
 	/** Create a cache record for the specified URL. */
-	public set(url: string, page: CacheData) {
+	public set(url: string, page: PageData) {
 		url = this.resolve(url);
 		page = { ...page, url };
 		this.pages.set(url, page);
@@ -47,7 +45,7 @@ export class Cache {
 	}
 
 	/** Update a cache record, overwriting or adding custom data. */
-	public update(url: string, page: CacheData) {
+	public update(url: string, page: PageData) {
 		url = this.resolve(url);
 		page = { ...this.get(url), ...page, url };
 		this.pages.set(url, page);
@@ -65,7 +63,7 @@ export class Cache {
 	}
 
 	/** Remove all cache entries that return true for a given predicate function.  */
-	public prune(predicate: (url: string, page: CacheData) => boolean): void {
+	public prune(predicate: (url: string, page: PageData) => boolean): void {
 		this.pages.forEach((page, url) => {
 			if (predicate(url, page)) {
 				this.delete(url);

--- a/src/modules/__test__/cache.test.ts
+++ b/src/modules/__test__/cache.test.ts
@@ -1,18 +1,19 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import Swup from '../../Swup.js';
-import { Cache, CacheData } from '../Cache.js';
+import { Cache } from '../Cache.js';
+import type { PageData } from '../fetchPage.js';
 import { Visit } from '../Visit.js';
 
-interface CacheTtlData {
+interface PageTtlData {
 	ttl: number;
 	created: number;
 }
 
-interface CacheIndexData {
+interface PageIndexData {
 	index: number;
 }
 
-interface AugmentedCacheData extends CacheData, CacheTtlData, CacheIndexData {}
+interface AugmentedPageData extends PageData, PageTtlData, PageIndexData {}
 
 const swup = new Swup();
 const visit = swup.visit;
@@ -89,27 +90,27 @@ describe('Cache', () => {
 		const now = Date.now();
 
 		swup.hooks.on('cache:set', (_, { page }) => {
-			const ttl: CacheTtlData = { ttl: 1000, created: now };
-			cache.update(page.url, ttl as AugmentedCacheData);
+			const ttl: PageTtlData = { ttl: 1000, created: now };
+			cache.update(page.url, ttl as AugmentedPageData);
 		});
 
 		cache.set('/page', { url: '/page', html: '' });
 
-		const page = cache.get('/page') as AugmentedCacheData;
+		const page = cache.get('/page') as AugmentedPageData;
 
 		expect(page).toEqual({ url: '/page', html: '', ttl: 1000, created: now });
 	});
 
 	it('should allow manual pruning', () => {
 		swup.hooks.on('cache:set', (_, { page }) => {
-			cache.update(page.url, { index: cache.size } as AugmentedCacheData);
+			cache.update(page.url, { index: cache.size } as AugmentedPageData);
 		});
 
 		cache.set(page1.url, page1);
 		cache.set(page2.url, page2);
 		cache.set(page3.url, page3);
 
-		cache.prune((url, page) => (page as AugmentedCacheData).index > 2);
+		cache.prune((url, page) => (page as AugmentedPageData).index > 2);
 
 		expect(cache.size).toBe(2);
 		expect(cache.has(page1.url)).toBe(true);

--- a/src/modules/fetchPage.ts
+++ b/src/modules/fetchPage.ts
@@ -40,12 +40,12 @@ export async function fetchPage(
 ): Promise<PageData> {
 	url = Location.fromUrl(url).url;
 
-	if (this.cache.has(url)) {
-		const page = this.cache.get(url) as PageData;
+	const cachedPage = this.cache.get(url);
+	if (cachedPage) {
 		if (options.triggerHooks !== false) {
-			await this.hooks.call('page:load', { page, cache: true });
+			await this.hooks.call('page:load', { page: cachedPage, cache: true });
 		}
-		return page;
+		return cachedPage;
 	}
 
 	const headers = { ...this.options.requestHeaders, ...options.headers };


### PR DESCRIPTION
**Description**

Replaces the alias `CacheData` with the actual `PageData` interface. Anytime a page is being saved/mutated in the cache or being rendered by `content:replace`, it should be the same type.

This will make working with the `page` object easier, be it when manipulating the cache or when manipulating the `args.page` in `content:replace`.

**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `next` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
