### PR TITLE
Mangle private properties

### DIFF
--- a/mangle.json
+++ b/mangle.json
@@ -1,0 +1,9 @@
+{
+  "minify": {
+    "mangle": {
+      "properties": {
+        "regex": "^_"
+      }
+    }
+  }
+}

--- a/mangle.json
+++ b/mangle.json
@@ -1,9 +1,26 @@
 {
+  "help": {
+    "what is this file?": "It controls protected/private property mangling so that minified builds have consistent property names.",
+    "why are there duplicate minified properties?": "Most properties are only used on one type of objects, so they can have the same name since they will never collide. Doing this reduces size."
+  },
   "minify": {
     "mangle": {
       "properties": {
-        "regex": "^_"
+        "regex": "^_[^_]",
+        "reserved": []
       }
+    },
+    "compress": {
+      "keep_fargs": false,
+      "module": true,
+      "unsafe_arrows": true,
+      "unsafe_comps": true,
+      "unsafe_math": true,
+      "unsafe_methods": true,
+      "unsafe_proto": true,
+      "passes": 2,
+      "ecma": "2015"
     }
-  }
+  },
+  "props": {}
 }

--- a/src/modules/Cache.ts
+++ b/src/modules/Cache.ts
@@ -9,24 +9,24 @@ export interface CacheData extends PageData {}
  */
 export class Cache {
 	/** Swup instance this cache belongs to */
-	protected swup: Swup;
+	protected _swup: Swup;
 
 	/** Cached pages, indexed by URL */
-	protected pages: Map<string, CacheData> = new Map();
+	protected _pages: Map<string, CacheData> = new Map();
 
 	constructor(swup: Swup) {
-		this.swup = swup;
+		this._swup = swup;
 	}
 
 	/** Number of cached pages in memory. */
 	get size(): number {
-		return this.pages.size;
+		return this._pages.size;
 	}
 
 	/** All cached pages. */
 	get all() {
 		const copy = new Map();
-		this.pages.forEach((page, key) => {
+		this._pages.forEach((page, key) => {
 			copy.set(key, { ...page });
 		});
 		return copy;
@@ -34,45 +34,45 @@ export class Cache {
 
 	/** Check if the given URL has been cached. */
 	has(url: string): boolean {
-		return this.pages.has(this.resolve(url));
+		return this._pages.has(this._resolve(url));
 	}
 
 	/** Return a shallow copy of the cached page object if available. */
 	get(url: string): CacheData | undefined {
-		const result = this.pages.get(this.resolve(url));
+		const result = this._pages.get(this._resolve(url));
 		if (!result) return result;
 		return { ...result };
 	}
 
 	/** Create a cache record for the specified URL. */
 	set(url: string, page: CacheData) {
-		url = this.resolve(url);
+		url = this._resolve(url);
 		page = { ...page, url };
-		this.pages.set(url, page);
-		this.swup.hooks.callSync('cache:set', { page });
+		this._pages.set(url, page);
+		this._swup.hooks.callSync('cache:set', { page });
 	}
 
 	/** Update a cache record, overwriting or adding custom data. */
 	update(url: string, payload: object) {
-		url = this.resolve(url);
+		url = this._resolve(url);
 		const page = { ...this.get(url), ...payload, url } as CacheData;
-		this.pages.set(url, page);
+		this._pages.set(url, page);
 	}
 
 	/** Delete a cache record. */
 	delete(url: string): void {
-		this.pages.delete(this.resolve(url));
+		this._pages.delete(this._resolve(url));
 	}
 
 	/** Empty the cache. */
 	clear(): void {
-		this.pages.clear();
-		this.swup.hooks.callSync('cache:clear', undefined);
+		this._pages.clear();
+		this._swup.hooks.callSync('cache:clear', undefined);
 	}
 
 	/** Remove all cache entries that return true for a given predicate function.  */
 	prune(predicate: (url: string, page: CacheData) => boolean): void {
-		this.pages.forEach((page, url) => {
+		this._pages.forEach((page, url) => {
 			if (predicate(url, page)) {
 				this.delete(url);
 			}
@@ -80,8 +80,8 @@ export class Cache {
 	}
 
 	/** Resolve URLs by making them local and letting swup resolve them. */
-	protected resolve(urlToResolve: string): string {
+	protected _resolve(urlToResolve: string): string {
 		const { url } = Location.fromUrl(urlToResolve);
-		return this.swup.resolveUrl(url);
+		return this._swup.resolveUrl(url);
 	}
 }

--- a/src/modules/Classes.ts
+++ b/src/modules/Classes.ts
@@ -2,46 +2,46 @@ import type Swup from '../Swup.js';
 import { queryAll } from '../utils.js';
 
 export class Classes {
-	protected swup: Swup;
-	protected swupClasses = ['to-', 'is-changing', 'is-rendering', 'is-popstate', 'is-animating'];
+	protected _swup: Swup;
+	protected _swupClasses = ['to-', 'is-changing', 'is-rendering', 'is-popstate', 'is-animating'];
 
 	constructor(swup: Swup) {
-		this.swup = swup;
+		this._swup = swup;
 	}
 
-	protected get selectors(): string[] {
-		const { scope } = this.swup.visit.animation;
-		if (scope === 'containers') return this.swup.visit.containers;
+	protected get _selectors(): string[] {
+		const { scope } = this._swup.visit.animation;
+		if (scope === 'containers') return this._swup.visit.containers;
 		if (scope === 'html') return ['html'];
 		if (Array.isArray(scope)) return scope;
 		return [];
 	}
 
-	protected get selector(): string {
-		return this.selectors.join(',');
+	protected get _selector(): string {
+		return this._selectors.join(',');
 	}
 
-	protected get targets(): HTMLElement[] {
-		if (!this.selector.trim()) return [];
-		return queryAll(this.selector);
+	protected get _targets(): HTMLElement[] {
+		if (!this._selector.trim()) return [];
+		return queryAll(this._selector);
 	}
 
 	add(...classes: string[]): void {
-		this.targets.forEach((target) => target.classList.add(...classes));
+		this._targets.forEach((target) => target.classList.add(...classes));
 	}
 
 	remove(...classes: string[]): void {
-		this.targets.forEach((target) => target.classList.remove(...classes));
+		this._targets.forEach((target) => target.classList.remove(...classes));
 	}
 
 	clear(): void {
-		this.targets.forEach((target) => {
-			const remove = target.className.split(' ').filter((c) => this.isSwupClass(c));
+		this._targets.forEach((target) => {
+			const remove = target.className.split(' ').filter((c) => this._isSwupClass(c));
 			target.classList.remove(...remove);
 		});
 	}
 
-	protected isSwupClass(className: string): boolean {
-		return this.swupClasses.some((c) => className.startsWith(c));
+	protected _isSwupClass(className: string): boolean {
+		return this._swupClasses.some((c) => className.startsWith(c));
 	}
 }

--- a/src/modules/navigate.ts
+++ b/src/modules/navigate.ts
@@ -43,8 +43,8 @@ export function navigate(
 	}
 
 	const { url: to, hash } = Location.fromUrl(url);
-	this.visit = this.createVisit({ ...init, to, hash });
-	this.performNavigation(options);
+	this.visit = this._createVisit({ ...init, to, hash });
+	this._performNavigation(options);
 }
 
 /**
@@ -62,7 +62,7 @@ export async function performNavigation(
 	this: Swup,
 	options: NavigationOptions & FetchOptions = {}
 ): Promise<void> {
-	this.navigating = true;
+	this._navigating = true;
 	// Save this localy to a) allow ignoring the visit if a new one was started in the meantime
 	// and b) avoid unintended modifications to any newer visits
 	const visit = this.visit;
@@ -125,8 +125,8 @@ export async function performNavigation(
 			if (visit.history.action === 'replace' || visit.to.url === this.currentPageUrl) {
 				updateHistoryRecord(newUrl);
 			} else {
-				this.currentHistoryIndex++;
-				createHistoryRecord(newUrl, { index: this.currentHistoryIndex });
+				this._currentHistoryIndex++;
+				createHistoryRecord(newUrl, { index: this._currentHistoryIndex });
 			}
 		}
 
@@ -141,7 +141,7 @@ export async function performNavigation(
 		// perform the actual transition: animate and replace content
 		await this.hooks.call('visit:transition', undefined, async (visit) => {
 			// Start leave animation
-			const animationPromise = this.animatePageOut();
+			const animationPromise = this._animatePageOut();
 
 			// Wait for page to load and leave animation to finish
 			const [page] = await Promise.all([pagePromise, animationPromise]);
@@ -152,10 +152,10 @@ export async function performNavigation(
 			}
 
 			// Render page: replace content and scroll to top/fragment
-			await this.renderPage(page);
+			await this._renderPage(page);
 
 			// Wait for enter animation
-			await this.animatePageIn();
+			await this._animatePageIn();
 
 			return true;
 		});
@@ -167,7 +167,7 @@ export async function performNavigation(
 		// if (visit.to && this.isSameResolvedUrl(visit.to.url, requestedUrl)) {
 		// 	this.visit = this.createVisit({ to: undefined });
 		// }
-		this.navigating = false;
+		this._navigating = false;
 	} catch (error) {
 		// Return early if error is undefined or signals an aborted request
 		if (!error || (error as FetchError)?.aborted) {

--- a/src/modules/renderPage.ts
+++ b/src/modules/renderPage.ts
@@ -11,7 +11,7 @@ export const renderPage = async function (this: Swup, page: PageData): Promise<v
 	this.classes.remove('is-leaving');
 
 	// update state if the url was redirected
-	if (!this.isSameResolvedUrl(getCurrentUrl(), url)) {
+	if (!this._isSameResolvedUrl(getCurrentUrl(), url)) {
 		updateHistoryRecord(url);
 		this.currentPageUrl = getCurrentUrl();
 		this.visit.to.url = this.currentPageUrl;
@@ -43,7 +43,7 @@ export const renderPage = async function (this: Swup, page: PageData): Promise<v
 	// scroll into view: either anchor or top of page
 	// @ts-ignore: not returning a promise is intentional to allow users to pause in handler
 	await this.hooks.call('content:scroll', undefined, () => {
-		return this.scrollToContent();
+		return this._scrollToContent();
 	});
 
 	await this.hooks.call('page:view', { url: this.currentPageUrl, title: document.title });


### PR DESCRIPTION
**Description**

- Decrease bundle size by mangling private properties: `swup._performNavigation` → `swup.d`
- Requires prepending underscores for now
- Would prefer if this could be automatic just by the `protected` status of a property/method
- Tests currently breaking as we're relying on access to some private props of internal classes

**Checks**

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [ ] All tests are passing (`npm run test`)
- [ ] ~~New or updated tests are included~~
- [ ] ~~The documentation was updated as required~~