### PR TITLE
Configure behavior on links to current page

### DIFF
--- a/cypress/e2e/main.spec.js
+++ b/cypress/e2e/main.spec.js
@@ -362,6 +362,21 @@ describe('Link resolution', function () {
 			expect(navigated).to.be.false;
 		});
 	});
+
+	it('should navigate to same page if configured via linkToSelf option', function () {
+		let navigated = false;
+		cy.window().then(() => {
+			this.swup.options.linkToSelf = 'navigate';
+			this.swup.hooks.once('visit:start', () => (navigated = true));
+		});
+		cy.scrollTo(0, 200);
+		cy.window().its('scrollY').should('equal', 200);
+		cy.get('[data-cy=nav-link-self]').click();
+		cy.window().its('scrollY').should('equal', 0);
+		cy.window().should(() => {
+			expect(navigated).to.be.true;
+		});
+	});
 });
 
 describe('Redirects', function () {

--- a/cypress/e2e/main.spec.js
+++ b/cypress/e2e/main.spec.js
@@ -324,6 +324,7 @@ describe('Navigation', function () {
 describe('Link resolution', function () {
 	beforeEach(() => {
 		cy.visit('/link-resolution.html');
+		cy.wrapSwupInstance();
 	});
 
 	it('should skip links to different origins', function () {
@@ -346,6 +347,20 @@ describe('Link resolution', function () {
 		cy.get('[data-cy=nav-link-sub]').click();
 		cy.shouldBeAtPage('/nested/nested-2.html');
 		cy.shouldHaveH1('Nested Page 2');
+	});
+
+	it('should reset scroll when clicking link to same page', function () {
+		let navigated = false;
+		cy.window().then(() => {
+			this.swup.hooks.once('visit:start', () => (navigated = true));
+		});
+		cy.scrollTo(0, 200);
+		cy.window().its('scrollY').should('equal', 200);
+		cy.get('[data-cy=nav-link-self]').click();
+		cy.window().its('scrollY').should('equal', 0);
+		cy.window().should(() => {
+			expect(navigated).to.be.false;
+		});
 	});
 });
 

--- a/cypress/e2e/main.spec.js
+++ b/cypress/e2e/main.spec.js
@@ -377,6 +377,14 @@ describe('Link resolution', function () {
 			expect(navigated).to.be.true;
 		});
 	});
+
+	it('should reload the same page if configured via linkToSelf option', function () {
+		cy.shouldHaveReloadedAfterAction(() => {
+			this.swup.options.linkToSelf = 'reload';
+			cy.get('[data-cy=nav-link-self]').click();
+		});
+		cy.shouldBeAtPage('/link-resolution.html');
+	});
 });
 
 describe('Redirects', function () {

--- a/cypress/fixtures/link-resolution.html
+++ b/cypress/fixtures/link-resolution.html
@@ -11,11 +11,44 @@
     <header class="header">
         <ul>
             <li><a href="./../page-2.html" data-cy="nav-link-rel">Relative link</a></li>
+            <li><a href="./link-resolution.html" data-cy="nav-link-self">Relative link to self</a></li>
             <li><a href="https://example.net/" data-cy="nav-link-ext">External link</a></li>
         </ul>
     </header>
     <main class="wrapper transition-default" id="swup">
         <h1>Link resolution</h1>
+        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+        Alias assumenda consectetur consequatur enim esse incidunt iusto, magnam
+        maxime molestias nisi perferendis perspiciatis quibusdam quos repellat,
+        vel veniam vero voluptate voluptatem.</p>
+        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+        Alias assumenda consectetur consequatur enim esse incidunt iusto, magnam
+        maxime molestias nisi perferendis perspiciatis quibusdam quos repellat,
+        vel veniam vero voluptate voluptatem.</p>
+        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+        Alias assumenda consectetur consequatur enim esse incidunt iusto, magnam
+        maxime molestias nisi perferendis perspiciatis quibusdam quos repellat,
+        vel veniam vero voluptate voluptatem.</p>
+        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+        Alias assumenda consectetur consequatur enim esse incidunt iusto, magnam
+        maxime molestias nisi perferendis perspiciatis quibusdam quos repellat,
+        vel veniam vero voluptate voluptatem.</p>
+        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+        Alias assumenda consectetur consequatur enim esse incidunt iusto, magnam
+        maxime molestias nisi perferendis perspiciatis quibusdam quos repellat,
+        vel veniam vero voluptate voluptatem.</p>
+        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+        Alias assumenda consectetur consequatur enim esse incidunt iusto, magnam
+        maxime molestias nisi perferendis perspiciatis quibusdam quos repellat,
+        vel veniam vero voluptate voluptatem.</p>
+        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+        Alias assumenda consectetur consequatur enim esse incidunt iusto, magnam
+        maxime molestias nisi perferendis perspiciatis quibusdam quos repellat,
+        vel veniam vero voluptate voluptatem.</p>
+        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+        Alias assumenda consectetur consequatur enim esse incidunt iusto, magnam
+        maxime molestias nisi perferendis perspiciatis quibusdam quos repellat,
+        vel veniam vero voluptate voluptatem.</p>
         <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.
         Alias assumenda consectetur consequatur enim esse incidunt iusto, magnam
         maxime molestias nisi perferendis perspiciatis quibusdam quos repellat,

--- a/src/Swup.ts
+++ b/src/Swup.ts
@@ -273,14 +273,11 @@ export default class Swup {
 					this.hooks.callSync('link:self', undefined, () => {
 						switch (this.options.linkToSelf) {
 							case 'scroll':
-								this.scrollToContent();
-								break;
+								return this.scrollToContent();
 							case 'navigate':
-								this.performNavigation(url);
-								break;
+								return this.performNavigation(url);
 							case 'reload':
 								window.location.href = url;
-								break;
 						}
 					});
 				}

--- a/src/Swup.ts
+++ b/src/Swup.ts
@@ -38,8 +38,8 @@ export type Options = {
 	ignoreVisit: (url: string, { el, event }: { el?: Element; event?: Event }) => boolean;
 	/** Selector for links that trigger visits. Default: `'a[href]'` */
 	linkSelector: string;
-	/** How swup handles links to the same page. Default: `ignore` */
-	linkToSelf: 'scroll' | 'navigate' | 'reload' | 'ignore';
+	/** How swup handles links to the same page. Default: `scroll` */
+	linkToSelf: 'scroll' | 'navigate' | 'reload';
 	/** Plugins to register on startup. */
 	plugins: Plugin[];
 	/** Custom headers sent along with fetch requests. */
@@ -58,7 +58,7 @@ const defaults: Options = {
 	containers: ['#swup'],
 	ignoreVisit: (url, { el, event } = {}) => !!el?.closest('[data-no-swup]'),
 	linkSelector: 'a[href]',
-	linkToSelf: 'ignore',
+	linkToSelf: 'scroll',
 	plugins: [],
 	resolveUrl: (url) => url,
 	requestHeaders: {
@@ -280,9 +280,6 @@ export default class Swup {
 								break;
 							case 'reload':
 								window.location.href = url;
-								break;
-							case 'ignore':
-								// do nothing
 								break;
 						}
 					});

--- a/src/Swup.ts
+++ b/src/Swup.ts
@@ -262,14 +262,16 @@ export default class Swup {
 
 			event.preventDefault();
 
-			// Handle links to the same page: with or without hash
+			// Handle links to the same page
 			if (!url || url === from) {
 				if (hash) {
+					// With hash: scroll to anchor
 					this.hooks.callSync('link:anchor', { hash }, () => {
 						updateHistoryRecord(url + hash);
 						this.scrollToContent();
 					});
 				} else {
+					// Without hash: scroll to top or load/reload page
 					this.hooks.callSync('link:self', undefined, () => {
 						switch (this.options.linkToSelf) {
 							case 'scroll':

--- a/src/Swup.ts
+++ b/src/Swup.ts
@@ -38,6 +38,8 @@ export type Options = {
 	ignoreVisit: (url: string, { el, event }: { el?: Element; event?: Event }) => boolean;
 	/** Selector for links that trigger visits. Default: `'a[href]'` */
 	linkSelector: string;
+	/** How swup handles links to the same page. Default: `ignore` */
+	linkToSelf: 'scroll' | 'navigate' | 'reload' | 'ignore';
 	/** Plugins to register on startup. */
 	plugins: Plugin[];
 	/** Custom headers sent along with fetch requests. */
@@ -56,6 +58,7 @@ const defaults: Options = {
 	containers: ['#swup'],
 	ignoreVisit: (url, { el, event } = {}) => !!el?.closest('[data-no-swup]'),
 	linkSelector: 'a[href]',
+	linkToSelf: 'ignore',
 	plugins: [],
 	resolveUrl: (url) => url,
 	requestHeaders: {
@@ -268,7 +271,20 @@ export default class Swup {
 					});
 				} else {
 					this.hooks.callSync('link:self', undefined, () => {
-						this.scrollToContent();
+						switch (this.options.linkToSelf) {
+							case 'scroll':
+								this.scrollToContent();
+								break;
+							case 'navigate':
+								this.performNavigation(url);
+								break;
+							case 'reload':
+								window.location.href = url;
+								break;
+							case 'ignore':
+								// do nothing
+								break;
+						}
 					});
 				}
 				return;


### PR DESCRIPTION
**Description**

- Add a new option to configure how swup handles links to the current page: `linkToSelf`
- Scroll to the top (current behavior and new default), navigate via swup, or let the browser reload
- Added tests for all three options
- Thoughts on the name of the option? Tried to be consistent with the `link:self` hook

```ts
export type Options = {
  /** How swup handles links to the same page. Default: `scroll` */
  linkToSelf: 'scroll' | 'navigate' | 'reload';
};
```

**Checks**

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [x] New or updated tests are included
- [ ] The documentation was updated as required
