### PR TITLE
Fix history index

### DIFF
--- a/cypress/e2e/main.spec.js
+++ b/cypress/e2e/main.spec.js
@@ -701,12 +701,8 @@ describe('History', function () {
 		cy.triggerClickOnLink('/page-2.html');
 		cy.shouldBeAtPage('/page-2.html');
 
-		cy.window().then((window) => {
-			window.history.back();
-		});
-		cy.window().should(() => {
-			expect(handlers.popstate).to.be.called;
-		});
+		cy.window().then((window) => window.history.back());
+		cy.window().should(() => expect(handlers.popstate).to.be.called);
 	});
 
 	it('should skip popstate handling for foreign state entries', function () {
@@ -799,9 +795,7 @@ describe('Visit context', function () {
 			this.swup.navigate('/page-2.html');
 		});
 		cy.shouldBeAtPage('/page-2.html');
-		cy.window().then((window) => {
-			window.history.back();
-		});
+		cy.window().then((window) => window.history.back());
 		cy.shouldBeAtPage('/page-1.html');
 		cy.window().should((win) => {
 			expect(event).to.be.instanceof(win.PopStateEvent);

--- a/cypress/e2e/main.spec.js
+++ b/cypress/e2e/main.spec.js
@@ -675,33 +675,21 @@ describe('History', function () {
 		});
 
 		cy.triggerClickOnLink('/page-2.html');
-		cy.shouldBeAtPage('/page-2.html');
+		cy.shouldBeAtPage('/page-2.html', 'Page 2');
 
-		cy.window().then((window) => {
-			window.history.back();
-			cy.window().should(() => {
-				expect(direction).to.equal('backwards');
-			});
-		});
+		cy.window().then((window) => window.history.back());
+		cy.window().should(() => expect(direction).to.equal('backwards'));
 
-		cy.shouldBeAtPage('/page-1.html');
+		cy.shouldBeAtPage('/page-1.html', 'Page 1');
 
-		cy.window().then((window) => {
-			window.history.forward();
-			cy.window().should(() => {
-				expect(direction).to.equal('forwards');
-			});
-		});
+		cy.window().then((window) => window.history.forward());
+		cy.window().should(() => expect(direction).to.equal('forwards'));
 
 		cy.triggerClickOnLink('/page-3.html');
-		cy.shouldBeAtPage('/page-3.html');
+		cy.shouldBeAtPage('/page-3.html', 'Page 3');
 
-		cy.window().then((window) => {
-			window.history.go(-2);
-			cy.window().should(() => {
-				expect(direction).to.equal('backwards');
-			});
-		});
+		cy.window().then((window) => window.history.go(-2));
+		cy.window().should(() => expect(direction).to.equal('backwards'));
 	});
 
 	it('should trigger a custom popstate event', function () {

--- a/src/Swup.ts
+++ b/src/Swup.ts
@@ -328,7 +328,7 @@ export default class Swup {
 
 		// Determine direction of history visit
 		const index = (event.state as HistoryState)?.index ?? 0;
-		if (index) {
+		if (index && index !== this.currentHistoryIndex) {
 			const direction = index - this.currentHistoryIndex > 0 ? 'forwards' : 'backwards';
 			this.visit.history.direction = direction;
 			this.currentHistoryIndex = index;

--- a/src/Swup.ts
+++ b/src/Swup.ts
@@ -183,8 +183,10 @@ export default class Swup {
 		// Mount plugins
 		this.options.plugins.forEach((plugin) => this.use(plugin));
 
-		// Modify initial history record
-		updateHistoryRecord(null, { index: 1 });
+		// Create initial history record
+		if ((history.state as HistoryState)?.source !== 'swup') {
+			updateHistoryRecord(null, { index: this.currentHistoryIndex });
+		}
 
 		// Give consumers a chance to hook into enable
 		await nextTick();

--- a/src/Swup.ts
+++ b/src/Swup.ts
@@ -90,7 +90,7 @@ export default class Swup {
 	/** URL of the currently visible page */
 	currentPageUrl: string = getCurrentUrl();
 	/** Index of the current history entry */
-	protected currentHistoryIndex = 1;
+	protected currentHistoryIndex: number;
 	/** Delegated event subscription handle */
 	protected clickDelegate?: DelegateEventUnsubscribe;
 
@@ -143,6 +143,8 @@ export default class Swup {
 		this.classes = new Classes(this);
 		this.hooks = new Hooks(this);
 		this.visit = this.createVisit({ to: '' });
+
+		this.currentHistoryIndex = (history.state as HistoryState)?.index ?? 1;
 
 		if (!this.checkRequirements()) {
 			return;

--- a/src/Swup.ts
+++ b/src/Swup.ts
@@ -331,6 +331,7 @@ export default class Swup {
 		if (index) {
 			const direction = index - this.currentHistoryIndex > 0 ? 'forwards' : 'backwards';
 			this.visit.history.direction = direction;
+			this.currentHistoryIndex = index;
 		}
 
 		// Disable animation & scrolling for history visits

--- a/src/Swup.ts
+++ b/src/Swup.ts
@@ -327,7 +327,7 @@ export default class Swup {
 		this.visit.history.popstate = true;
 
 		// Determine direction of history visit
-		const index = Number((event.state as HistoryState)?.index);
+		const index = (event.state as HistoryState)?.index ?? 0;
 		if (index) {
 			const direction = index - this.currentHistoryIndex > 0 ? 'forwards' : 'backwards';
 			this.visit.history.direction = direction;

--- a/src/modules/navigate.ts
+++ b/src/modules/navigate.ts
@@ -123,8 +123,7 @@ export async function performNavigation(
 			) {
 				updateHistoryRecord(newUrl);
 			} else {
-				const index = this.currentHistoryIndex + 1;
-				createHistoryRecord(newUrl, { index });
+				createHistoryRecord(newUrl, { index: this.currentHistoryIndex++ });
 			}
 		}
 

--- a/src/modules/navigate.ts
+++ b/src/modules/navigate.ts
@@ -123,7 +123,8 @@ export async function performNavigation(
 			) {
 				updateHistoryRecord(newUrl);
 			} else {
-				createHistoryRecord(newUrl, { index: this.currentHistoryIndex++ });
+				this.currentHistoryIndex++;
+				createHistoryRecord(newUrl, { index: this.currentHistoryIndex });
 			}
 		}
 


### PR DESCRIPTION
**Description**

- While experimenting with parallel layouts and history stacks, I noticed the history index isn't set correctly
- The value was never permanently incremented, leading to index `2` for all history states 🙃
- This PR adds a few things around that topic:
  - Read index from existing history state on load
  - Only create initial history index if none exists
  - Actually increment the index
  - Only set direction if an index was found

**Checks**

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [x] New or updated tests are included
- [ ] ~~The documentation was updated as required~~