### PR TITLE
Track bundle size with bundlejs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 <div align="center">
 
 [![npm version](https://img.shields.io/npm/v/swup.svg)](https://www.npmjs.com/package/swup)
-[![Bundle size](https://img.shields.io/bundlephobia/minzip/swup?label=size)](https://bundlephobia.com/package/swup)
+[![Bundle size](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fdeno.bundlejs.com%2F%3Fq%3Dswup%26treeshake%3D%257Bdefault%2520as%2520Swup%257D&query=size.compressedSize&label=size)](https://bundlejs.com/?q=swup&treeshake=%5B%7B+default+%7D%5D)
 [![npm downloads](https://img.shields.io/npm/dt/swup.svg)](https://www.npmjs.com/package/swup)
 [![Test status](https://img.shields.io/github/actions/workflow/status/swup/swup/e2e-tests.yml?branch=master&label=tests)](https://github.com/swup/swup/actions/workflows/e2e-tests.yml)
 [![License](https://img.shields.io/github/license/swup/swup.svg)](https://github.com/swup/swup/blob/master/LICENSE)


### PR DESCRIPTION
- The bundle size reported by bundlephobia is ridiculous inflated
- Switch to [bundlejs](https://bundlejs.com/), a modern alternative with first-class support for ESM and tree-shaking
- See [live results](https://bundlejs.com/?q=swup&treeshake=%5B%7B+default+%7D%5D) of bundlejs re-bundling swup's default export
- 8.8 kB → 6.2 kB