### PR TITLE
Prepare ViewTransition support

### DIFF
--- a/src/modules/Hooks.ts
+++ b/src/modules/Hooks.ts
@@ -31,6 +31,7 @@ export interface HookDefinitions {
 	'scroll:top': { options: ScrollIntoViewOptions };
 	'scroll:anchor': { hash: string; options: ScrollIntoViewOptions };
 	'visit:start': undefined;
+	'visit:transition': undefined;
 	'visit:end': undefined;
 }
 
@@ -40,6 +41,7 @@ export interface HookReturnValues {
 	'page:load': Promise<PageData>;
 	'scroll:top': boolean;
 	'scroll:anchor': boolean;
+	'visit:transition': Promise<boolean>;
 }
 
 export type HookArguments<T extends HookName> = HookDefinitions[T];
@@ -141,6 +143,7 @@ export class Hooks {
 		'scroll:top',
 		'scroll:anchor',
 		'visit:start',
+		'visit:transition',
 		'visit:end'
 	];
 


### PR DESCRIPTION
**Description**

- Trying to get swup to play nice with the new [ViewTransitions API](https://developer.mozilla.org/en-US/docs/Web/API/ViewTransition)
- Turns out the only (!) thing required to get them working is wrapping all DOM changes in a new hook
- We can now replace that hook and wrap the DOM changes with a `document.startViewTransition()` call
- That's all — ViewTransition are now supported 🤠

**Example**

The animations are all done in CSS using `::view-transition-*` pseudo-elements. Parallel animations without plugins!

https://github.com/swup/swup/assets/22225348/2f716aca-1d6f-4606-9ab9-4a828ec97b5f

**Checks**

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [ ] New or updated tests are included
- [ ] The documentation was updated as required