### PR TITLE
fix: types in tests

### DIFF
--- a/tests/functional/cache.spec.ts
+++ b/tests/functional/cache.spec.ts
@@ -1,7 +1,11 @@
 import { expect, test } from '@playwright/test';
 
 import { expectToBeAt } from '../support/commands.js';
-import { expectSwupToHaveCacheEntries, expectSwupToHaveCacheEntry, navigateWithSwup } from '../support/swup.js';
+import {
+	expectSwupToHaveCacheEntries,
+	expectSwupToHaveCacheEntry,
+	navigateWithSwup
+} from '../support/swup.js';
 
 test.describe('cache', () => {
 	test.beforeEach(async ({ page }) => {
@@ -58,7 +62,7 @@ test.describe('cache', () => {
 		});
 
 		// Check disabling completely
-		await navigateWithSwup(page, '/page-2.html', { cache: false });
+		await navigateWithSwup(page, '/page-2.html', { cache: { read: false, write: false } });
 		await expectToBeAt(page, '/page-2.html', 'Page 2');
 		expect(await page.evaluate(() => window.data.read['/page-2.html'])).toEqual(false);
 		expect(await page.evaluate(() => window.data.write['/page-2.html'])).toEqual(false);
@@ -89,7 +93,7 @@ test.describe('cache', () => {
 
 		// Check disabling writes
 		await page.evaluate(() => {
-			window._swup.hooks.on('visit:start', (visit) => visit.cache.write = false);
+			window._swup.hooks.on('visit:start', (visit) => (visit.cache.write = false));
 		});
 		await navigateWithSwup(page, '/page-2.html');
 		await expectToBeAt(page, '/page-2.html', 'Page 2');
@@ -103,7 +107,7 @@ test.describe('cache', () => {
 
 		// Check disabling reads
 		await page.evaluate(() => {
-			window._swup.hooks.on('visit:start', (visit) => visit.cache.read = false);
+			window._swup.hooks.on('visit:start', (visit) => (visit.cache.read = false));
 		});
 		await navigateWithSwup(page, '/page-1.html');
 		await expectToBeAt(page, '/page-1.html', 'Page 1');
@@ -112,7 +116,7 @@ test.describe('cache', () => {
 
 	test('marks cached pages in page:load', async ({ page }) => {
 		await page.evaluate(() => {
-			window._swup.hooks.on('page:load', (visit, { cache }) => window.data = cache);
+			window._swup.hooks.on('page:load', (visit, { cache }) => (window.data = cache));
 		});
 		await navigateWithSwup(page, '/page-2.html');
 		await expectToBeAt(page, '/page-2.html', 'Page 2');

--- a/tests/functional/link-resolution.spec.ts
+++ b/tests/functional/link-resolution.spec.ts
@@ -24,16 +24,15 @@ test.describe('link resolution', () => {
 	});
 
 	test('resets scroll when resolving to same page', async ({ page }) => {
-		let navigated = false;
-		await page.exposeBinding('navigated', () => (navigated = true));
 		await page.evaluate(() => {
-			window._swup.hooks.on('visit:start', () => window.navigated());
+			window.data = { navigated: false }
+			window._swup.hooks.on('visit:start', () => window.data.navigated = true);
 		});
 		scrollToPosition(page, 200);
 		await expectScrollPosition(page, 200);
 		await page.getByTestId('nav-link-self').click();
 		await expectScrollPosition(page, 0);
-		expect(navigated).toBe(false);
+		expect(await page.evaluate(() => window.data.navigated)).toBe(false);
 	});
 
 	test('navigates to same page if configured via linkToSelf option', async ({ page }) => {

--- a/tests/functional/main.spec.ts
+++ b/tests/functional/main.spec.ts
@@ -1,8 +1,0 @@
-import Swup from '../../src/Swup.js';
-
-declare global {
-	interface Window {
-		_swup: Swup;
-		data: any;
-	}
-}

--- a/tests/support/swup.ts
+++ b/tests/support/swup.ts
@@ -3,6 +3,13 @@ import type { Page } from '@playwright/test';
 
 import type Swup from '../../src/Swup.js';
 
+declare global {
+	interface Window {
+		_swup: Swup;
+		data: any;
+	}
+}
+
 export async function waitForSwup(page: Page) {
 	await page.waitForSelector('html.swup-enabled');
 }

--- a/tests/support/swup.ts
+++ b/tests/support/swup.ts
@@ -6,7 +6,6 @@ declare global {
 	interface Window {
 		_swup: Swup;
 		data: any;
-		navigated: () => boolean;
 	}
 }
 

--- a/tests/support/swup.ts
+++ b/tests/support/swup.ts
@@ -7,6 +7,7 @@ declare global {
 	interface Window {
 		_swup: Swup;
 		data: any;
+		navigated: () => boolean;
 	}
 }
 


### PR DESCRIPTION
**Description**

My IDE didn't pick up the globals declared in `main.spec.ts`. Instead, it started working when I added the globals declaration to [`./tests/support/swup.ts`](https://github.com/swup/swup/blob/1d2df420c6608464fae507a58af71ab3207f39cd/tests/support/swup.ts#L6-L13), I suspect because that file is being imported by the test files.

**Drive-By**

- Fix typings in test for navigation without cache
- Add new global type `navigated: () => boolean` for link resolution tests
- Format test files

**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [x] New or updated tests are included

