### PR TITLE
Add unique id to visit object

### DIFF
--- a/cypress/e2e/main.spec.js
+++ b/cypress/e2e/main.spec.js
@@ -389,6 +389,31 @@ describe('Navigation', function () {
 		cy.shouldHaveH1('Page 2');
 	});
 
+	it('should ignore visit if a new visit has started', function() {
+		cy.delayRequest('/page-2.html', 1000);
+		cy.triggerClickOnLink('/page-2.html');
+		cy.wait(50);
+		cy.triggerClickOnLink('/page-3.html');
+		cy.shouldBeAtPage('/page-3.html', 'Page 3');
+		cy.wait(1000);
+		cy.shouldBeAtPage('/page-3.html', 'Page 3');
+	});
+
+	it('should ignore visit if a new visit to same URL has started', function() {
+		const titles = [];
+		this.swup.options.linkToSelf = 'navigate';
+		this.swup.hooks.on('visit:start', (visit) => titles.push(visit.id));
+		this.swup.hooks.on('content:replace', () => document.title = titles[titles.length - 1]);
+
+		cy.delayRequest('/page-2.html', 500);
+		cy.triggerClickOnLink('/page-2.html');
+		cy.wait(50);
+		cy.triggerClickOnLink('/page-2.html');
+		cy.shouldBeAtPage('/page-2.html', titles[1]);
+		cy.wait(500);
+		cy.shouldBeAtPage('/page-2.html', titles[1]);
+	});
+
 	// it('should ignore visit when meta key pressed', function() {
 	//     cy.triggerClickOnLink('/page-2.html', { metaKey: true });
 	//     cy.wait(200);

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -162,3 +162,10 @@ Cypress.Commands.add('pushHistoryState', (url, data = {}) => {
 		window.history.pushState(state, '', url);
 	});
 });
+
+Cypress.Commands.add('delayRequest', (url, delay) => {
+	cy.intercept({ pathname: url, times: 1 }, (req) => {
+		const { pathname: fixture } = new URL(req.url);
+		req.reply({ fixture, delay });
+	});
+});

--- a/src/modules/Visit.ts
+++ b/src/modules/Visit.ts
@@ -3,6 +3,8 @@ import { HistoryAction, HistoryDirection } from './navigate.js';
 
 /** An object holding details about the current visit. */
 export interface Visit {
+	/** A unique ID to identify this visit */
+	id: number;
 	/** The previous page, about to leave */
 	from: VisitFrom;
 	/** The next page, about to enter */
@@ -92,6 +94,7 @@ export function createVisit(
 	{ to, from = this.currentPageUrl, hash, el, event }: VisitInitOptions
 ): Visit {
 	return {
+		id: Math.random(),
 		from: { url: from },
 		to: { url: to, hash },
 		containers: this.options.containers,

--- a/src/modules/__test__/visit.test.ts
+++ b/src/modules/__test__/visit.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 import Swup from '../../Swup.js';
 import { Visit, createVisit } from '../Visit.js';
 

--- a/src/modules/__test__/visit.test.ts
+++ b/src/modules/__test__/visit.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import Swup from '../../Swup.js';
+import { Visit, createVisit } from '../Visit.js';
+
+class SwupWithPublicVisitMethods extends Swup {
+	public createVisit = createVisit;
+}
+
+const swup = new SwupWithPublicVisitMethods();
+let visit: Visit;
+
+describe('Visit', () => {
+	beforeEach(() => {
+		visit = swup.createVisit({ to: '' });
+	});
+
+	it('is an object', () => {
+		expect(visit).to.be.an('object');
+	});
+
+	it('has an id', () => {
+		expect(visit.id).to.be.a('number');
+	});
+
+	it('generates unique ids', () => {
+		let id = visit.id;
+		visit = swup.createVisit({ to: '' });
+		expect(visit.id).to.not.equal(id);
+	});
+
+	it('has a from object with the current URL', () => {
+		expect(visit.from).to.be.an('object');
+		expect(visit.from.url).to.be.a('string');
+		visit = swup.createVisit({ to: '', from: '/from' });
+		expect(visit.from).toMatchObject({ url: '/from' });
+	});
+
+	it('has a to object with the next URL', () => {
+		expect(visit.to).to.be.an('object');
+		expect(visit.to.url).to.be.a('string');
+		visit = swup.createVisit({ to: '/to' });
+		expect(visit.to).toMatchObject({ url: '/to' });
+	});
+
+	it('has an animation object', () => {
+		expect(visit.animation).to.be.an('object');
+		expect(visit.animation).toMatchObject({
+			animate: true,
+			name: undefined,
+			scope: swup.options.animationScope,
+			selector: swup.options.animationSelector
+		 });
+	});
+
+	it('has a container array', () => {
+		expect(visit.containers).to.be.an('array');
+		expect(visit.containers).toEqual(swup.options.containers);
+	});
+
+	it('has a trigger object', () => {
+		expect(visit.trigger).to.be.an('object');
+		expect(visit.trigger).toMatchObject({
+			el: undefined,
+			event: undefined
+		 });
+	});
+
+	it('has a cache object', () => {
+		expect(visit.cache).to.be.an('object');
+		expect(visit.cache).toEqual({
+			read: swup.options.cache,
+			write: swup.options.cache
+		});
+	});
+
+	it('has a history object', () => {
+		expect(visit.history).to.be.an('object');
+		expect(visit.history).toEqual({
+			action: 'push',
+			popstate: false,
+			direction: undefined
+		});
+	});
+
+	it('has a scroll object', () => {
+		expect(visit.scroll).to.be.an('object');
+		expect(visit.scroll).toEqual({
+			reset: true,
+			target: undefined
+		});
+	});
+});

--- a/src/modules/navigate.ts
+++ b/src/modules/navigate.ts
@@ -61,7 +61,7 @@ export function navigate(
 export async function performNavigation(
 	this: Swup,
 	options: NavigationOptions & FetchOptions = {}
-) {
+): Promise<void> {
 	// Save this localy to a) allow ignoring the visit if a new one was started in the meantime
 	// and b) avoid unintended modifications to any newer visits
 	const visit = this.visit;
@@ -141,11 +141,13 @@ export async function performNavigation(
 		const animationPromise = this.animatePageOut();
 		const [page] = await Promise.all([pagePromise, animationPromise]);
 
-		// Render page: replace content and scroll to top/fragment
-		const handled = await this.renderPage(visit, page);
-		if (!handled) {
+		// Abort if another visit was started in the meantime
+		if (visit.id !== this.visit.id) {
 			return;
 		}
+
+		// Render page: replace content and scroll to top/fragment
+		await this.renderPage(page);
 
 		// Wait for enter animation
 		await this.animatePageIn();

--- a/src/modules/navigate.ts
+++ b/src/modules/navigate.ts
@@ -141,7 +141,7 @@ export async function performNavigation(
 		const [page] = await Promise.all([pagePromise, animationPromise]);
 
 		// Render page: replace content and scroll to top/fragment
-		await this.renderPage(this.visit.to.url, page);
+		await this.renderPage(this.visit, page);
 
 		// Wait for enter animation
 		await this.animatePageIn();

--- a/src/modules/navigate.ts
+++ b/src/modules/navigate.ts
@@ -141,7 +141,10 @@ export async function performNavigation(
 		const [page] = await Promise.all([pagePromise, animationPromise]);
 
 		// Render page: replace content and scroll to top/fragment
-		await this.renderPage(this.visit, page);
+		const handled = await this.renderPage(this.visit, page);
+		if (!handled) {
+			return;
+		}
 
 		// Wait for enter animation
 		await this.animatePageIn();

--- a/src/modules/navigate.ts
+++ b/src/modules/navigate.ts
@@ -62,7 +62,8 @@ export async function performNavigation(
 	this: Swup,
 	options: NavigationOptions & FetchOptions = {}
 ) {
-	// Save this to allow aborting the navigation if a new visit was started in the meantime
+	// Save this localy to a) allow ignoring the visit if a new one was started in the meantime
+	// and b) avoid unintended modifications to any newer visits
 	const visit = this.visit;
 
 	const { el } = visit.trigger;

--- a/src/modules/renderPage.ts
+++ b/src/modules/renderPage.ts
@@ -7,14 +7,18 @@ import { Visit } from './Visit.js';
  * Render the next page: replace the content and update scroll position.
  * @returns Promise<void>
  */
-export const renderPage = async function (this: Swup, visit: Visit, page: PageData) {
+export const renderPage = async function (
+	this: Swup,
+	visit: Visit,
+	page: PageData
+): Promise<boolean> {
 	const { url, html } = page;
 
 	this.classes.remove('is-leaving');
 
 	// do nothing if another visit was started in the meantime
 	if (visit.id !== this.visit.id) {
-		return;
+		return false;
 	}
 
 	// update state if the url was redirected
@@ -54,4 +58,6 @@ export const renderPage = async function (this: Swup, visit: Visit, page: PageDa
 	});
 
 	await this.hooks.call('page:view', { url: this.currentPageUrl, title: document.title });
+
+	return true;
 };

--- a/src/modules/renderPage.ts
+++ b/src/modules/renderPage.ts
@@ -5,7 +5,7 @@ import { Visit } from './Visit.js';
 
 /**
  * Render the next page: replace the content and update scroll position.
- * @returns Promise<void>
+ * @returns Promise<boolean> Indicates whether the page was rendered or ignored
  */
 export const renderPage = async function (
 	this: Swup,

--- a/src/modules/renderPage.ts
+++ b/src/modules/renderPage.ts
@@ -25,16 +25,16 @@ export const renderPage = async function (
 	if (!this.isSameResolvedUrl(getCurrentUrl(), url)) {
 		updateHistoryRecord(url);
 		this.currentPageUrl = getCurrentUrl();
-		this.visit.to.url = this.currentPageUrl;
+		visit.to.url = this.currentPageUrl;
 	}
 
 	// only add for animated page loads
-	if (this.visit.animation.animate) {
+	if (visit.animation.animate) {
 		this.classes.add('is-rendering');
 	}
 
 	// save html into visit context for easier retrieval
-	this.visit.to.html = html;
+	visit.to.html = html;
 
 	// replace content: allow handlers and plugins to overwrite paga data and containers
 	await this.hooks.call('content:replace', { page }, (visit, { page }) => {

--- a/src/modules/renderPage.ts
+++ b/src/modules/renderPage.ts
@@ -1,18 +1,19 @@
 import { updateHistoryRecord, getCurrentUrl, classify } from '../helpers.js';
 import Swup from '../Swup.js';
 import { PageData } from './fetchPage.js';
+import { Visit } from './Visit.js';
 
 /**
  * Render the next page: replace the content and update scroll position.
  * @returns Promise<void>
  */
-export const renderPage = async function (this: Swup, requestedUrl: string, page: PageData) {
+export const renderPage = async function (this: Swup, visit: Visit, page: PageData) {
 	const { url, html } = page;
 
 	this.classes.remove('is-leaving');
 
-	// do nothing if another page was requested in the meantime
-	if (!this.isSameResolvedUrl(getCurrentUrl(), requestedUrl)) {
+	// do nothing if another visit was started in the meantime
+	if (visit.id !== this.visit.id) {
 		return;
 	}
 

--- a/src/modules/renderPage.ts
+++ b/src/modules/renderPage.ts
@@ -1,40 +1,29 @@
 import { updateHistoryRecord, getCurrentUrl, classify } from '../helpers.js';
 import Swup from '../Swup.js';
 import { PageData } from './fetchPage.js';
-import { Visit } from './Visit.js';
 
 /**
  * Render the next page: replace the content and update scroll position.
- * @returns Promise<boolean> Indicates whether the page was rendered or ignored
  */
-export const renderPage = async function (
-	this: Swup,
-	visit: Visit,
-	page: PageData
-): Promise<boolean> {
+export const renderPage = async function (this: Swup, page: PageData): Promise<void> {
 	const { url, html } = page;
 
 	this.classes.remove('is-leaving');
-
-	// do nothing if another visit was started in the meantime
-	if (visit.id !== this.visit.id) {
-		return false;
-	}
 
 	// update state if the url was redirected
 	if (!this.isSameResolvedUrl(getCurrentUrl(), url)) {
 		updateHistoryRecord(url);
 		this.currentPageUrl = getCurrentUrl();
-		visit.to.url = this.currentPageUrl;
+		this.visit.to.url = this.currentPageUrl;
 	}
 
 	// only add for animated page loads
-	if (visit.animation.animate) {
+	if (this.visit.animation.animate) {
 		this.classes.add('is-rendering');
 	}
 
 	// save html into visit context for easier retrieval
-	visit.to.html = html;
+	this.visit.to.html = html;
 
 	// replace content: allow handlers and plugins to overwrite paga data and containers
 	await this.hooks.call('content:replace', { page }, (visit, { page }) => {
@@ -58,6 +47,4 @@ export const renderPage = async function (
 	});
 
 	await this.hooks.call('page:view', { url: this.currentPageUrl, title: document.title });
-
-	return true;
 };


### PR DESCRIPTION
**Description**

- Add a unique random `visit.id` when creating new visits
- Ignore outdated visits if IDs mismatch
- As much as possible, refer to local `visit` var instead of `this.visit` to avoid modifying newer visit
- Add tests for the shape of the Visit object
- Add tests for outdated visits being ignored

**Goals**

- Identify and ignore outdated visits with more certainty
- Allow checking if we're still in the same visit in `hooks.once()` calls

**Allow identifying outdated visits**

Currently, we're checking if a newer visit was started in the meantime by comparing the two requested URLs. That doesn't work for the now-possible same-link visits, and it's also safer and clearer to just compare IDs:

```diff
- if (!this.isSameResolvedUrl(getCurrentUrl(), requestedUrl)) return;
+ if (visit.id !== this.visit.id) return;
```

**Allow checking for same visit in `once` hooks**

Currently, when registering a hook `once`, there is no guarantee that the run hook belongs to the same visit, e.g.:

- When clicking links twice in quick succession, it's possible for the second link to fetch earlier
- When hooking into animation functions that might be skipped, we'd get the animation of the **next** visit

By having a unique id on the visit object we can check in `once` hooks if we're indeed dealing with the same visit:

```js
swup.hooks.on('visit:start', (visit) => {
  if (someCondition) {
    swup.hooks.once('animation:in:await', ({ id }) => {
      if (visit.id !== id) return;
      await someCustomFunction();
    }
  }
});
```

**Checks**

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [x] New or updated tests are included
- [ ] ~~The documentation was updated as required~~
