### PR TITLE
Infer element type from delegate selector

### DIFF
--- a/src/helpers/delegateEvent.ts
+++ b/src/helpers/delegateEvent.ts
@@ -6,19 +6,18 @@ export type DelegateEventUnsubscribe = {
 };
 
 /** Register a delegated event listener. */
-export const delegateEvent = <Selector extends string, TEvent extends EventType>(
+export const delegateEvent = <
+	Selector extends string,
+	TElement extends Element = ParseSelector<Selector, HTMLElement>,
+	TEvent extends EventType = EventType
+>(
 	selector: Selector,
 	type: TEvent,
-	callback: DelegateEventHandler<GlobalEventHandlersEventMap[TEvent]>,
+	callback: DelegateEventHandler<GlobalEventHandlersEventMap[TEvent], TElement>,
 	options?: DelegateOptions
 ): DelegateEventUnsubscribe => {
 	const controller = new AbortController();
 	options = { ...options, signal: controller.signal };
-	delegate<string, ParseSelector<Selector, HTMLElement>, TEvent>(
-		selector,
-		type,
-		callback,
-		options
-	);
+	delegate<Selector, TElement, TEvent>(selector, type, callback, options);
 	return { destroy: () => controller.abort() };
 };

--- a/src/modules/__test__/delegateEvent.ts
+++ b/src/modules/__test__/delegateEvent.ts
@@ -1,0 +1,36 @@
+import { DelegateEvent } from 'delegate-it';
+import { describe, it } from 'vitest';
+
+import { delegateEvent } from '../../helpers/delegateEvent.js';
+
+describe('delegateEvent', () => {
+	it('should return correct types', () => {
+		delegateEvent('form', 'submit', (event) => {});
+
+		// @ts-expect-no-error
+		delegateEvent('form', 'submit', (event: SubmitEvent) => {});
+		// @ts-expect-error
+		delegateEvent('form', 'submit', (event: MouseEvent) => {});
+
+		// @ts-expect-no-error
+		delegateEvent('form', 'submit', (event: DelegateEvent<SubmitEvent>) => {});
+		// @ts-expect-error
+		delegateEvent('form', 'submit', (event: DelegateEvent<MouseEvent>) => {});
+
+		// @ts-expect-no-error
+		delegateEvent('form', 'submit', (event: DelegateEvent<SubmitEvent, HTMLFormElement>) => {});
+		delegateEvent(
+			'form',
+			'submit',
+			// @ts-expect-error
+			(event: DelegateEvent<MouseEvent, HTMLAnchorElement>) => {}
+		);
+
+		delegateEvent('form', 'submit', (event) => {
+			// @ts-expect-no-error
+			const el: HTMLFormElement = event.delegateTarget;
+		});
+		// @ts-expect-error
+		delegateEvent('form', 'submit', (event: MouseEvent) => {});
+	});
+});


### PR DESCRIPTION
**Description**

- Currently, the `delegateEvent` helper returns `HTMLElement` for all event targets
- This change will automatically infer the element type from the selector: `form`  → `HTMLFormElement`
- Required for typing the Forms Plugin

**Checks**

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [x] New or updated tests are included
- [ ] ~~The documentation was updated as required~~
