### PR TITLE
Feature: persist elements across page loads

### DIFF
--- a/cypress/e2e/main.spec.js
+++ b/cypress/e2e/main.spec.js
@@ -878,6 +878,29 @@ describe('Containers', function () {
 	});
 });
 
+describe.only('Persist', function () {
+	beforeEach(() => {
+		cy.visit('/persist-1.html');
+		cy.wrapSwupInstance();
+	});
+
+	it('should persist elements across page loads', function () {
+		let state = Math.random();
+		let newState = Math.random();
+		cy.get('[data-cy="persisted"]').then(($el) => {
+			$el[0].__state = state;
+			this.swup.navigate('/persist-2.html', { animate: false });
+		});
+		cy.shouldBeAtPage('/persist-2.html', 'Persist 2');
+		cy.get('[data-cy="persisted"]').should('contain', 'Persist 1');
+		cy.get('[data-cy="unpersisted"]').should('contain', 'Persist 2');
+		cy.get('[data-cy="persisted"]').then(($el) => {
+			newState = $el[0].__state;
+			expect(state).to.eq(newState);
+		});
+	});
+});
+
 describe('Scrolling', function () {
 	beforeEach(() => {
 		cy.visit('/scrolling-1.html');

--- a/cypress/e2e/main.spec.js
+++ b/cypress/e2e/main.spec.js
@@ -878,7 +878,7 @@ describe('Containers', function () {
 	});
 });
 
-describe.only('Persist', function () {
+describe('Persist', function () {
 	beforeEach(() => {
 		cy.visit('/persist-1.html');
 		cy.wrapSwupInstance();

--- a/cypress/fixtures/persist-1.html
+++ b/cypress/fixtures/persist-1.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Persist 1</title>
+    <link rel="stylesheet" href="/assets/main.css">
+    <script src="/dist/Swup.umd.js"></script>
+</head>
+<body>
+    <header class="header">
+        <ul>
+            <li><a href="/persist-1.html">Page 1</a></li>
+            <li><a href="/persist-2.html">Page 2</a></li>
+        </ul>
+    </header>
+    <main id="swup" class="wrapper transition-default" data-cy="container">
+        <div class="wrapper-inner">
+            <h1>Persist 1</h1>
+            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+            Alias assumenda consectetur consequatur enim esse incidunt iusto, magnam
+            maxime molestias nisi perferendis perspiciatis quibusdam quos repellat,
+            vel veniam vero voluptate voluptatem.</p>
+            <p data-cy="unpersisted">Persist 1</p>
+            <p data-cy="persisted" data-swup-persist="paragraph">Persist 1</p>
+        </div>
+    </main>
+    <script>
+        window._swup = new Swup();
+    </script>
+</body>
+</html>

--- a/cypress/fixtures/persist-2.html
+++ b/cypress/fixtures/persist-2.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Persist 2</title>
+    <link rel="stylesheet" href="/assets/main.css">
+    <script src="/dist/Swup.umd.js"></script>
+</head>
+<body>
+    <header class="header">
+        <ul>
+            <li><a href="/persist-1.html">Page 1</a></li>
+            <li><a href="/persist-2.html">Page 2</a></li>
+        </ul>
+    </header>
+    <main id="swup" class="wrapper transition-default" data-cy="container">
+        <div class="wrapper-inner">
+            <h1>Persist 2</h1>
+            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+            Alias assumenda consectetur consequatur enim esse incidunt iusto, magnam
+            maxime molestias nisi perferendis perspiciatis quibusdam quos repellat,
+            vel veniam vero voluptate voluptatem.</p>
+            <p data-cy="unpersisted">Persist 2</p>
+            <p data-cy="persisted" data-swup-persist="paragraph">Persist 2</p>
+        </div>
+    </main>
+    <script>
+        window._swup = new Swup();
+    </script>
+</body>
+</html>

--- a/src/modules/replaceContent.ts
+++ b/src/modules/replaceContent.ts
@@ -22,7 +22,7 @@ export const replaceContent = function (
 	document.title = title;
 
 	// Save persisted elements
-	const persistedElements = queryAll('[data-swup-persist]');
+	const persistedElements = queryAll('[data-swup-persist]:not([data-swup-persist=""])');
 
 	// Update content containers
 	const replaced = containers
@@ -47,7 +47,7 @@ export const replaceContent = function (
 	persistedElements.forEach((existing) => {
 		const key = existing.getAttribute('data-swup-persist');
 		const replacement = query(`[data-swup-persist="${key}"]`);
-		if (replacement) {
+		if (replacement && replacement !== existing) {
 			replacement.replaceWith(existing);
 		}
 	});

--- a/src/modules/replaceContent.ts
+++ b/src/modules/replaceContent.ts
@@ -1,4 +1,5 @@
 import Swup, { Options } from '../Swup.js';
+import { query, queryAll } from '../utils.js';
 import { PageData } from './fetchPage.js';
 
 /**
@@ -20,6 +21,9 @@ export const replaceContent = function (
 	const title = incomingDocument.querySelector('title')?.innerText || '';
 	document.title = title;
 
+	// Save persisted elements
+	const persistedElements = queryAll('[data-swup-persist]');
+
 	// Update content containers
 	const replaced = containers
 		.map((selector) => {
@@ -38,6 +42,15 @@ export const replaceContent = function (
 			return false;
 		})
 		.filter(Boolean);
+
+	// Restore persisted elements
+	persistedElements.forEach((existing) => {
+		const key = existing.getAttribute('data-swup-persist');
+		const replacement = query(`[data-swup-persist="${key}"]`);
+		if (replacement) {
+			replacement.replaceWith(existing);
+		}
+	});
 
 	return replaced.length === containers.length;
 };


### PR DESCRIPTION
**Description**

- Assign a `data-swup-persist` attribute to persist elements across page loads
- Keep element content, state and events regardless of incoming page content
- Use case: autoplay videos, animations, countdown
- This is technically already possible by having elements outside of any container
  - However, sometimes a persistent element needs to be inside a replaced container
  - e.g. a countdown inside of a replaced sidebar, or an animated logo inside a replaced header
- I thought this was a good plugin idea, but it comes in at just 60 bytes 🥳

**Example**

```html
<video src="/video.mp4" autoplay loop data-swup-persist="unique-video-key">
```

**Before**

https://github.com/swup/swup/assets/22225348/27661f6f-c38e-4d68-be8d-74bc277ef2db

**After**

https://github.com/swup/swup/assets/22225348/03bad0b6-cba2-4ec1-9492-9edd9f545b55

**Checks**

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [x] New or updated tests are included
- [ ] The documentation was updated as required
