### PR TITLE
Don't append the hash if setting `visit.scroll.target` on the fly

### DIFF
--- a/cypress/e2e/main.spec.js
+++ b/cypress/e2e/main.spec.js
@@ -774,6 +774,7 @@ describe('Containers', function () {
 describe('Scrolling', function () {
 	beforeEach(() => {
 		cy.visit('/scrolling-1.html');
+		cy.wrapSwupInstance();
 	});
 
 	it('should scroll to hash element and back to top', function () {
@@ -839,9 +840,8 @@ describe('Scrolling', function () {
 			this.swup.hooks.once('visit:start', (visit) => (visit.scroll.target = '#anchor'));
 		});
 		cy.get('[data-cy=link-to-page]').click();
-		cy.window().should(() => {
-			const urlEndsWithHash = this.swup.getCurrentUrl({ hash: true }).endsWith('#anchor');
-			expect(urlEndsWithHash).to.be.false;
-		});
+		cy.shouldBeAtPage('/scrolling-2.html');
+		cy.shouldHaveH1('Scrolling 2');
+		cy.shouldHaveElementInViewport('[data-cy=anchor]');
 	});
 });

--- a/cypress/e2e/main.spec.js
+++ b/cypress/e2e/main.spec.js
@@ -833,4 +833,15 @@ describe('Scrolling', function () {
 		cy.shouldHaveH1('Scrolling 2');
 		cy.shouldHaveElementInViewport('[data-cy=anchor]');
 	});
+
+	it.only('should not append the hash if changing visit.scroll.target on the fly', function () {
+		cy.window().then(() => {
+			this.swup.hooks.once('visit:start', (visit) => (visit.scroll.target = '#anchor'));
+		});
+		cy.get('[data-cy=link-to-page]').click();
+		cy.window().should(() => {
+			const urlEndsWithHash = this.swup.getCurrentUrl({ hash: true }).endsWith('#anchor');
+			expect(urlEndsWithHash).to.be.false;
+		});
+	});
 });

--- a/cypress/e2e/main.spec.js
+++ b/cypress/e2e/main.spec.js
@@ -880,7 +880,17 @@ describe('Scrolling', function () {
 		cy.shouldHaveElementInViewport('[data-cy=anchor]');
 	});
 
-	it.only('should not append the hash if changing visit.scroll.target on the fly', function () {
+	it('should append the hash if changing visit.to.hash on the fly', function () {
+		cy.window().then(() => {
+			this.swup.hooks.once('visit:start', (visit) => (visit.to.hash = '#anchor'));
+		});
+		cy.get('[data-cy=link-to-page]').click();
+		cy.shouldBeAtPage('/scrolling-2.html#anchor');
+		cy.shouldHaveH1('Scrolling 2');
+		cy.shouldHaveElementInViewport('[data-cy=anchor]');
+	});
+
+	it('should not append the hash if changing visit.scroll.target on the fly', function () {
 		cy.window().then(() => {
 			this.swup.hooks.once('visit:start', (visit) => (visit.scroll.target = '#anchor'));
 		});

--- a/src/Swup.ts
+++ b/src/Swup.ts
@@ -143,7 +143,7 @@ export default class Swup {
 		this.cache = new Cache(this);
 		this.classes = new Classes(this);
 		this.hooks = new Hooks(this);
-		this.visit = this.createVisit({ to: undefined });
+		this.visit = this.createVisit({ to: '' });
 
 		if (!this.checkRequirements()) {
 			return;
@@ -281,7 +281,7 @@ export default class Swup {
 						}
 						switch (action) {
 							case 'navigate':
-								return this.performNavigation(url);
+								return this.performNavigation();
 							case 'scroll':
 							default:
 								return this.scrollToContent();
@@ -297,7 +297,7 @@ export default class Swup {
 			}
 
 			// Finally, proceed with loading the page
-			this.performNavigation(url);
+			this.performNavigation();
 		});
 	}
 
@@ -342,7 +342,7 @@ export default class Swup {
 		// }
 
 		this.hooks.callSync('history:popstate', { event }, () => {
-			this.performNavigation(url);
+			this.performNavigation();
 		});
 	}
 

--- a/src/modules/Visit.ts
+++ b/src/modules/Visit.ts
@@ -26,7 +26,9 @@ export interface VisitFrom {
 
 export interface VisitTo {
 	/** The URL of the next page */
-	url?: string;
+	url: string;
+	/** The hash of the next page */
+	hash?: string;
 	/** The HTML content of the next page */
 	html?: string;
 }
@@ -68,7 +70,7 @@ export interface VisitHistory {
 }
 
 export interface VisitInitOptions {
-	to: string | undefined;
+	to: string;
 	from?: string;
 	hash?: string;
 	animate?: boolean;
@@ -86,7 +88,7 @@ export function createVisit(
 	{
 		to,
 		from = this.currentPageUrl,
-		hash: target,
+		hash,
 		animate = true,
 		animation: name,
 		el,
@@ -97,7 +99,7 @@ export function createVisit(
 ): Visit {
 	return {
 		from: { url: from },
-		to: { url: to },
+		to: { url: to, hash },
 		containers: this.options.containers,
 		animation: {
 			animate,
@@ -117,7 +119,7 @@ export function createVisit(
 		},
 		scroll: {
 			reset,
-			target
+			target: undefined
 		}
 	};
 }

--- a/src/modules/getAnchorElement.ts
+++ b/src/modules/getAnchorElement.ts
@@ -8,7 +8,7 @@ import { escapeCssIdentifier as escape, query } from '../utils.js';
  *
  * @see https://html.spec.whatwg.org/#find-a-potential-indicated-element
  */
-export const getAnchorElement = (hash: string): Element | null => {
+export const getAnchorElement = (hash?: string): Element | null => {
 	if (hash && hash.charAt(0) === '#') {
 		hash = hash.substring(1);
 	}

--- a/src/modules/navigate.ts
+++ b/src/modules/navigate.ts
@@ -29,6 +29,10 @@ export function navigate(
 	options: NavigationOptions & FetchOptions = {},
 	init: Omit<VisitInitOptions, 'to'> = {}
 ) {
+	if (typeof url !== 'string') {
+		throw new Error(`swup.navigate() requires a URL parameter`);
+	}
+
 	// Check if the visit should be ignored
 	if (this.shouldIgnoreVisit(url, { el: init.el, event: init.event })) {
 		window.location.href = url;
@@ -37,7 +41,7 @@ export function navigate(
 
 	const { url: to, hash } = Location.fromUrl(url);
 	this.visit = this.createVisit({ ...init, to, hash });
-	this.performNavigation(to, options);
+	this.performNavigation(options);
 }
 
 /**
@@ -53,15 +57,9 @@ export function navigate(
  */
 export async function performNavigation(
 	this: Swup,
-	url: string,
 	options: NavigationOptions & FetchOptions = {}
 ) {
-	if (typeof url !== 'string') {
-		throw new Error(`swup.navigate() requires a URL parameter`);
-	}
-
 	const { el } = this.visit.trigger;
-	this.visit.to.url = Location.fromUrl(url).url;
 	options.referrer = options.referrer || this.currentPageUrl;
 
 	if (options.animate === false) {
@@ -99,7 +97,7 @@ export async function performNavigation(
 		// Create/update history record if this is not a popstate call or leads to the same URL
 		if (!this.visit.history.popstate) {
 			// Add the hash directly from the trigger element
-			const newUrl = url + (el ? Location.fromElement(el).hash : '');
+			const newUrl = this.visit.to.url + this.visit.to.hash;
 			if (
 				this.visit.history.action === 'replace' ||
 				this.visit.to.url === this.currentPageUrl
@@ -147,7 +145,7 @@ export async function performNavigation(
 
 		// Rewrite `skipPopStateHandling` to redirect manually when `history.go` is processed
 		this.options.skipPopStateHandling = () => {
-			window.location.href = this.visit.to.url as string;
+			window.location.href = this.visit.to.url + this.visit.to.hash;
 			return true;
 		};
 

--- a/src/modules/navigate.ts
+++ b/src/modules/navigate.ts
@@ -97,7 +97,8 @@ export async function performNavigation(
 
 		// Create history record if this is not a popstate call (with or without anchor)
 		if (!this.visit.history.popstate) {
-			const newUrl = url + (this.visit.scroll.target || '');
+			// Add the hash directly from the trigger element
+			const newUrl = url + (el ? Location.fromElement(el).hash : '');
 			if (this.visit.history.action === 'replace') {
 				updateHistoryRecord(newUrl);
 			} else {

--- a/src/modules/scrollToContent.ts
+++ b/src/modules/scrollToContent.ts
@@ -7,14 +7,16 @@ import Swup from '../Swup.js';
 export const scrollToContent = function (this: Swup): boolean {
 	const options: ScrollIntoViewOptions = { behavior: 'auto' };
 	const { target, reset } = this.visit.scroll;
+	const scrollTarget = target || this.visit.to.hash;
+
 	let scrolled = false;
 
-	if (target) {
+	if (scrollTarget) {
 		scrolled = this.hooks.callSync(
 			'scroll:anchor',
-			{ hash: target, options },
+			{ hash: scrollTarget, options },
 			(visit, { hash, options }) => {
-				const anchor = this.getAnchorElement(hash || '');
+				const anchor = this.getAnchorElement(hash);
 				if (anchor) {
 					anchor.scrollIntoView(options);
 				}


### PR DESCRIPTION
Replaces #757 

**Description**

- Uses `visit.to.url + visit.to.hash` for creating history entries
- Ignores `visit.scroll.target` for the history URL
- Scrolls to either `visit.scroll.target` or `visit.to.hash`

**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [x] New or updated tests are included