### PR TITLE
Cache control per visit

### DIFF
--- a/cypress/e2e/main.spec.js
+++ b/cypress/e2e/main.spec.js
@@ -103,19 +103,19 @@ describe('Cache', function () {
 
 	it('should cache pages', function () {
 		this.swup.navigate('/page-2.html');
-		cy.shouldBeAtPage('/page-2.html');
+		cy.shouldBeAtPage('/page-2.html', 'Page 2');
 		cy.shouldHaveCacheEntry('/page-2.html');
 	});
 
 	it('should cache pages from absolute URLs', function () {
 		this.swup.navigate(`${baseUrl}/page-2.html`);
-		cy.shouldBeAtPage('/page-2.html');
+		cy.shouldBeAtPage('/page-2.html', 'Page 2');
 		cy.shouldHaveCacheEntry('/page-2.html');
 	});
 
 	it('should not cache pages for POST requests', function () {
 		this.swup.navigate(`${baseUrl}/page-2.html`, { method: 'POST' });
-		cy.shouldBeAtPage('/page-2.html');
+		cy.shouldBeAtPage('/page-2.html', 'Page 2');
 		cy.shouldNotHaveCacheEntry('/page-2.html');
 	});
 
@@ -128,11 +128,11 @@ describe('Cache', function () {
 		});
 
 		cy.window().then(() => this.swup.navigate('/page-2.html'));
-		cy.shouldBeAtPage('/page-2.html');
+		cy.shouldBeAtPage('/page-2.html', 'Page 2');
 		cy.window().then(() => this.swup.navigate('/page-1.html'));
-		cy.shouldBeAtPage('/page-1.html');
+		cy.shouldBeAtPage('/page-1.html', 'Page 1');
 		cy.window().then(() => this.swup.navigate('/page-2.html'));
-		cy.shouldBeAtPage('/page-2.html');
+		cy.shouldBeAtPage('/page-2.html', 'Page 2');
 		cy.window().should(() => expect(cacheAccessed.read).to.be.false);
 		cy.window().should(() => expect(cacheAccessed.write).to.be.false);
 	});
@@ -146,20 +146,20 @@ describe('Cache', function () {
 
 		// Check disabling completely
 		cy.window().then(() => this.swup.navigate('/page-2.html', { cache: false }));
-		cy.shouldBeAtPage('/page-2.html');
+		cy.shouldBeAtPage('/page-2.html', 'Page 2');
 		cy.window().should(() => expect(cacheAccessed.read['/page-2.html']).to.be.false);
 		cy.window().should(() => expect(cacheAccessed.write['/page-2.html']).to.be.false);
 
 		// Check disabling writes
 		cy.window().then(() => this.swup.navigate('/page-1.html', { cache: { write: false } }));
-		cy.shouldBeAtPage('/page-1.html');
+		cy.shouldBeAtPage('/page-1.html', 'Page 1');
 		cy.window().should(() => expect(cacheAccessed.write['/page-1.html']).to.be.false);
 
 		cy.window().then(() => this.swup.cache.clear());
 
 		// Check disabling reads
 		cy.window().then(() => this.swup.navigate('/page-2.html', { cache: { read: false } }));
-		cy.shouldBeAtPage('/page-2.html');
+		cy.shouldBeAtPage('/page-2.html', 'Page 2');
 		cy.window().should(() => expect(cacheAccessed.read['/page-2.html']).to.be.false);
 		cy.window().should(() => expect(cacheAccessed.write['/page-2.html']).to.be.true);
 	});
@@ -176,18 +176,18 @@ describe('Cache', function () {
 			this.swup.hooks.once('visit:start', (visit) => visit.cache.write = false);
 			this.swup.navigate('/page-2.html');
 		});
-		cy.shouldBeAtPage('/page-2.html');
+		cy.shouldBeAtPage('/page-2.html', 'Page 2');
 		cy.window().should(() => expect(cacheAccessed.write['/page-2.html']).to.be.false);
 
 		cy.window().then(() => this.swup.navigate('/page-1.html'));
-		cy.shouldBeAtPage('/page-1.html');
+		cy.shouldBeAtPage('/page-1.html', 'Page 1');
 		cy.window().then(() => this.swup.navigate('/page-2.html'));
-		cy.shouldBeAtPage('/page-2.html');
+		cy.shouldBeAtPage('/page-2.html', 'Page 2');
 
 		// Check disabling reads
 		cy.window().then(() => {
 			this.swup.hooks.once('visit:start', (visit) => visit.cache.read = false);
-			this.swup.navigate('/page-1.html');
+			this.swup.navigate('/page-1.html', 'Page 1');
 		});
 		cy.shouldBeAtPage('/page-1.html');
 		cy.window().should(() => expect(cacheAccessed.read['/page-1.html']).to.be.false);
@@ -195,19 +195,19 @@ describe('Cache', function () {
 
 	// Passes locally, but not in CI. TODO: investigate
 
-	// it('should mark pages as cached in page:load', function () {
-	// 	let cached = null;
-	// 	this.swup.hooks.on('page:load', (visit, { cache }) => cached = cache);
+	it('should mark pages as cached in page:load', function () {
+		let cached = null;
+		this.swup.hooks.on('page:load', (visit, { cache }) => cached = cache);
 
-	// 	cy.window().then(() => this.swup.navigate('/page-2.html'));
-	// 	cy.shouldBeAtPage('/page-2.html');
-	// 	cy.window().should(() => expect(cached).to.be.false);
-	// 	cy.window().then(() => this.swup.navigate('/page-1.html'));
-	// 	cy.shouldBeAtPage('/page-1.html');
-	// 	cy.window().then(() => this.swup.navigate('/page-2.html'));
-	// 	cy.shouldBeAtPage('/page-2.html');
-	// 	cy.window().should(() => expect(cached).to.be.true);
-	// });
+		cy.window().then(() => this.swup.navigate('/page-2.html'));
+		cy.shouldBeAtPage('/page-2.html', 'Page 2');
+		cy.window().should(() => expect(cached).to.be.false);
+		cy.window().then(() => this.swup.navigate('/page-1.html'));
+		cy.shouldBeAtPage('/page-1.html', 'Page 1');
+		cy.window().then(() => this.swup.navigate('/page-2.html'));
+		cy.shouldBeAtPage('/page-2.html', 'Page 2');
+		cy.window().should(() => expect(cached).to.be.true);
+	});
 });
 
 describe('Markup', function () {

--- a/cypress/e2e/main.spec.js
+++ b/cypress/e2e/main.spec.js
@@ -113,6 +113,12 @@ describe('Cache', function () {
 		cy.shouldHaveCacheEntry('/page-2.html');
 	});
 
+	it('should not cache pages for POST requests', function () {
+		this.swup.navigate(`${baseUrl}/page-2.html`, { method: 'POST' });
+		cy.shouldBeAtPage('/page-2.html');
+		cy.shouldNotHaveCacheEntry('/page-2.html');
+	});
+
 	it('should disable cache from swup options', function () {
 		const cacheAccessed = { read: null, write: null };
 		this.swup.options.cache = false;

--- a/cypress/e2e/main.spec.js
+++ b/cypress/e2e/main.spec.js
@@ -113,21 +113,91 @@ describe('Cache', function () {
 		cy.shouldHaveCacheEntry('/page-2.html');
 	});
 
+	it('should disable cache from swup options', function () {
+		const cacheAccessed = { read: null, write: null };
+		this.swup.options.cache = false;
+		this.swup.hooks.on('page:load', (visit, { cache }) => {
+			cacheAccessed.read = cache;
+			cacheAccessed.write = this.swup.cache.has(visit.to.url);
+		});
+
+		cy.window().then(() => this.swup.navigate('/page-2.html'));
+		cy.shouldBeAtPage('/page-2.html');
+		cy.window().then(() => this.swup.navigate('/page-1.html'));
+		cy.shouldBeAtPage('/page-1.html');
+		cy.window().then(() => this.swup.navigate('/page-2.html'));
+		cy.shouldBeAtPage('/page-2.html');
+		cy.window().should(() => expect(cacheAccessed.read).to.be.false);
+		cy.window().should(() => expect(cacheAccessed.write).to.be.false);
+	});
+
+	it('should disable cache from navigation options', function () {
+		const cacheAccessed = { read: {}, write: {} };
+		this.swup.hooks.on('page:load', (visit, { cache }) => {
+			cacheAccessed.read[visit.to.url] = cache;
+			cacheAccessed.write[visit.to.url] = this.swup.cache.has(visit.to.url);
+		});
+
+		// Check disabling completely
+		cy.window().then(() => this.swup.navigate('/page-2.html', { cache: false }));
+		cy.shouldBeAtPage('/page-2.html');
+		cy.window().should(() => expect(cacheAccessed.read['/page-2.html']).to.be.false);
+		cy.window().should(() => expect(cacheAccessed.write['/page-2.html']).to.be.false);
+
+		// Check disabling writes
+		cy.window().then(() => this.swup.navigate('/page-1.html', { cache: { write: false } }));
+		cy.shouldBeAtPage('/page-1.html');
+		cy.window().should(() => expect(cacheAccessed.write['/page-1.html']).to.be.false);
+
+		cy.window().then(() => this.swup.cache.clear());
+
+		// Check disabling reads
+		cy.window().then(() => this.swup.navigate('/page-2.html', { cache: { read: false } }));
+		cy.shouldBeAtPage('/page-2.html');
+		cy.window().should(() => expect(cacheAccessed.read['/page-2.html']).to.be.false);
+		cy.window().should(() => expect(cacheAccessed.write['/page-2.html']).to.be.true);
+	});
+
+	it('should disable cache in visit object', function () {
+		const cacheAccessed = { read: {}, write: {} };
+		this.swup.hooks.on('page:load', (visit, { cache }) => {
+			cacheAccessed.read[visit.to.url] = cache;
+			cacheAccessed.write[visit.to.url] = this.swup.cache.has(visit.to.url);
+		});
+
+		// Check disabling writes
+		cy.window().then(() => {
+			this.swup.hooks.once('visit:start', (visit) => visit.cache.write = false);
+			this.swup.navigate('/page-2.html');
+		});
+		cy.shouldBeAtPage('/page-2.html');
+		cy.window().should(() => expect(cacheAccessed.write['/page-2.html']).to.be.false);
+
+		cy.window().then(() => this.swup.navigate('/page-1.html'));
+		cy.shouldBeAtPage('/page-1.html');
+		cy.window().then(() => this.swup.navigate('/page-2.html'));
+		cy.shouldBeAtPage('/page-2.html');
+
+		// Check disabling reads
+		cy.window().then(() => {
+			this.swup.hooks.once('visit:start', (visit) => visit.cache.read = false);
+			this.swup.navigate('/page-1.html');
+		});
+		cy.shouldBeAtPage('/page-1.html');
+		cy.window().should(() => expect(cacheAccessed.read['/page-1.html']).to.be.false);
+	});
+
 	// Passes locally, but not in CI. TODO: investigate
 
 	// it('should mark pages as cached in page:load', function () {
 	// 	let cached = null;
-	// 	this.swup.hooks.on('page:load', (visit, { cache }) => {
-	// 		cached = cache;
-	// 	});
+	// 	this.swup.hooks.on('page:load', (visit, { cache }) => cached = cache);
 
 	// 	cy.window().then(() => this.swup.navigate('/page-2.html'));
 	// 	cy.shouldBeAtPage('/page-2.html');
 	// 	cy.window().should(() => expect(cached).to.be.false);
-
 	// 	cy.window().then(() => this.swup.navigate('/page-1.html'));
 	// 	cy.shouldBeAtPage('/page-1.html');
-
 	// 	cy.window().then(() => this.swup.navigate('/page-2.html'));
 	// 	cy.shouldBeAtPage('/page-2.html');
 	// 	cy.window().should(() => expect(cached).to.be.true);

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -36,10 +36,13 @@ Cypress.Commands.add('triggerClickOnLink', (buttonHref, options = {}) => {
 		.click(options);
 });
 
-Cypress.Commands.add('shouldBeAtPage', (href) => {
+Cypress.Commands.add('shouldBeAtPage', (href, h1 = null) => {
 	cy.location().should((loc) => {
 		expect(loc.pathname + loc.hash).to.eq(href);
 	});
+	if (h1) {
+		cy.shouldHaveH1(h1);
+	}
 });
 
 Cypress.Commands.add('shouldHaveCacheEntries', (urls) => {

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -52,12 +52,23 @@ Cypress.Commands.add('shouldHaveCacheEntries', (urls) => {
 
 Cypress.Commands.add('shouldHaveCacheEntry', (url) => {
 	cy.window().should((window) => {
+		expect(url).to.be.a('string');
 		const { cache } = window._swup;
 		const exists = cache.has(url);
 		const page = cache.get(url);
-		expect(url).to.be.a('string');
 		expect(exists).to.be.true;
 		expect(page).not.to.be.undefined;
+	});
+});
+
+Cypress.Commands.add('shouldNotHaveCacheEntry', (url) => {
+	cy.window().should((window) => {
+		expect(url).to.be.a('string');
+		const { cache } = window._swup;
+		const exists = cache.has(url);
+		const page = cache.get(url);
+		expect(exists).to.be.false;
+		expect(page).to.be.undefined;
 	});
 });
 

--- a/src/modules/Visit.ts
+++ b/src/modules/Visit.ts
@@ -13,6 +13,8 @@ export interface Visit {
 	animation: VisitAnimation;
 	/** What triggered this visit */
 	trigger: VisitTrigger;
+	/** Cache behavior for this visit */
+	cache: VisitCache;
 	/** Browser history behavior on this visit */
 	history: VisitHistory;
 	/** Scroll behavior on this visit */
@@ -58,6 +60,13 @@ export interface VisitTrigger {
 	el?: Element;
 	/** DOM event that triggered this visit. */
 	event?: Event;
+}
+
+export interface VisitCache {
+	/** Whether this visit will try to load the requested page from cache. */
+	read: boolean;
+	/** Whether this visit will save the loaded page in cache. */
+	write: boolean;
 }
 
 export interface VisitHistory {
@@ -111,6 +120,10 @@ export function createVisit(
 		trigger: {
 			el,
 			event
+		},
+		cache: {
+			read: this.options.cache,
+			write: this.options.cache
 		},
 		history: {
 			action,

--- a/src/modules/fetchPage.ts
+++ b/src/modules/fetchPage.ts
@@ -16,9 +16,9 @@ export interface FetchOptions extends RequestInit {
 	/** The body of the request: raw string, form data object or URL params. */
 	body?: string | FormData | URLSearchParams;
 	/** Whether this request should ignore existing cache entries. */
-	bypassCache?: boolean;
-	/** Whether the response should be kept out of the cache.  */
-	skipCacheSave?: boolean;
+	cacheBypass?: boolean;
+	/** Whether the response should be kept out of to the cache.  */
+	cacheSkipSave?: boolean;
 }
 
 export class FetchError extends Error {

--- a/src/modules/fetchPage.ts
+++ b/src/modules/fetchPage.ts
@@ -15,8 +15,10 @@ export interface FetchOptions extends RequestInit {
 	method?: 'GET' | 'POST';
 	/** The body of the request: raw string, form data object or URL params. */
 	body?: string | FormData | URLSearchParams;
-	/** The headers of the request: key/value object. */
-	headers?: Record<string, string>;
+	/** Whether this request should ignore existing cache entries. */
+	bypassCache?: boolean;
+	/** Whether the response should be kept out of the cache.  */
+	skipCacheSave?: boolean;
 }
 
 export class FetchError extends Error {
@@ -65,11 +67,6 @@ export async function fetchPage(
 	// Resolve real url after potential redirect
 	const { url: finalUrl } = Location.fromUrl(responseUrl);
 	const page = { url: finalUrl, html };
-
-	// Only save cache entry for non-redirects
-	if (url === finalUrl) {
-		this.cache.set(page.url, page);
-	}
 
 	return page;
 }

--- a/src/modules/fetchPage.ts
+++ b/src/modules/fetchPage.ts
@@ -15,10 +15,6 @@ export interface FetchOptions extends Omit<RequestInit, 'cache'> {
 	method?: 'GET' | 'POST';
 	/** The body of the request: raw string, form data object or URL params. */
 	body?: string | FormData | URLSearchParams;
-	/** Whether this request should ignore existing cache entries. */
-	cacheBypass?: boolean;
-	/** Whether the response should be kept out of to the cache.  */
-	cacheSkipSave?: boolean;
 }
 
 export class FetchError extends Error {
@@ -67,6 +63,11 @@ export async function fetchPage(
 	// Resolve real url after potential redirect
 	const { url: finalUrl } = Location.fromUrl(responseUrl);
 	const page = { url: finalUrl, html };
+
+	// Write to cache for non-redirects
+	if (this.visit.cache.write && url === finalUrl) {
+		this.cache.set(page.url, page);
+	}
 
 	return page;
 }

--- a/src/modules/fetchPage.ts
+++ b/src/modules/fetchPage.ts
@@ -64,8 +64,12 @@ export async function fetchPage(
 	const { url: finalUrl } = Location.fromUrl(responseUrl);
 	const page = { url: finalUrl, html };
 
-	// Write to cache for non-redirects
-	if (this.visit.cache.write && url === finalUrl) {
+	// Write to cache for safe methods and non-redirects
+	if (
+		this.visit.cache.write &&
+		(!options.method || options.method === 'GET') &&
+		url === finalUrl
+	) {
 		this.cache.set(page.url, page);
 	}
 

--- a/src/modules/fetchPage.ts
+++ b/src/modules/fetchPage.ts
@@ -10,7 +10,7 @@ export interface PageData {
 }
 
 /** Define how a page is fetched. */
-export interface FetchOptions extends RequestInit {
+export interface FetchOptions extends Omit<RequestInit, 'cache'> {
 	/** The request method. */
 	method?: 'GET' | 'POST';
 	/** The body of the request: raw string, form data object or URL params. */

--- a/src/modules/navigate.ts
+++ b/src/modules/navigate.ts
@@ -6,6 +6,7 @@ import { VisitInitOptions } from './Visit.js';
 export type HistoryAction = 'push' | 'replace';
 export type HistoryDirection = 'forwards' | 'backwards';
 export type NavigationToSelfAction = 'scroll' | 'navigate';
+export type CacheControl = boolean | Partial<{ read: boolean; write: boolean }>;
 
 /** Define how to navigate to a page. */
 type NavigationOptions = {
@@ -15,6 +16,8 @@ type NavigationOptions = {
 	animation?: string;
 	/** History action to perform: `push` for creating a new history entry, `replace` for replacing the current entry. Default: `push` */
 	history?: HistoryAction;
+	/** Whether this visit should read from or write to the cache. */
+	cache?: CacheControl;
 };
 
 /**
@@ -83,24 +86,27 @@ export async function performNavigation(
 		this.visit.animation.name = animation;
 	}
 
+	// Sanitize cache option
+	if (typeof options.cache === 'boolean') {
+		this.visit.cache = { read: options.cache, write: options.cache };
+	} else if (typeof options.cache === 'object') {
+		this.visit.cache.read = options.cache.read ?? this.visit.cache.read;
+		this.visit.cache.write = options.cache.write ?? this.visit.cache.write;
+	}
+
 	try {
 		await this.hooks.call('visit:start');
 
 		// Begin loading page
 		const pagePromise = this.hooks.call('page:load', { options }, async (visit, args) => {
-			// Check cache for page
+			// Read from cache
 			let cachedPage: PageData | undefined;
-			if (!options.cacheBypass) {
+			if (this.visit.cache.read) {
 				cachedPage = this.cache.get(visit.to.url);
 			}
 
 			args.page = cachedPage || (await this.fetchPage(visit.to.url!, args.options));
 			args.cache = !!cachedPage;
-
-			// Only save cache entry for non-redirects
-			if (visit.to.url === page.url && !options.cacheSkipSave) {
-				this.cache.set(page.url, args.page);
-			}
 
 			return args.page;
 		});

--- a/src/modules/navigate.ts
+++ b/src/modules/navigate.ts
@@ -90,7 +90,7 @@ export async function performNavigation(
 	if (typeof options.cache === 'object') {
 		this.visit.cache.read = options.cache.read ?? this.visit.cache.read;
 		this.visit.cache.write = options.cache.write ?? this.visit.cache.write;
-	} else {
+	} else if (options.cache !== undefined) {
 		this.visit.cache = { read: !!options.cache, write: !!options.cache };
 	}
 	// Delete this so that window.fetch doesn't mis-interpret it

--- a/src/modules/navigate.ts
+++ b/src/modules/navigate.ts
@@ -90,15 +90,15 @@ export async function performNavigation(
 		const pagePromise = this.hooks.call('page:load', { options }, async (visit, args) => {
 			// Check cache for page
 			let cachedPage: PageData | undefined;
-			if (!options.bypassCache) {
-				cachedPage = this.cache.get(visit.to.url!);
+			if (!options.cacheBypass) {
+				cachedPage = this.cache.get(visit.to.url);
 			}
 
 			args.page = cachedPage || (await this.fetchPage(visit.to.url!, args.options));
 			args.cache = !!cachedPage;
 
 			// Only save cache entry for non-redirects
-			if (visit.to.url === page.url && !options.skipCacheSave) {
+			if (visit.to.url === page.url && !options.cacheSkipSave) {
 				this.cache.set(page.url, args.page);
 			}
 

--- a/src/modules/navigate.ts
+++ b/src/modules/navigate.ts
@@ -93,6 +93,8 @@ export async function performNavigation(
 		this.visit.cache.read = options.cache.read ?? this.visit.cache.read;
 		this.visit.cache.write = options.cache.write ?? this.visit.cache.write;
 	}
+	// Delete this so that window.fetch doesn't mis-interpret it
+	delete options.cache;
 
 	try {
 		await this.hooks.call('visit:start');

--- a/src/modules/navigate.ts
+++ b/src/modules/navigate.ts
@@ -6,7 +6,7 @@ import { VisitInitOptions } from './Visit.js';
 export type HistoryAction = 'push' | 'replace';
 export type HistoryDirection = 'forwards' | 'backwards';
 export type NavigationToSelfAction = 'scroll' | 'navigate';
-export type CacheControl = boolean | Partial<{ read: boolean; write: boolean }>;
+export type CacheControl = Partial<{ read: boolean; write: boolean }>;
 
 /** Define how to navigate to a page. */
 type NavigationOptions = {
@@ -87,11 +87,11 @@ export async function performNavigation(
 	}
 
 	// Sanitize cache option
-	if (typeof options.cache === 'boolean') {
-		this.visit.cache = { read: options.cache, write: options.cache };
-	} else if (typeof options.cache === 'object') {
+	if (typeof options.cache === 'object') {
 		this.visit.cache.read = options.cache.read ?? this.visit.cache.read;
 		this.visit.cache.write = options.cache.write ?? this.visit.cache.write;
+	} else {
+		this.visit.cache = { read: !!options.cache, write: !!options.cache };
 	}
 	// Delete this so that window.fetch doesn't mis-interpret it
 	delete options.cache;

--- a/src/modules/renderPage.ts
+++ b/src/modules/renderPage.ts
@@ -52,9 +52,4 @@ export const renderPage = async function (this: Swup, requestedUrl: string, page
 	});
 
 	await this.hooks.call('page:view', { url: this.currentPageUrl, title: document.title });
-
-	// empty cache if it's disabled (in case preload plugin filled it)
-	if (!this.options.cache) {
-		this.cache.clear();
-	}
 };


### PR DESCRIPTION
**Description**

- Store cache settings in visit object: `{ read: true, write: true }`
- Add cache option to `swup.navigate`:  `{ read?: true, write?: true }`
- Only cache responses of `GET` requests
- Increases bundle size by 100 bytes

**Drive-by changes**

- Remove `this.cache.clear()` from `renderPage` as it was meant for Preload Plugin which now requires the cache

**Checks**

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [x] New or updated tests are included
- [ ] The documentation was updated as required

**Additional information**

Closes #763 