### PR TITLE
Remove callback for `linkToSelf` option

### DIFF
--- a/cypress/e2e/main.spec.js
+++ b/cypress/e2e/main.spec.js
@@ -378,20 +378,6 @@ describe('Link resolution', function () {
 		});
 	});
 
-	it('should allow callbacks for linkToSelf option', function () {
-		let navigated = false;
-		cy.window().then(() => {
-			this.swup.options.linkToSelf = () => 'navigate';
-			this.swup.hooks.once('visit:start', () => (navigated = true));
-		});
-		cy.scrollTo(0, 200);
-		cy.window().its('scrollY').should('equal', 200);
-		cy.get('[data-cy=nav-link-self]').click();
-		cy.window().its('scrollY').should('equal', 0);
-		cy.window().should(() => {
-			expect(navigated).to.be.true;
-		});
-	});
 });
 
 describe('Redirects', function () {

--- a/src/Swup.ts
+++ b/src/Swup.ts
@@ -39,9 +39,7 @@ export type Options = {
 	/** Selector for links that trigger visits. Default: `'a[href]'` */
 	linkSelector: string;
 	/** How swup handles links to the same page. Default: `scroll` */
-	linkToSelf:
-		| NavigationToSelfAction
-		| ((url: string, { el, event }: { el?: Element; event?: Event }) => NavigationToSelfAction);
+	linkToSelf: NavigationToSelfAction;
 	/** Plugins to register on startup. */
 	plugins: Plugin[];
 	/** Custom headers sent along with fetch requests. */
@@ -275,11 +273,7 @@ export default class Swup {
 				} else {
 					// Without hash: scroll to top or load/reload page
 					this.hooks.callSync('link:self', undefined, () => {
-						let action: NavigationToSelfAction | Function = this.options.linkToSelf;
-						if (typeof action === 'function') {
-							action = action();
-						}
-						switch (action) {
+						switch (this.options.linkToSelf) {
 							case 'navigate':
 								return this.performNavigation();
 							case 'scroll':


### PR DESCRIPTION
**Description**

Remove the callback for the option `linkToSelf`. Remaining options:

```js
export type NavigationToSelfAction = 'scroll' | 'navigate';
```

**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)

**Additional information**

<!--
Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc.
-->
