### PR TITLE
Export hook return value and default handler types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,12 +14,14 @@ import type {
 	VisitHistory
 } from './modules/Visit.js';
 import type {
-	HookArguments,
-	HookDefinitions,
 	HookName,
+	HookDefinitions,
+	HookArguments,
+	HookReturnValues,
+	HookHandler,
+	HookDefaultHandler,
 	HookOptions,
-	HookUnregister,
-	Handler
+	HookUnregister
 } from './modules/Hooks.js';
 import type { Plugin } from './modules/plugins.js';
 
@@ -32,19 +34,22 @@ export type {
 	Plugin,
 	CacheData,
 	PageData,
+	Path,
 	Visit,
 	VisitFrom,
 	VisitTo,
 	VisitAnimation,
 	VisitScroll,
 	VisitHistory,
-	HookArguments,
-	HookDefinitions,
 	HookName,
+	HookDefinitions,
+	HookArguments,
+	HookReturnValues,
+	HookHandler,
+	HookHandler as Handler, // backwards compatibility
+	HookDefaultHandler,
 	HookOptions,
 	HookUnregister,
-	Handler,
-	Path,
 	DelegateEvent,
 	DelegateEventHandler,
 	DelegateEventUnsubscribe

--- a/tests/unit/hooks.test.ts
+++ b/tests/unit/hooks.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import Swup from '../../src/Swup.js';
-import { DefaultHandler, Handler, Hooks } from '../../src/modules/Hooks.js';
-import { Visit } from '../../src/modules/Visit.js';
+import { Hooks, type HookHandler, type HookDefaultHandler } from '../../src/modules/Hooks.js';
+import { type Visit } from '../../src/modules/Visit.js';
 
 describe('Hook registry', () => {
 	it('should add handlers', () => {
@@ -286,7 +286,7 @@ describe('Hook registry', () => {
 
 	it('should trigger event handler with visit and args', async () => {
 		const swup = new Swup();
-		const handler: Handler<'history:popstate'> = vi.fn();
+		const handler: HookHandler<'history:popstate'> = vi.fn();
 		const visit = swup.visit;
 		const args = { event: new PopStateEvent('') };
 
@@ -314,6 +314,6 @@ describe('Types', () => {
 		// @ts-expect-error: event arg must be PopStateEvent
 		await swup.hooks.call('history:popstate', { event: new MouseEvent('') });
 		// @ts-expect-error: handler arg must be optional: handler?
-		swup.hooks.replace('enable', (visit: Visit, args: undefined, handler: DefaultHandler<'enable'>) => {});
+		swup.hooks.replace('enable', (visit: Visit, args: undefined, handler: HookDefaultHandler<'enable'>) => {});
 	});
 });


### PR DESCRIPTION
**Description**

- Export `DefaultHandler` type so plugins can define them properly
- Rename `Handler` to `HookHandler` and `DefaultHandler` to `DefaultHookHandler` to unify naming of types
- Keep `Handler` type as alias for backward compatibility

**Checks**

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [x] New or updated tests are included
- [ ] ~~The documentation was updated as required~~
