### PR TITLE
Fix scroll restoration

### DIFF
--- a/src/Swup.ts
+++ b/src/Swup.ts
@@ -331,6 +331,7 @@ export default class Swup {
 		// Disable animation & scrolling for history visits
 		this.visit.animation.animate = false;
 		this.visit.scroll.reset = false;
+		this.visit.scroll.target = false;
 
 		// Animated history visit: re-enable animation & scroll reset
 		if (this.options.animateHistoryBrowsing) {

--- a/src/Swup.ts
+++ b/src/Swup.ts
@@ -315,18 +315,10 @@ export default class Swup {
 		}
 
 		const { url, hash } = Location.fromUrl(href);
-		const animate = this.options.animateHistoryBrowsing;
-		const resetScroll = this.options.animateHistoryBrowsing;
 
-		this.visit = this.createVisit({
-			to: url,
-			hash,
-			event,
-			animate,
-			resetScroll
-		});
+		this.visit = this.createVisit({ to: url, hash, event });
 
-		// Mark as popstate visit
+		// Mark as history visit
 		this.visit.history.popstate = true;
 
 		// Determine direction of history visit
@@ -334,6 +326,16 @@ export default class Swup {
 		if (index) {
 			const direction = index - this.currentHistoryIndex > 0 ? 'forwards' : 'backwards';
 			this.visit.history.direction = direction;
+		}
+
+		// Disable animation & scrolling for history visits
+		this.visit.animation.animate = false;
+		this.visit.scroll.reset = false;
+
+		// Animated history visit: re-enable animation & scroll reset
+		if (this.options.animateHistoryBrowsing) {
+			this.visit.animation.animate = true;
+			this.visit.scroll.reset = true;
 		}
 
 		// Does this even do anything?

--- a/src/Swup.ts
+++ b/src/Swup.ts
@@ -167,6 +167,11 @@ export default class Swup {
 
 		window.addEventListener('popstate', this.handlePopState);
 
+		// Set scroll restoration to manual if animating history visits
+		if (this.options.animateHistoryBrowsing) {
+			window.history.scrollRestoration = 'manual';
+		}
+
 		// Initial save to cache
 		if (this.options.cache) {
 			// Disabled to avoid caching modified dom state: logic moved to preload plugin

--- a/src/modules/Visit.ts
+++ b/src/modules/Visit.ts
@@ -52,7 +52,7 @@ export interface VisitScroll {
 	/** Whether to reset the scroll position after the visit. Default: `true` */
 	reset: boolean;
 	/** Anchor element to scroll to on the next page. */
-	target?: string;
+	target?: string | false;
 }
 
 export interface VisitTrigger {

--- a/src/modules/Visit.ts
+++ b/src/modules/Visit.ts
@@ -82,38 +82,23 @@ export interface VisitInitOptions {
 	to: string;
 	from?: string;
 	hash?: string;
-	animate?: boolean;
-	animation?: string;
-	targets?: string[];
 	el?: Element;
 	event?: Event;
-	action?: HistoryAction;
-	resetScroll?: boolean;
 }
 
 /** Create a new visit object. */
 export function createVisit(
 	this: Swup,
-	{
-		to,
-		from = this.currentPageUrl,
-		hash,
-		animate = true,
-		animation: name,
-		el,
-		event,
-		action = 'push',
-		resetScroll: reset = true
-	}: VisitInitOptions
+	{ to, from = this.currentPageUrl, hash, el, event }: VisitInitOptions
 ): Visit {
 	return {
 		from: { url: from },
 		to: { url: to, hash },
 		containers: this.options.containers,
 		animation: {
-			animate,
+			animate: true,
 			wait: false,
-			name,
+			name: undefined,
 			scope: this.options.animationScope,
 			selector: this.options.animationSelector
 		},
@@ -126,12 +111,12 @@ export function createVisit(
 			write: this.options.cache
 		},
 		history: {
-			action,
+			action: 'push',
 			popstate: false,
 			direction: undefined
 		},
 		scroll: {
-			reset,
+			reset: true,
 			target: undefined
 		}
 	};

--- a/src/modules/scrollToContent.ts
+++ b/src/modules/scrollToContent.ts
@@ -7,7 +7,7 @@ import Swup from '../Swup.js';
 export const scrollToContent = function (this: Swup): boolean {
 	const options: ScrollIntoViewOptions = { behavior: 'auto' };
 	const { target, reset } = this.visit.scroll;
-	const scrollTarget = target || this.visit.to.hash;
+	const scrollTarget = target ?? this.visit.to.hash;
 
 	let scrolled = false;
 


### PR DESCRIPTION
Fix two issues with scrolling.

**1: Scroll restoration**

Make sure the browser doesn't try to restore scroll positions when animating history visits by conditionally setting `history.scrollRestoration = 'manual'`. This was already in the Scroll Plugin, but is required in swup as well to avoid a flash of scrolled-down content before swup resets it to the top.

Before:

https://github.com/swup/swup/assets/22225348/1ff34a7a-9d07-4cd1-9ea9-aefb3ef66dfb

After:

https://github.com/swup/swup/assets/22225348/6ff8b0bd-65e6-43e4-b007-2d9b30a9cf15

**2: Scroll targets on history visits**

The recent addition of `visit.to.hash` had a flaw on history visits: when going back to a page with a `#hash` in the URL, the browser would first restore the previous scroll position, then scroll to the anchor element. Solved by allowing boolean `false` in `visit.scroll.target` and disabling it in the popstate handler. The scroll target will now be ignored on history visits.

**Other changes**

Simplified the surface of the object passed into `createVisit` — most keys are only needed once, so it makes more sense to keep the most common keys (from, to, hash, el, event) and just set any others directly after creating the visit by doing `this.visit.x = y`. Not breaking since only used internally and in no plugins.

**Checks**

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [ ] ~~New or updated tests are included~~
- [ ] ~~The documentation was updated as required~~
