### PR TITLE
feat : enable source diving

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "nyc": "^15.1.0",
         "prettier": "^2.8.2",
         "serve": "^14.2.1",
+        "typed-query-selector": "^2.11.0",
         "vitest": "^0.34.3"
       }
     },

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "nyc": "^15.1.0",
     "prettier": "^2.8.2",
     "serve": "^14.2.1",
+    "typed-query-selector": "^2.11.0",
     "vitest": "^0.34.3"
   },
   "collective": {

--- a/src/Swup.ts
+++ b/src/Swup.ts
@@ -1,27 +1,27 @@
-import { DelegateEvent } from 'delegate-it';
+import { type DelegateEvent } from 'delegate-it';
 
 import version from './config/version.js';
 
 import { delegateEvent, getCurrentUrl, Location, updateHistoryRecord } from './helpers.js';
-import { DelegateEventUnsubscribe } from './helpers/delegateEvent.js';
+import { type DelegateEventUnsubscribe } from './helpers/delegateEvent.js';
 
 import { Cache } from './modules/Cache.js';
 import { Classes } from './modules/Classes.js';
-import { Visit, createVisit } from './modules/Visit.js';
+import { type Visit, createVisit } from './modules/Visit.js';
 import { Hooks } from './modules/Hooks.js';
 import { getAnchorElement } from './modules/getAnchorElement.js';
 import { awaitAnimations } from './modules/awaitAnimations.js';
-import { navigate, performNavigation, NavigationToSelfAction } from './modules/navigate.js';
+import { navigate, performNavigation, type NavigationToSelfAction } from './modules/navigate.js';
 import { fetchPage } from './modules/fetchPage.js';
 import { animatePageOut } from './modules/animatePageOut.js';
 import { replaceContent } from './modules/replaceContent.js';
 import { scrollToContent } from './modules/scrollToContent.js';
 import { animatePageIn } from './modules/animatePageIn.js';
 import { renderPage } from './modules/renderPage.js';
-import { use, unuse, findPlugin, Plugin } from './modules/plugins.js';
+import { use, unuse, findPlugin, type Plugin } from './modules/plugins.js';
 import { isSameResolvedUrl, resolveUrl } from './modules/resolveUrl.js';
 import { nextTick } from './utils.js';
-import { HistoryState } from './helpers/createHistoryRecord.js';
+import { type HistoryState } from './helpers/createHistoryRecord.js';
 
 /** Options for customizing swup's behavior. */
 export type Options = {

--- a/src/helpers/delegateEvent.ts
+++ b/src/helpers/delegateEvent.ts
@@ -1,5 +1,9 @@
-import delegate, { DelegateEventHandler, DelegateOptions, EventType } from 'delegate-it';
-import { ParseSelector } from 'typed-query-selector/parser.js';
+import delegate, {
+	type DelegateEventHandler,
+	type DelegateOptions,
+	type EventType
+} from 'delegate-it';
+import type { ParseSelector } from 'typed-query-selector/parser.js';
 
 export type DelegateEventUnsubscribe = {
 	destroy: () => void;

--- a/src/helpers/matchPath.ts
+++ b/src/helpers/matchPath.ts
@@ -8,7 +8,7 @@ import type {
 	MatchFunction
 } from 'path-to-regexp';
 
-export { Path };
+export { type Path };
 
 /** Create a match function from a path pattern that checks if a URLs matches it. */
 export const matchPath = <P extends object = object>(

--- a/src/helpers/updateHistoryRecord.ts
+++ b/src/helpers/updateHistoryRecord.ts
@@ -1,4 +1,4 @@
-import { HistoryState } from './createHistoryRecord.js';
+import type { HistoryState } from './createHistoryRecord.js';
 import { getCurrentUrl } from './getCurrentUrl.js';
 
 /** Update the current history record with a custom swup identifier. */

--- a/src/modules/Cache.ts
+++ b/src/modules/Cache.ts
@@ -1,6 +1,6 @@
-import Swup from '../Swup.js';
+import type Swup from '../Swup.js';
 import { Location } from '../helpers.js';
-import { PageData } from './fetchPage.js';
+import { type PageData } from './fetchPage.js';
 
 export interface CacheData extends PageData {}
 

--- a/src/modules/Classes.ts
+++ b/src/modules/Classes.ts
@@ -1,4 +1,4 @@
-import Swup from '../Swup.js';
+import type Swup from '../Swup.js';
 import { queryAll } from '../utils.js';
 
 export class Classes {

--- a/src/modules/Hooks.ts
+++ b/src/modules/Hooks.ts
@@ -1,9 +1,9 @@
-import { DelegateEvent } from 'delegate-it';
+import type { DelegateEvent } from 'delegate-it';
 
-import Swup from '../Swup.js';
+import type Swup from '../Swup.js';
 import { isPromise, runAsPromise } from '../utils.js';
-import { Visit } from './Visit.js';
-import { FetchOptions, PageData } from './fetchPage.js';
+import type { Visit } from './Visit.js';
+import type { FetchOptions, PageData } from './fetchPage.js';
 
 export interface HookDefinitions {
 	'animation:out:start': undefined;

--- a/src/modules/Visit.ts
+++ b/src/modules/Visit.ts
@@ -1,5 +1,6 @@
-import Swup, { Options } from '../Swup.js';
-import { HistoryAction, HistoryDirection } from './navigate.js';
+import type Swup from '../Swup.js';
+import type { Options } from '../Swup.js';
+import type { HistoryAction, HistoryDirection } from './navigate.js';
 
 /** An object holding details about the current visit. */
 export interface Visit {

--- a/src/modules/animatePageIn.ts
+++ b/src/modules/animatePageIn.ts
@@ -1,4 +1,4 @@
-import Swup from '../Swup.js';
+import type Swup from '../Swup.js';
 import { nextTick } from '../utils.js';
 
 /**

--- a/src/modules/animatePageOut.ts
+++ b/src/modules/animatePageOut.ts
@@ -1,4 +1,4 @@
-import Swup from '../Swup.js';
+import type Swup from '../Swup.js';
 import { classify } from '../helpers.js';
 
 /**

--- a/src/modules/awaitAnimations.ts
+++ b/src/modules/awaitAnimations.ts
@@ -1,5 +1,6 @@
 import { queryAll, toMs } from '../utils.js';
-import Swup, { Options } from '../Swup.js';
+import type Swup from '../Swup.js';
+import type { Options } from '../Swup.js';
 
 const TRANSITION = 'transition';
 const ANIMATION = 'animation';

--- a/src/modules/fetchPage.ts
+++ b/src/modules/fetchPage.ts
@@ -1,4 +1,4 @@
-import Swup from '../Swup.js';
+import type Swup from '../Swup.js';
 import { Location } from '../helpers.js';
 
 /** A page object as used by swup and its cache. */

--- a/src/modules/navigate.ts
+++ b/src/modules/navigate.ts
@@ -1,7 +1,7 @@
-import Swup from '../Swup.js';
+import type Swup from '../Swup.js';
 import { createHistoryRecord, updateHistoryRecord, getCurrentUrl, Location } from '../helpers.js';
-import { FetchError, FetchOptions, PageData } from './fetchPage.js';
-import { VisitInitOptions } from './Visit.js';
+import { FetchError, type FetchOptions, type PageData } from './fetchPage.js';
+import type { VisitInitOptions } from './Visit.js';
 
 export type HistoryAction = 'push' | 'replace';
 export type HistoryDirection = 'forwards' | 'backwards';

--- a/src/modules/plugins.ts
+++ b/src/modules/plugins.ts
@@ -1,4 +1,4 @@
-import Swup from '../Swup.js';
+import type Swup from '../Swup.js';
 
 export type Plugin = {
 	/** Identify as a swup plugin */

--- a/src/modules/renderPage.ts
+++ b/src/modules/renderPage.ts
@@ -1,6 +1,6 @@
 import { updateHistoryRecord, getCurrentUrl, classify } from '../helpers.js';
-import Swup from '../Swup.js';
-import { PageData } from './fetchPage.js';
+import type Swup from '../Swup.js';
+import type { PageData } from './fetchPage.js';
 
 /**
  * Render the next page: replace the content and update scroll position.

--- a/src/modules/replaceContent.ts
+++ b/src/modules/replaceContent.ts
@@ -1,6 +1,7 @@
-import Swup, { Options } from '../Swup.js';
+import type Swup from '../Swup.js';
+import type { Options } from '../Swup.js';
 import { query, queryAll } from '../utils.js';
-import { PageData } from './fetchPage.js';
+import type { PageData } from './fetchPage.js';
 
 /**
  * Perform the replacement of content after loading a page.

--- a/src/modules/resolveUrl.ts
+++ b/src/modules/resolveUrl.ts
@@ -1,4 +1,4 @@
-import Swup from '../Swup.js';
+import type Swup from '../Swup.js';
 
 /**
  * Utility function to validate and run the global option 'resolveUrl'

--- a/src/modules/scrollToContent.ts
+++ b/src/modules/scrollToContent.ts
@@ -1,4 +1,4 @@
-import Swup from '../Swup.js';
+import type Swup from '../Swup.js';
 
 /**
  * Update the scroll position after page render.

--- a/tests/functional/main.spec.ts
+++ b/tests/functional/main.spec.ts
@@ -1,4 +1,4 @@
-import Swup from '../../src/Swup.js';
+import type Swup from '../../src/Swup.js';
 
 declare global {
 	interface Window {

--- a/tests/unit/exports.test.ts
+++ b/tests/unit/exports.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
 import pckg from '../../package.json';
-import Swup, { Options, Plugin } from '../../src/index.js';
+import Swup from '../../src/index.js';
+import type { Options, Plugin } from '../../src/index.js';
 import * as SwupTS from '../../src/Swup.js';
 
 describe('Exports', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,104 +1,29 @@
 {
+  /** @see https://www.totaltypescript.com/tsconfig-cheat-sheet#quickstart */
   "include": ["src"],
   "compilerOptions": {
-    /* Visit https://aka.ms/tsconfig to read more about this file */
-
-    /* Projects */
-    // "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
-    // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
-    // "tsBuildInfoFile": "./.tsbuildinfo",              /* Specify the path to .tsbuildinfo incremental compilation file. */
-    // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects. */
-    // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
-    // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
-
-    /* Language and Environment */
-    "target": "ESNext",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
-    // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
-    // "jsx": "preserve",                                /* Specify what JSX code is generated. */
-    // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
-    // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
-    // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'. */
-    // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
-    // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using 'jsx: react-jsx*'. */
-    // "reactNamespace": "",                             /* Specify the object invoked for 'createElement'. This only applies when targeting 'react' JSX emit. */
-    // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
-    // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
-    // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
-
-    /* Modules */
-    "module": "Node16",                                  /* Specify what module code is generated. */
-    "rootDir": "./src",                                  /* Specify the root folder within your source files. */
-    "moduleResolution": "Node16",                        /* Specify how TypeScript looks up a file from a given module specifier. */
-    // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
-    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
-    // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
-    // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
-    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
-    // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
-    // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
-    "resolveJsonModule": true,                           /* Enable importing .json files. */
-    // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
-
-    /* JavaScript Support */
-    "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
-    // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
-    // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
-
-    /* Emit */
-    // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
-    // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
-    // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
-    // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
-    // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
-    "outDir": "./dist",                                  /* Specify an output folder for all emitted files. */
-    // "removeComments": true,                           /* Disable emitting comments. */
-    // "noEmit": true,                                   /* Disable emitting files from a compilation. */
-    // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
-    // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types. */
-    // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
-    // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
-    // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
-    // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
-    // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
-    // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
-    // "newLine": "crlf",                                /* Set the newline character for emitting files. */
-    // "stripInternal": true,                            /* Disable emitting declarations that have '@internal' in their JSDoc comments. */
-    // "noEmitHelpers": true,                            /* Disable generating custom helper functions like '__extends' in compiled output. */
-    // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
-    // "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
-    // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
-    // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
-
-    /* Interop Constraints */
-    // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
-    // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
-    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
-    // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
-    // "forceConsistentCasingInFileNames": true,         /* Ensure that casing is correct in imports. */
-
-    /* Type Checking */
-    "strict": true                                      /* Enable all strict type-checking options. */
-    // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
-    // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
-    // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
-    // "strictBindCallApply": true,                      /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
-    // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
-    // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
-    // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
-    // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
-    // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
-    // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */
-    // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
-    // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
-    // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
-    // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
-    // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
-    // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
-    // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
-    // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
-
-    /* Completeness */
-    // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
-    // "skipLibCheck": true                              /* Skip type checking all .d.ts files. */
+    /* Base Options: */
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "target": "es2022",
+    "verbatimModuleSyntax": true,
+    "allowJs": true,
+    "resolveJsonModule": true,
+    "moduleDetection": "force",
+    /* Strictness */
+    "strict": true,
+    // "noUncheckedIndexedAccess": true,
+    /* If transpiling with TypeScript: */
+    "moduleResolution": "NodeNext",
+    "module": "NodeNext",
+    "rootDir": "src",
+    "outDir": "dist",
+    "sourceMap": true,
+    /* If your code runs in the DOM: */
+    "lib": ["es2022", "dom", "dom.iterable"],
+    /* If you're building for a library: */
+    "declaration": true,
+    /* If you're building for a library in a monorepo: */
+    "declarationMap": true
   },
 }


### PR DESCRIPTION
**Description**

Currently, if you alt-click on swup code, you will jump to a `d.ts` file. I would prefer if we could instead jump to the actual implementation. This PR enables that by activating type map files.

Inspiration from here:

https://blog.liblab.com/typescript-npm-packages-done-right/#setting-up-tsc-for-optimal-developer-experience

And here:

https://www.totaltypescript.com/tsconfig-cheat-sheet#quickstart

**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)