### PR TITLE
Scroll hooks

### DIFF
--- a/src/Swup.ts
+++ b/src/Swup.ts
@@ -15,6 +15,7 @@ import { navigate, performNavigation } from './modules/navigate.js';
 import { fetchPage } from './modules/fetchPage.js';
 import { animatePageOut } from './modules/animatePageOut.js';
 import { replaceContent } from './modules/replaceContent.js';
+import { scrollToContent } from './modules/scrollToContent.js';
 import { animatePageIn } from './modules/animatePageIn.js';
 import { renderPage } from './modules/renderPage.js';
 import { use, unuse, findPlugin, Plugin } from './modules/plugins.js';
@@ -74,6 +75,7 @@ export default class Swup {
 	animatePageOut = animatePageOut;
 	renderPage = renderPage;
 	replaceContent = replaceContent;
+	scrollToContent = scrollToContent;
 	animatePageIn = animatePageIn;
 	delegateEvent = delegateEvent;
 	fetchPage = fetchPage;

--- a/src/Swup.ts
+++ b/src/Swup.ts
@@ -241,11 +241,13 @@ export default class Swup {
 			if (!url || url === from) {
 				if (hash) {
 					this.hooks.callSync('link:anchor', { hash }, () => {
-						this.scrollToContent();
 						updateHistoryRecord(url + hash);
+						this.scrollToContent();
 					});
 				} else {
-					this.hooks.callSync('link:self', undefined, () => this.scrollToContent());
+					this.hooks.callSync('link:self', undefined, () => {
+						this.scrollToContent();
+					});
 				}
 				return;
 			}

--- a/src/Swup.ts
+++ b/src/Swup.ts
@@ -241,21 +241,9 @@ export default class Swup {
 			if (!url || url === from) {
 				if (hash) {
 					updateHistoryRecord(url + hash);
-					this.hooks.callSync(
-						'link:anchor',
-						{ hash, options: { behavior: 'auto' } },
-						(visit, { hash, options }) => {
-							const target = this.getAnchorElement(hash);
-							if (target) {
-								target.scrollIntoView(options);
-							}
-						}
-					);
+					this.hooks.callSync('link:anchor', { hash }, () => this.scrollToContent());
 				} else {
-					this.hooks.callSync('link:self', undefined, (visit) => {
-						if (!visit.scroll.reset) return;
-						window.scroll({ top: 0, left: 0, behavior: 'auto' });
-					});
+					this.hooks.callSync('link:self', undefined, () => this.scrollToContent());
 				}
 				return;
 			}

--- a/src/Swup.ts
+++ b/src/Swup.ts
@@ -240,8 +240,10 @@ export default class Swup {
 			// Handle links to the same page: with or without hash
 			if (!url || url === from) {
 				if (hash) {
-					updateHistoryRecord(url + hash);
-					this.hooks.callSync('link:anchor', { hash }, () => this.scrollToContent());
+					this.hooks.callSync('link:anchor', { hash }, () => {
+						this.scrollToContent();
+						updateHistoryRecord(url + hash);
+					});
 				} else {
 					this.hooks.callSync('link:self', undefined, () => this.scrollToContent());
 				}

--- a/src/modules/Hooks.ts
+++ b/src/modules/Hooks.ts
@@ -47,7 +47,7 @@ export type Handler<T extends HookName> = (
 	args: HookArguments<T>,
 	/** Default handler to be executed. Available if replacing an internal hook handler. */
 	defaultHandler?: Handler<T>
-) => Promise<any> | void;
+) => Promise<any> | any;
 
 export type Handlers = {
 	[K in HookName]: Handler<K>[];

--- a/src/modules/Hooks.ts
+++ b/src/modules/Hooks.ts
@@ -16,7 +16,7 @@ export interface HookDefinitions {
 	'cache:clear': undefined;
 	'cache:set': { page: PageData };
 	'content:replace': { page: PageData };
-	'content:scroll': { options: ScrollIntoViewOptions };
+	'content:scroll': undefined;
 	'enable': undefined;
 	'disable': undefined;
 	'fetch:request': { url: string; options: FetchOptions };
@@ -24,11 +24,13 @@ export interface HookDefinitions {
 	'history:popstate': { event: PopStateEvent };
 	'link:click': { el: HTMLAnchorElement; event: DelegateEvent<MouseEvent> };
 	'link:self': undefined;
-	'link:anchor': { hash: string; options: ScrollIntoViewOptions };
+	'link:anchor': { hash: string };
 	'link:newtab': { href: string };
 	'page:request': { url: string; options: FetchOptions };
 	'page:load': { page: PageData; cache?: boolean };
 	'page:view': { url: string; title: string };
+	'scroll:top': { options: ScrollIntoViewOptions };
+	'scroll:anchor': { hash: string; options: ScrollIntoViewOptions };
 	'visit:start': undefined;
 	'visit:end': undefined;
 }
@@ -119,6 +121,8 @@ export class Hooks {
 		'page:request',
 		'page:load',
 		'page:view',
+		'scroll:top',
+		'scroll:anchor',
 		'visit:start',
 		'visit:end'
 	];

--- a/src/modules/renderPage.ts
+++ b/src/modules/renderPage.ts
@@ -46,22 +46,10 @@ export const renderPage = async function (this: Swup, requestedUrl: string, page
 		}
 	});
 
-	await this.hooks.call(
-		'content:scroll',
-		{ options: { behavior: 'auto' } },
-		(visit, { options }) => {
-			if (visit.scroll.target) {
-				const target = this.getAnchorElement(visit.scroll.target);
-				if (target) {
-					target.scrollIntoView(options);
-					return;
-				}
-			}
-			if (visit.scroll.reset) {
-				window.scrollTo(0, 0);
-			}
-		}
-	);
+	// scroll into view: either anchor or top of page
+	await this.hooks.call('content:scroll', undefined, () => {
+		return this.scrollToContent();
+	});
 
 	await this.hooks.call('page:view', { url: this.currentPageUrl, title: document.title });
 

--- a/src/modules/scrollToContent.ts
+++ b/src/modules/scrollToContent.ts
@@ -1,0 +1,34 @@
+import Swup from '../Swup.js';
+
+/**
+ * Update the scroll position after page render.
+ * @returns Promise<boolean>
+ */
+export const scrollToContent = function (this: Swup): boolean {
+	const options: ScrollIntoViewOptions = { behavior: 'auto' };
+	const { target, reset } = this.visit.scroll;
+	let scrolled = false;
+
+	if (target) {
+		scrolled = this.hooks.callSync(
+			'scroll:anchor',
+			{ hash: target, options },
+			(visit, { hash, options }) => {
+				const anchor = this.getAnchorElement(hash || '');
+				if (anchor) {
+					anchor.scrollIntoView(options);
+				}
+				return !!anchor;
+			}
+		);
+	}
+
+	if (reset && !scrolled) {
+		scrolled = this.hooks.callSync('scroll:top', { options }, (visit, { options }) => {
+			window.scrollTo({ top: 0, left: 0, ...options });
+			return true;
+		});
+	}
+
+	return scrolled;
+};


### PR DESCRIPTION
**Description**

- Create separate `scroll:top` and `scroll:anchor` hooks
- Allow easier replacement by scroll plugin
- Now we can introduce an option `ignoreLinksToCurrentUrl` as non-breaking
- Or users can do it themselves: `swup.hooks.replace('link:self', (visit) => swup.navigate(visit.to.url))`
- Adds 40 bytes, but in my opinion definitely worth it

**Checks**

- [x] The PR is submitted to the `next` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [ ] ~~New or updated tests are included~~
- [ ] The documentation was updated as required