### PR TITLE
Refactor to single page:load hook

### DIFF
--- a/src/modules/Hooks.ts
+++ b/src/modules/Hooks.ts
@@ -26,8 +26,7 @@ export interface HookDefinitions {
 	'link:self': undefined;
 	'link:anchor': { hash: string };
 	'link:newtab': { href: string };
-	'page:request': { url: string; options: FetchOptions };
-	'page:load': { page: PageData; cache?: boolean };
+	'page:load': { page?: PageData; cache?: boolean; options: FetchOptions };
 	'page:view': { url: string; title: string };
 	'scroll:top': { options: ScrollIntoViewOptions };
 	'scroll:anchor': { hash: string; options: ScrollIntoViewOptions };
@@ -118,7 +117,6 @@ export class Hooks {
 		'link:self',
 		'link:anchor',
 		'link:newtab',
-		'page:request',
 		'page:load',
 		'page:view',
 		'scroll:top',

--- a/src/modules/fetchPage.ts
+++ b/src/modules/fetchPage.ts
@@ -36,17 +36,9 @@ export class FetchError extends Error {
 export async function fetchPage(
 	this: Swup,
 	url: URL | string,
-	options: FetchOptions & { triggerHooks?: boolean } = {}
+	options: FetchOptions = {}
 ): Promise<PageData> {
 	url = Location.fromUrl(url).url;
-
-	if (this.cache.has(url)) {
-		const page = this.cache.get(url) as PageData;
-		if (options.triggerHooks !== false) {
-			await this.hooks.call('page:load', { page, cache: true });
-		}
-		return page;
-	}
 
 	const headers = { ...this.options.requestHeaders, ...options.headers };
 	options = { ...options, headers };
@@ -77,10 +69,6 @@ export async function fetchPage(
 	// Only save cache entry for non-redirects
 	if (url === finalUrl) {
 		this.cache.set(page.url, page);
-	}
-
-	if (options.triggerHooks !== false) {
-		await this.hooks.call('page:load', { page, cache: false });
 	}
 
 	return page;

--- a/src/modules/navigate.ts
+++ b/src/modules/navigate.ts
@@ -87,12 +87,13 @@ export async function performNavigation(
 	try {
 		await this.hooks.call('visit:start');
 
-		// Begin fetching page
-		const pagePromise = this.hooks.call(
-			'page:request',
-			{ url: this.visit.to.url, options },
-			async (visit, { options }) => await this.fetchPage(visit.to.url as string, options)
-		);
+		// Begin loading page
+		const pagePromise = this.hooks.call('page:load', { options }, async (visit, args) => {
+			const cachedPage = this.cache.get(visit.to.url!);
+			args.page = cachedPage || (await this.fetchPage(visit.to.url!, args.options));
+			args.cache = !!cachedPage;
+			return args.page;
+		});
 
 		// Create history record if this is not a popstate call (with or without anchor)
 		if (!this.visit.history.popstate) {


### PR DESCRIPTION
**Description**

- Reduce confusion around page load lifecycle
- Instead of `page:request` and `page:load`, refactor to a single `page:load` hook
- Hook before to replace or edit options, hook after to get the loaded page
- Shaves off ~50 bytes 🧃

**Checks**

- [x] The PR is submitted to the `next` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [x] New or updated tests are included
- [ ] The documentation was updated as required
