### PR TITLE
Native mode for built-in View Transition support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@playwright/test": "^1.37.1",
         "@swup/browserslist-config": "^1.0.0",
         "@swup/prettier-config": "^1.0.0",
+        "@types/dom-view-transitions": "^1.0.2",
         "@types/jsdom": "^21.1.1",
         "@typescript-eslint/eslint-plugin": "^6.3.0",
         "@typescript-eslint/parser": "^6.3.0",
@@ -2787,6 +2788,12 @@
       "dependencies": {
         "@types/chai": "*"
       }
+    },
+    "node_modules/@types/dom-view-transitions": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/dom-view-transitions/-/dom-view-transitions-1.0.2.tgz",
+      "integrity": "sha512-+ctRyzGMOZB5AbvhpTv37OWkP9N3Xxfac7bhS7AcuRMmO03SHxm5/5kWCPtcatx2gW+NhFMdl7l1DqJvvPVtwg==",
+      "dev": true
     },
     "node_modules/@types/estree": {
       "version": "0.0.39",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@playwright/test": "^1.37.1",
     "@swup/browserslist-config": "^1.0.0",
     "@swup/prettier-config": "^1.0.0",
+    "@types/dom-view-transitions": "^1.0.2",
     "@types/jsdom": "^21.1.1",
     "@typescript-eslint/eslint-plugin": "^6.3.0",
     "@typescript-eslint/parser": "^6.3.0",

--- a/src/Swup.ts
+++ b/src/Swup.ts
@@ -167,7 +167,7 @@ export default class Swup {
 			return false;
 		}
 		if (this.options.native && !('startViewTransition' in document)) {
-			console.warn('Native View Transitions are not supported');
+			this.log('Native View Transitions are not supported');
 			this.options.native = false;
 		}
 		return true;

--- a/src/Swup.ts
+++ b/src/Swup.ts
@@ -41,6 +41,8 @@ export type Options = {
 	linkSelector: string;
 	/** How swup handles links to the same page. Default: `scroll` */
 	linkToSelf: NavigationToSelfAction;
+	/** Enable native animations using the View Transitions API. */
+	native: boolean;
 	/** Plugins to register on startup. */
 	plugins: Plugin[];
 	/** Custom headers sent along with fetch requests. */
@@ -62,6 +64,7 @@ const defaults: Options = {
 	ignoreVisit: (url, { el } = {}) => !!el?.closest('[data-no-swup]'),
 	linkSelector: 'a[href]',
 	linkToSelf: 'scroll',
+	native: false,
 	plugins: [],
 	resolveUrl: (url) => url,
 	requestHeaders: {
@@ -162,6 +165,10 @@ export default class Swup {
 		if (typeof Promise === 'undefined') {
 			console.warn('Promise is not supported');
 			return false;
+		}
+		if (this.options.native && !('startViewTransition' in document)) {
+			console.warn('Native View Transitions are not supported');
+			this.options.native = false;
 		}
 		return true;
 	}

--- a/src/modules/Hooks.ts
+++ b/src/modules/Hooks.ts
@@ -42,7 +42,6 @@ export interface HookReturnValues {
 	'page:load': Promise<PageData>;
 	'scroll:top': boolean;
 	'scroll:anchor': boolean;
-	'visit:transition': Promise<boolean>;
 }
 
 export type HookArguments<T extends HookName> = HookDefinitions[T];

--- a/src/modules/animatePageIn.ts
+++ b/src/modules/animatePageIn.ts
@@ -6,14 +6,10 @@ import { nextTick } from '../utils.js';
  * @returns Promise<void>
  */
 export const animatePageIn = async function (this: Swup) {
-	const animation = this.hooks.call(
-		'animation:in:await',
-		{ skip: false },
-		async (visit, { skip }) => {
-			if (skip) return;
-			await this.awaitAnimations({ selector: visit.animation.selector });
-		}
-	);
+	const animation = this.hooks.call('animation:in:await', { skip: false }, (visit, { skip }) => {
+		if (skip) return;
+		return this.awaitAnimations({ selector: visit.animation.selector });
+	});
 
 	await nextTick();
 

--- a/src/modules/animatePageIn.ts
+++ b/src/modules/animatePageIn.ts
@@ -6,10 +6,6 @@ import { nextTick } from '../utils.js';
  * @returns Promise<void>
  */
 export const animatePageIn = async function (this: Swup) {
-	if (!this.visit.animation.animate) {
-		return;
-	}
-
 	const animation = this.hooks.call(
 		'animation:in:await',
 		{ skip: false },

--- a/src/modules/animatePageOut.ts
+++ b/src/modules/animatePageOut.ts
@@ -6,11 +6,6 @@ import { classify } from '../helpers.js';
  * @returns Promise<void>
  */
 export const animatePageOut = async function (this: Swup) {
-	if (!this.visit.animation.animate) {
-		await this.hooks.call('animation:skip', undefined);
-		return;
-	}
-
 	await this.hooks.call('animation:out:start', undefined, (visit) => {
 		this.classes.add('is-changing', 'is-leaving', 'is-animating');
 		if (visit.history.popstate) {

--- a/src/modules/animatePageOut.ts
+++ b/src/modules/animatePageOut.ts
@@ -1,24 +1,17 @@
 import type Swup from '../Swup.js';
-import { classify } from '../helpers.js';
 
 /**
  * Perform the out/leave animation of the current page.
  * @returns Promise<void>
  */
 export const animatePageOut = async function (this: Swup) {
-	await this.hooks.call('animation:out:start', undefined, (visit) => {
+	await this.hooks.call('animation:out:start', undefined, () => {
 		this.classes.add('is-changing', 'is-leaving', 'is-animating');
-		if (visit.history.popstate) {
-			this.classes.add('is-popstate');
-		}
-		if (visit.animation.name) {
-			this.classes.add(`to-${classify(visit.animation.name)}`);
-		}
 	});
 
-	await this.hooks.call('animation:out:await', { skip: false }, async (visit, { skip }) => {
+	await this.hooks.call('animation:out:await', { skip: false }, (visit, { skip }) => {
 		if (skip) return;
-		await this.awaitAnimations({ selector: visit.animation.selector });
+		return this.awaitAnimations({ selector: visit.animation.selector });
 	});
 
 	await this.hooks.call('animation:out:end', undefined);

--- a/src/modules/navigate.ts
+++ b/src/modules/navigate.ts
@@ -1,5 +1,11 @@
 import type Swup from '../Swup.js';
-import { createHistoryRecord, updateHistoryRecord, getCurrentUrl, Location } from '../helpers.js';
+import {
+	classify,
+	createHistoryRecord,
+	updateHistoryRecord,
+	getCurrentUrl,
+	Location
+} from '../helpers.js';
 import { FetchError, type FetchOptions, type PageData } from './fetchPage.js';
 import type { VisitInitOptions } from './Visit.js';
 
@@ -131,6 +137,14 @@ export async function performNavigation(
 		}
 
 		this.currentPageUrl = getCurrentUrl();
+
+		// Mark visit type with classes on html element
+		if (visit.history.popstate) {
+			this.classes.add('is-popstate');
+		}
+		if (visit.animation.name) {
+			this.classes.add(`to-${classify(visit.animation.name)}`);
+		}
 
 		// Wait for page before starting to animate out?
 		if (visit.animation.wait) {

--- a/src/modules/navigate.ts
+++ b/src/modules/navigate.ts
@@ -140,17 +140,23 @@ export async function performNavigation(
 
 		// Perform the actual transition: animate and replace content
 		await this.hooks.call('visit:transition', undefined, async (visit) => {
-			if (this.options.native) {
+			if (visit.animation.animate && this.options.native) {
 				const page = await pagePromise;
 				if (visit.id === this.visit.id) {
 					await document.startViewTransition(() => this.renderPage(page)).finished;
 				}
-			} else {
+			} else if (visit.animation.animate) {
 				const animationPromise = this.animatePageOut();
 				const [page] = await Promise.all([pagePromise, animationPromise]);
 				if (visit.id === this.visit.id) {
 					await this.renderPage(page);
 					await this.animatePageIn();
+				}
+			} else {
+				await this.hooks.call('animation:skip', undefined);
+				const page = await pagePromise;
+				if (visit.id === this.visit.id) {
+					await this.renderPage(page);
 				}
 			}
 		});


### PR DESCRIPTION
**Description**

- Builds on #779 
- New `native` option to enable [View Transition](https://developer.mozilla.org/en-US/docs/Web/API/View_Transitions_API) support
- Native mode skips all `animation:*` hooks
- Works great in local playground for basic scenarios

**To-do**

- Fallback strategy for unsupported browsers
- Strategy for dynamic containers
- Functional tests

**Questions**

- How do we deal with dynamic containers? How can we mark them as "changing"?
  - We can use a new class `is-transitioning` to mark containers
  - We can replace the whole body as users now have precise control over what is transitioned
  - We can make users rely on custom routes and fragment visit names to specify view transitions
- Should the `animation:*` hooks fire on native transitions as well? I'd say no, as they're tied to swup's CSS logic

**Follow-ups**

- We should think about the concept of pluggable/modular animation handlers (Native, CSS, JS, None)
- Something like that would reduce bundle size and improve control flow
- Sounds like a project for v5 🤪
- Or we integrate this into v4 and load a CSS handler by default to avoid breaking changes

**Checks**

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [ ] New or updated tests are included
- [ ] The documentation was updated as required
