### PR TITLE
fix: ignore double-clicks on links

### DIFF
--- a/src/Swup.ts
+++ b/src/Swup.ts
@@ -96,6 +96,8 @@ export default class Swup {
 	protected currentHistoryIndex: number;
 	/** Delegated event subscription handle */
 	protected clickDelegate?: DelegateEventUnsubscribe;
+	/** Navigation status */
+	navigating: boolean = false;
 
 	/** Install a plugin */
 	use = use;
@@ -145,7 +147,7 @@ export default class Swup {
 		this.cache = new Cache(this);
 		this.classes = new Classes(this);
 		this.hooks = new Hooks(this);
-		this.visit = this.createVisit({ to: '', settled: true });
+		this.visit = this.createVisit({ to: '' });
 
 		this.currentHistoryIndex = (history.state as HistoryState)?.index ?? 1;
 
@@ -258,7 +260,7 @@ export default class Swup {
 		}
 
 		// Ignore if swup is currently navigating towards the link's URL
-		if (!this.visit.settled && url === this.visit.to.url) {
+		if (this.navigating && url === this.visit.to.url) {
 			event.preventDefault();
 			return;
 		}
@@ -268,13 +270,11 @@ export default class Swup {
 		// Exit early if control key pressed
 		if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
 			this.hooks.call('link:newtab', { href });
-			this.visit.settled = true;
 			return;
 		}
 
 		// Exit early if other than left mouse button
 		if (event.button !== 0) {
-			this.visit.settled = true;
 			return;
 		}
 
@@ -285,7 +285,6 @@ export default class Swup {
 
 			// Handle links to the same page
 			if (!url || url === from) {
-				this.visit.settled = true;
 				if (hash) {
 					// With hash: scroll to anchor
 					this.hooks.callSync('link:anchor', { hash }, () => {
@@ -310,7 +309,6 @@ export default class Swup {
 
 			// Exit early if the resolved path hasn't changed
 			if (this.isSameResolvedUrl(url, from)) {
-				this.visit.settled = true;
 				return;
 			}
 

--- a/src/Swup.ts
+++ b/src/Swup.ts
@@ -283,6 +283,7 @@ export default class Swup {
 
 			// Handle links to the same page
 			if (!url || url === from) {
+				this.visit.settled = true;
 				if (hash) {
 					// With hash: scroll to anchor
 					this.hooks.callSync('link:anchor', { hash }, () => {
@@ -307,6 +308,7 @@ export default class Swup {
 
 			// Exit early if the resolved path hasn't changed
 			if (this.isSameResolvedUrl(url, from)) {
+				this.visit.settled = true;
 				return;
 			}
 

--- a/src/Swup.ts
+++ b/src/Swup.ts
@@ -257,6 +257,12 @@ export default class Swup {
 			return;
 		}
 
+		// Ignore if swup is currently navigating towards the link's URL
+		if (!this.visit.settled && url === this.visit.to.url) {
+			event.preventDefault();
+			return;
+		}
+
 		this.visit = this.createVisit({ to: url, hash, el, event });
 
 		// Exit early if control key pressed

--- a/src/Swup.ts
+++ b/src/Swup.ts
@@ -268,11 +268,13 @@ export default class Swup {
 		// Exit early if control key pressed
 		if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
 			this.hooks.call('link:newtab', { href });
+			this.visit.settled = true;
 			return;
 		}
 
 		// Exit early if other than left mouse button
 		if (event.button !== 0) {
+			this.visit.settled = true;
 			return;
 		}
 

--- a/src/Swup.ts
+++ b/src/Swup.ts
@@ -145,7 +145,7 @@ export default class Swup {
 		this.cache = new Cache(this);
 		this.classes = new Classes(this);
 		this.hooks = new Hooks(this);
-		this.visit = this.createVisit({ to: '' });
+		this.visit = this.createVisit({ to: '', settled: true });
 
 		this.currentHistoryIndex = (history.state as HistoryState)?.index ?? 1;
 

--- a/src/Swup.ts
+++ b/src/Swup.ts
@@ -97,7 +97,7 @@ export default class Swup {
 	/** Delegated event subscription handle */
 	protected clickDelegate?: DelegateEventUnsubscribe;
 	/** Navigation status */
-	navigating: boolean = false;
+	protected navigating: boolean = false;
 
 	/** Install a plugin */
 	use = use;

--- a/src/modules/Visit.ts
+++ b/src/modules/Visit.ts
@@ -22,7 +22,7 @@ export interface Visit {
 	/** Scroll behavior on this visit */
 	scroll: VisitScroll;
 	/** Has the visit settled? */
-	settled: boolean
+	settled: boolean;
 }
 
 export interface VisitFrom {

--- a/src/modules/Visit.ts
+++ b/src/modules/Visit.ts
@@ -21,6 +21,8 @@ export interface Visit {
 	history: VisitHistory;
 	/** Scroll behavior on this visit */
 	scroll: VisitScroll;
+	/** Has the visit settled? */
+	settled: boolean
 }
 
 export interface VisitFrom {
@@ -121,6 +123,7 @@ export function createVisit(
 		scroll: {
 			reset: true,
 			target: undefined
-		}
+		},
+		settled: false
 	};
 }

--- a/src/modules/Visit.ts
+++ b/src/modules/Visit.ts
@@ -88,12 +88,13 @@ export interface VisitInitOptions {
 	hash?: string;
 	el?: Element;
 	event?: Event;
+	settled?: boolean;
 }
 
 /** Create a new visit object. */
 export function createVisit(
 	this: Swup,
-	{ to, from = this.currentPageUrl, hash, el, event }: VisitInitOptions
+	{ to, from = this.currentPageUrl, hash, el, event, settled = false }: VisitInitOptions
 ): Visit {
 	return {
 		id: Math.random(),
@@ -124,6 +125,6 @@ export function createVisit(
 			reset: true,
 			target: undefined
 		},
-		settled: false
+		settled
 	};
 }

--- a/src/modules/Visit.ts
+++ b/src/modules/Visit.ts
@@ -21,8 +21,6 @@ export interface Visit {
 	history: VisitHistory;
 	/** Scroll behavior on this visit */
 	scroll: VisitScroll;
-	/** Has the visit settled? */
-	settled: boolean;
 }
 
 export interface VisitFrom {
@@ -88,13 +86,12 @@ export interface VisitInitOptions {
 	hash?: string;
 	el?: Element;
 	event?: Event;
-	settled?: boolean;
 }
 
 /** Create a new visit object. */
 export function createVisit(
 	this: Swup,
-	{ to, from = this.currentPageUrl, hash, el, event, settled = false }: VisitInitOptions
+	{ to, from = this.currentPageUrl, hash, el, event }: VisitInitOptions
 ): Visit {
 	return {
 		id: Math.random(),
@@ -124,7 +121,6 @@ export function createVisit(
 		scroll: {
 			reset: true,
 			target: undefined
-		},
-		settled
+		}
 	};
 }

--- a/src/modules/navigate.ts
+++ b/src/modules/navigate.ts
@@ -62,6 +62,7 @@ export async function performNavigation(
 	this: Swup,
 	options: NavigationOptions & FetchOptions = {}
 ): Promise<void> {
+	this.navigating = true;
 	// Save this localy to a) allow ignoring the visit if a new one was started in the meantime
 	// and b) avoid unintended modifications to any newer visits
 	const visit = this.visit;
@@ -166,7 +167,7 @@ export async function performNavigation(
 		// if (visit.to && this.isSameResolvedUrl(visit.to.url, requestedUrl)) {
 		// 	this.visit = this.createVisit({ to: undefined });
 		// }
-		this.visit.settled = true;
+		this.navigating = false;
 	} catch (error) {
 		// Return early if error is undefined or signals an aborted request
 		if (!error || (error as FetchError)?.aborted) {

--- a/src/modules/navigate.ts
+++ b/src/modules/navigate.ts
@@ -166,6 +166,7 @@ export async function performNavigation(
 		// if (visit.to && this.isSameResolvedUrl(visit.to.url, requestedUrl)) {
 		// 	this.visit = this.createVisit({ to: undefined });
 		// }
+		this.visit.settled = true;
 	} catch (error) {
 		// Return early if error is undefined or signals an aborted request
 		if (!error || (error as FetchError)?.aborted) {

--- a/tests/functional/main.spec.ts
+++ b/tests/functional/main.spec.ts
@@ -4,5 +4,7 @@ declare global {
 	interface Window {
 		_swup: Swup;
 		data: any;
+		navigated: () => void;
+		updateTestVar: (value: any) => void;
 	}
 }

--- a/tests/functional/main.spec.ts
+++ b/tests/functional/main.spec.ts
@@ -5,6 +5,5 @@ declare global {
 		_swup: Swup;
 		data: any;
 		navigated: () => void;
-		updateTestVar: (value: any) => void;
 	}
 }

--- a/tests/functional/navigation.spec.ts
+++ b/tests/functional/navigation.spec.ts
@@ -55,14 +55,14 @@ test.describe('navigation', () => {
 	// 	expect(await page.evaluate(() => window.data.fired)).toBe(false);
 	// });
 
-	test("ignores link clicks if already navigating towards the link's URL", async ({ page }) => {
-		let ignoredSecondClick: boolean | undefined;
-		await page.exposeBinding('updateTestVar', (_source, value) => (ignoredSecondClick = value));
+	test("ignore double-clicks on links", async ({ page }) => {
+		let triggerCount: number | undefined;
+		await page.exposeBinding('updateTestVar', (_source, value) => (triggerCount = value));
 		await page.evaluate(() => {
-			window.updateTestVar(true);
-			window._swup.hooks.on('link:self', () => window.updateTestVar(false));
+			let count = 0;
+			window._swup.hooks.on('link:click', () => (window.updateTestVar(++count)));
 		});
-		await clickOnLink(page, '/page-2.html', { clickCount: 2 });
-		expect(ignoredSecondClick).toBe(true);
+		await clickOnLink(page, '/page-2.html', { clickCount: 3 });
+		expect(triggerCount).toBe(1);
 	});
 });

--- a/tests/functional/navigation.spec.ts
+++ b/tests/functional/navigation.spec.ts
@@ -42,11 +42,11 @@ test.describe('navigation', () => {
 
 	test('ignores link clicks if already navigating towards the link\'s URL', async ({ page }) => {
 		await page.evaluate(() => {
-			window._swup.hooks.on('link:self', () => window.data.linkToSelfFired = true);
+			window._swup.hooks.on('link:self', () => window.linkToSelfFired = true);
 		});
 		await clickOnLink(page, '/page-2.html');
 		await clickOnLink(page, '/page-2.html');
-		expect(await page.evaluate(() => window.data.linkToSelfFired)).toEqual(undefined);
+		expect(await page.evaluate(() => window.linkToSelfFired)).toEqual(undefined);
 	});
 
 	test('immediately settles the visit for links to current page', async ({ page }) => {

--- a/tests/functional/navigation.spec.ts
+++ b/tests/functional/navigation.spec.ts
@@ -40,18 +40,29 @@ test.describe('navigation', () => {
 		await expectToBeAt(page, '/page-3.html', 'Page 3');
 	});
 
+	// test("ignores link clicks if already navigating towards the link's URL", async ({ page }) => {
+	// 	await page.evaluate(() => {
+	// 		window.data = { fired: false };
+	// 		window._swup.hooks.on('visit:start', (visit) => {
+	// 			// Immediately click the trigger again. This should be ignored.
+	// 			(visit.trigger.el as HTMLAnchorElement).click();
+	// 		});
+	// 		window._swup.hooks.on('link:self', () => {
+	// 			window.data.fired = true;
+	// 		});
+	// 	});
+	// 	await clickOnLink(page, '/page-2.html');
+	// 	expect(await page.evaluate(() => window.data.fired)).toBe(false);
+	// });
+
 	test("ignores link clicks if already navigating towards the link's URL", async ({ page }) => {
+		let ignoredSecondClick: boolean | undefined;
+		await page.exposeBinding('updateTestVar', (_source, value) => (ignoredSecondClick = value));
 		await page.evaluate(() => {
-			window.data = { fired: false };
-			window._swup.hooks.on('visit:start', (visit) => {
-				// Immediately click the trigger again. This should be ignored.
-				(visit.trigger.el as HTMLAnchorElement).click();
-			});
-			window._swup.hooks.on('link:self', () => {
-				window.data.fired = true;
-			});
+			window.updateTestVar(true);
+			window._swup.hooks.on('link:self', () => window.updateTestVar(false));
 		});
-		await clickOnLink(page, '/page-2.html');
-		expect(await page.evaluate(() => window.data.fired)).toBe(false);
+		await clickOnLink(page, '/page-2.html', { clickCount: 2 });
+		expect(ignoredSecondClick).toBe(true);
 	});
 });

--- a/tests/functional/navigation.spec.ts
+++ b/tests/functional/navigation.spec.ts
@@ -40,7 +40,7 @@ test.describe('navigation', () => {
 		await expectToBeAt(page, '/page-3.html', 'Page 3');
 	});
 
-	test('immediately settles visit for links to current page', async ({ page }) => {
+	test('immediately settles the visit for links to current page', async ({ page }) => {
 		await clickOnLink(page, '/page-1.html');
 		expect(await page.evaluate(() => window._swup.visit.settled)).toEqual(true);
 	});

--- a/tests/functional/navigation.spec.ts
+++ b/tests/functional/navigation.spec.ts
@@ -40,14 +40,12 @@ test.describe('navigation', () => {
 		await expectToBeAt(page, '/page-3.html', 'Page 3');
 	});
 
-	test("ignore double-clicks on links", async ({ page }) => {
-		let triggerCount: number | undefined;
-		await page.exposeBinding('updateTestVar', (_source, value) => (triggerCount = value));
+	test("ignore multiple rapid clicks on the same link", async ({ page }) => {
 		await page.evaluate(() => {
-			let count = 0;
-			window._swup.hooks.on('link:click', () => (window.updateTestVar(++count)));
+			window.data = { clickCount: 0 }
+			window._swup.hooks.on('link:click', () => (window.data.clickCount += 1));
 		});
 		await clickOnLink(page, '/page-2.html', { clickCount: 3 });
-		expect(triggerCount).toBe(1);
+		expect(await page.evaluate(() => window.data.clickCount)).toBe(1);
 	});
 });

--- a/tests/functional/navigation.spec.ts
+++ b/tests/functional/navigation.spec.ts
@@ -40,21 +40,6 @@ test.describe('navigation', () => {
 		await expectToBeAt(page, '/page-3.html', 'Page 3');
 	});
 
-	// test("ignores link clicks if already navigating towards the link's URL", async ({ page }) => {
-	// 	await page.evaluate(() => {
-	// 		window.data = { fired: false };
-	// 		window._swup.hooks.on('visit:start', (visit) => {
-	// 			// Immediately click the trigger again. This should be ignored.
-	// 			(visit.trigger.el as HTMLAnchorElement).click();
-	// 		});
-	// 		window._swup.hooks.on('link:self', () => {
-	// 			window.data.fired = true;
-	// 		});
-	// 	});
-	// 	await clickOnLink(page, '/page-2.html');
-	// 	expect(await page.evaluate(() => window.data.fired)).toBe(false);
-	// });
-
 	test("ignore double-clicks on links", async ({ page }) => {
 		let triggerCount: number | undefined;
 		await page.exposeBinding('updateTestVar', (_source, value) => (triggerCount = value));

--- a/tests/functional/navigation.spec.ts
+++ b/tests/functional/navigation.spec.ts
@@ -45,7 +45,7 @@ test.describe('navigation', () => {
 			window.data = { fired: false };
 			window._swup.hooks.on('visit:start', (visit) => {
 				// Immediately click the trigger again. This should be ignored.
-				visit.trigger.el.click();
+				(visit.trigger.el as HTMLAnchorElement).click();
 			});
 			window._swup.hooks.on('link:self', () => {
 				window.data.fired = true;

--- a/tests/functional/navigation.spec.ts
+++ b/tests/functional/navigation.spec.ts
@@ -43,11 +43,14 @@ test.describe('navigation', () => {
 	test("ignores link clicks if already navigating towards the link's URL", async ({ page }) => {
 		await page.evaluate(() => {
 			window.data = { fired: false };
+			window._swup.hooks.on('visit:start', (visit) => {
+				// Immediately click the trigger again. This should be ignored.
+				visit.trigger.el.click();
+			});
 			window._swup.hooks.on('link:self', () => {
 				window.data.fired = true;
 			});
 		});
-		await clickOnLink(page, '/page-2.html');
 		await clickOnLink(page, '/page-2.html');
 		expect(await page.evaluate(() => window.data.fired)).toBe(false);
 	});

--- a/tests/functional/navigation.spec.ts
+++ b/tests/functional/navigation.spec.ts
@@ -40,17 +40,15 @@ test.describe('navigation', () => {
 		await expectToBeAt(page, '/page-3.html', 'Page 3');
 	});
 
-	test('ignores link clicks if already navigating towards the link\'s URL', async ({ page }) => {
+	test("ignores link clicks if already navigating towards the link's URL", async ({ page }) => {
 		await page.evaluate(() => {
-			window._swup.hooks.on('link:self', () => window.linkToSelfFired = true);
+			window.data = { fired: false };
+			window._swup.hooks.on('link:self', () => {
+				window.data.fired = true;
+			});
 		});
 		await clickOnLink(page, '/page-2.html');
 		await clickOnLink(page, '/page-2.html');
-		expect(await page.evaluate(() => window.linkToSelfFired)).toEqual(undefined);
-	});
-
-	test('immediately settles the visit for links to current page', async ({ page }) => {
-		await clickOnLink(page, '/page-1.html');
-		expect(await page.evaluate(() => window._swup.visit.settled)).toEqual(true);
+		expect(await page.evaluate(() => window.data.fired)).toBe(false);
 	});
 });

--- a/tests/functional/navigation.spec.ts
+++ b/tests/functional/navigation.spec.ts
@@ -40,6 +40,15 @@ test.describe('navigation', () => {
 		await expectToBeAt(page, '/page-3.html', 'Page 3');
 	});
 
+	test('ignores link clicks if already navigating towards the link\'s URL', async ({ page }) => {
+		await page.evaluate(() => {
+			window._swup.hooks.on('link:self', () => window.data.linkToSelfFired = true);
+		});
+		await clickOnLink(page, '/page-2.html');
+		await clickOnLink(page, '/page-2.html');
+		expect(await page.evaluate(() => window.data.linkToSelfFired)).toEqual(undefined);
+	});
+
 	test('immediately settles the visit for links to current page', async ({ page }) => {
 		await clickOnLink(page, '/page-1.html');
 		expect(await page.evaluate(() => window._swup.visit.settled)).toEqual(true);

--- a/tests/functional/navigation.spec.ts
+++ b/tests/functional/navigation.spec.ts
@@ -1,4 +1,4 @@
-import { test } from '@playwright/test';
+import { test, expect } from '@playwright/test';
 
 import { clickOnLink, delayRequest, expectToBeAt } from '../support/commands.js';
 import { navigateWithSwup } from '../support/swup.js';
@@ -38,5 +38,10 @@ test.describe('navigation', () => {
 		await expectToBeAt(page, '/page-3.html', 'Page 3');
 		await page.waitForTimeout(700);
 		await expectToBeAt(page, '/page-3.html', 'Page 3');
+	});
+
+	test('immediately settles visit for links to current page', async ({ page }) => {
+		await clickOnLink(page, '/page-1.html');
+		expect(await page.evaluate(() => window._swup.visit.settled)).toEqual(true);
 	});
 });

--- a/tests/functional/scrolling.spec.ts
+++ b/tests/functional/scrolling.spec.ts
@@ -2,7 +2,6 @@ import { test, expect } from '@playwright/test';
 
 import { expectScrollPosition, expectToBeAt } from '../support/commands.js';
 import { waitForSwup } from '../support/swup.js';
-import { Visit } from '../../src/index.js';
 
 test.describe('scrolling', () => {
 	test.beforeEach(async ({ page }) => {

--- a/tests/functional/scrolling.spec.ts
+++ b/tests/functional/scrolling.spec.ts
@@ -80,9 +80,4 @@ test.describe('scrolling', () => {
 		await expectToBeAt(page, '/scrolling-2.html', 'Scrolling 2');
 		await expect(page.getByTestId('anchor')).toBeInViewport();
 	});
-
-	test('immediately settles the visit for anchor links', async ({ page }) => {
-		await page.getByTestId('link-to-anchor').click();
-		expect(await page.evaluate(() => window._swup.visit.settled)).toEqual(true);
-	});
 });

--- a/tests/functional/scrolling.spec.ts
+++ b/tests/functional/scrolling.spec.ts
@@ -81,7 +81,7 @@ test.describe('scrolling', () => {
 		await expect(page.getByTestId('anchor')).toBeInViewport();
 	});
 
-	test('sets visit.settled to true for anchor links', async ({ page }) => {
+	test('immediately settles the visit for anchor links', async ({ page }) => {
 		await page.getByTestId('link-to-anchor').click();
 		expect(await page.evaluate(() => window._swup.visit.settled)).toEqual(true);
 	});

--- a/tests/functional/scrolling.spec.ts
+++ b/tests/functional/scrolling.spec.ts
@@ -82,7 +82,7 @@ test.describe('scrolling', () => {
 		await expect(page.getByTestId('anchor')).toBeInViewport();
 	});
 
-	test.only('sets visit.settled to true for anchor links', async ({ page }) => {
+	test('sets visit.settled to true for anchor links', async ({ page }) => {
 		await page.getByTestId('link-to-anchor').click();
 		expect(await page.evaluate(() => window._swup.visit.settled)).toEqual(true);
 	});

--- a/tests/functional/scrolling.spec.ts
+++ b/tests/functional/scrolling.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from '@playwright/test';
 
 import { expectScrollPosition, expectToBeAt } from '../support/commands.js';
 import { waitForSwup } from '../support/swup.js';
+import { Visit } from '../../src/index.js';
 
 test.describe('scrolling', () => {
 	test.beforeEach(async ({ page }) => {
@@ -70,12 +71,19 @@ test.describe('scrolling', () => {
 		await expect(page.getByTestId('anchor')).toBeInViewport();
 	});
 
-	test('does not append the hash if changing visit.scroll.target on the fly', async ({ page }) => {
+	test('does not append the hash if changing visit.scroll.target on the fly', async ({
+		page
+	}) => {
 		await page.evaluate(() => {
 			window._swup.hooks.once('visit:start', (visit) => (visit.scroll.target = '#anchor'));
 		});
 		await page.getByTestId('link-to-page').click();
 		await expectToBeAt(page, '/scrolling-2.html', 'Scrolling 2');
 		await expect(page.getByTestId('anchor')).toBeInViewport();
+	});
+
+	test.only('sets visit.settled to true for anchor links', async ({ page }) => {
+		await page.getByTestId('link-to-anchor').click();
+		expect(await page.evaluate(() => window._swup.visit.settled)).toEqual(true);
 	});
 });


### PR DESCRIPTION
Fixes #791

**Description**

Ignores clicks on links if swup is currently already navigating towards the link's url. For that to work, we'll need some way to detect if a swup visit has settled. I've added a top level `visit.settled` for that.

**Questions**

- Where exactly would we want to set `settled` to true, before, after or inside `visit:end`?
- Naming: should it actually be called `visit.ended`, to comply with `visit:end`?

**Drive-by**

- Declare globals on `Window` in tests
- Fix test for disabling cache completely using navigation options

**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [x] New or updated tests are included
- [ ] ~The documentation was updated as required~

**Additional information**

<!--
Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc.
-->
