### PR TITLE
Fix class inheritance in Safari 13

### DIFF
--- a/src/helpers/Location.ts
+++ b/src/helpers/Location.ts
@@ -6,6 +6,7 @@
 export class Location extends URL {
 	constructor(url: URL | string, base: string = document.baseURI) {
 		super(url.toString(), base);
+		Object.setPrototypeOf(this, Location.prototype);
 	}
 
 	/**

--- a/tests/unit/location.test.ts
+++ b/tests/unit/location.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { Location } from '../../src/helpers/Location.js';
+
+describe('Location', () => {
+	it('has an href', () => {
+		const location = new Location('/path?query#anchor');
+		expect(location.href).to.eq('http://localhost:3000/path?query#anchor');
+	});
+	it('accepts a base', () => {
+		const location = new Location('/path?query#anchor', 'http://example.net');
+		expect(location.href).to.eq('http://example.net/path?query#anchor');
+	});
+	it('has a url', () => {
+		const location = new Location('/path?query#anchor');
+		expect(location.url).to.eq('/path?query');
+	});
+});

--- a/tests/unit/location.test.ts
+++ b/tests/unit/location.test.ts
@@ -6,12 +6,21 @@ describe('Location', () => {
 		const location = new Location('/path?query#anchor');
 		expect(location.href).to.eq('http://localhost:3000/path?query#anchor');
 	});
-	it('accepts a base', () => {
-		const location = new Location('/path?query#anchor', 'http://example.net');
-		expect(location.href).to.eq('http://example.net/path?query#anchor');
-	});
 	it('has a url', () => {
 		const location = new Location('/path?query#anchor');
+		expect(location.url).to.eq('/path?query');
+	});
+	it('accepts a base', () => {
+		const location = new Location('/path?query#anchor', 'http://base.net');
+		expect(location.href).to.eq('http://base.net/path?query#anchor');
+	});
+	it('accepts absolute URLs', () => {
+		const location = new Location('http://example.net/path?query#anchor', 'http://base.net');
+		expect(location.href).to.eq('http://example.net/path?query#anchor');
+	});
+	it('allows static creation', () => {
+		const location = Location.fromUrl('http://example.net/path?query#anchor');
+		expect(location.href).to.eq('http://example.net/path?query#anchor');
 		expect(location.url).to.eq('/path?query');
 	});
 });


### PR DESCRIPTION
**Description**

- Fix issue #822
- Safari below 14 doesn't fully support extending built-in classes
- This breaks our custom `Location.url` getter, returning `undefined` in Safari 13.1 and below
- The proposed fix by @MrCaumartin fixes it in Safari by forcing the prototype
- Also, added unit tests for the `Location` class

**Checks**

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [x] New or updated tests are included
- [ ] ~~The documentation was updated as required~~
