### PR TITLE
fix: Alpine.js compatibility

### DIFF
--- a/src/modules/Hooks.ts
+++ b/src/modules/Hooks.ts
@@ -494,7 +494,7 @@ export class Hooks {
 	 */
 	protected dispatchDomEvent<T extends HookName>(hook: T, args?: HookArguments<T>): void {
 		const detail = { hook, args, visit: this.swup.visit };
-		document.dispatchEvent(new CustomEvent(`swup:all`, { detail, bubbles: true }));
+		document.dispatchEvent(new CustomEvent(`swup:any`, { detail, bubbles: true }));
 		document.dispatchEvent(new CustomEvent(`swup:${hook}`, { detail, bubbles: true }));
 	}
 }

--- a/src/modules/Hooks.ts
+++ b/src/modules/Hooks.ts
@@ -494,7 +494,7 @@ export class Hooks {
 	 */
 	protected dispatchDomEvent<T extends HookName>(hook: T, args?: HookArguments<T>): void {
 		const detail = { hook, args, visit: this.swup.visit };
-		document.dispatchEvent(new CustomEvent(`swup:*`, { detail, bubbles: true }));
+		document.dispatchEvent(new CustomEvent(`swup:all`, { detail, bubbles: true }));
 		document.dispatchEvent(new CustomEvent(`swup:${hook}`, { detail, bubbles: true }));
 	}
 }

--- a/tests/fixtures/alpinejs/page-1.html
+++ b/tests/fixtures/alpinejs/page-1.html
@@ -15,7 +15,7 @@
 				x-data="{ clickFired: false, allFired: false }"
 				:class="{'click-fired': clickFired, 'all-fired': allFired}"
 				x-on:swup:link:click.window="clickFired = true"
-				x-on:swup:all.window="allFired = true"
+				x-on:swup:any.window="allFired = true"
 			>
 				Alpine Component
 			</div>

--- a/tests/fixtures/alpinejs/page-1.html
+++ b/tests/fixtures/alpinejs/page-1.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>Page 1</title>
+		<link rel="stylesheet" href="/assets/main.css" />
+		<script src="/dist/Swup.umd.js"></script>
+		<script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3/dist/cdn.min.js"></script>
+	</head>
+	<body>
+		<header class="header">
+			<div
+				class="alpine-component"
+				x-data="{ clickFired: false, allFired: false }"
+				:class="{'click-fired': clickFired, 'all-fired': allFired}"
+				x-on:swup:link:click.window="clickFired = true"
+				x-on:swup:all.window="allFired = true"
+			>
+				Alpine Component
+			</div>
+			<ul>
+				<li><a href="/alpinejs/page-1.html" data-testid="link-to-page-1">Page 1</a></li>
+				<li><a href="/alpinejs/page-2.html" data-testid="link-to-page-2">Page 2</a></li>
+			</ul>
+		</header>
+		<main id="swup" class="wrapper transition-default" data-testid="container">
+			<div class="wrapper-inner">
+				<h1>Page 1</h1>
+				<p>
+					Lorem ipsum dolor sit amet, consectetur adipisicing elit. Alias assumenda
+					consectetur consequatur enim esse incidunt iusto, magnam maxime molestias nisi
+					perferendis perspiciatis quibusdam quos repellat, vel veniam vero voluptate
+					voluptatem.
+				</p>
+				<p>
+					Lorem ipsum dolor sit amet, consectetur adipisicing elit. Alias assumenda
+					consectetur consequatur enim esse incidunt iusto, magnam maxime molestias nisi
+					perferendis perspiciatis quibusdam quos repellat, vel veniam vero voluptate
+					voluptatem.
+				</p>
+				<p>
+					Lorem ipsum dolor sit amet, consectetur adipisicing elit. Alias assumenda
+					consectetur consequatur enim esse incidunt iusto, magnam maxime molestias nisi
+					perferendis perspiciatis quibusdam quos repellat, vel veniam vero voluptate
+					voluptatem.
+				</p>
+				<p>
+					Lorem ipsum dolor sit amet, consectetur adipisicing elit. Alias assumenda
+					consectetur consequatur enim esse incidunt iusto, magnam maxime molestias nisi
+					perferendis perspiciatis quibusdam quos repellat, vel veniam vero voluptate
+					voluptatem.
+				</p>
+				<p>
+					Lorem ipsum dolor sit amet, consectetur adipisicing elit. Alias assumenda
+					consectetur consequatur enim esse incidunt iusto, magnam maxime molestias nisi
+					perferendis perspiciatis quibusdam quos repellat, vel veniam vero voluptate
+					voluptatem.
+				</p>
+				<p>
+					Lorem ipsum dolor sit amet, consectetur adipisicing elit. Alias assumenda
+					consectetur consequatur enim esse incidunt iusto, magnam maxime molestias nisi
+					perferendis perspiciatis quibusdam quos repellat, vel veniam vero voluptate
+					voluptatem.
+				</p>
+				<p>
+					Lorem ipsum dolor sit amet, consectetur adipisicing elit. Alias assumenda
+					consectetur consequatur enim esse incidunt iusto, magnam maxime molestias nisi
+					perferendis perspiciatis quibusdam quos repellat, vel veniam vero voluptate
+					voluptatem.
+				</p>
+				<p>
+					Lorem ipsum dolor sit amet, consectetur adipisicing elit. Alias assumenda
+					consectetur consequatur enim esse incidunt iusto, magnam maxime molestias nisi
+					perferendis perspiciatis quibusdam quos repellat, vel veniam vero voluptate
+					voluptatem.
+				</p>
+				<p>
+					<a href="/page-2.html" data-swup-animation="custom">Custom animation</a>
+				</p>
+			</div>
+		</main>
+		<script>
+			window._swup = new Swup();
+		</script>
+	</body>
+</html>

--- a/tests/fixtures/alpinejs/page-1.html
+++ b/tests/fixtures/alpinejs/page-1.html
@@ -12,10 +12,10 @@
 		<header class="header">
 			<div
 				class="alpine-component"
-				x-data="{ clickFired: false, allFired: false }"
-				:class="{'click-fired': clickFired, 'all-fired': allFired}"
+				x-data="{ clickFired: false, anyFired: false }"
+				:class="{'click-fired': clickFired, 'any-fired': anyFired}"
 				x-on:swup:link:click.window="clickFired = true"
-				x-on:swup:any.window="allFired = true"
+				x-on:swup:any.window="anyFired = true"
 			>
 				Alpine Component
 			</div>

--- a/tests/fixtures/alpinejs/page-2.html
+++ b/tests/fixtures/alpinejs/page-2.html
@@ -15,7 +15,7 @@
 				x-data="{ clickFired: false, allFired: false }"
 				:class="{'click-fired': clickFired, 'all-fired': allFired}"
 				x-on:swup:link:click.window="clickFired = true"
-				x-on:swup:all.window="allFired = true"
+				x-on:swup:any.window="allFired = true"
 			>
 				Alpine Component
 			</div>

--- a/tests/fixtures/alpinejs/page-2.html
+++ b/tests/fixtures/alpinejs/page-2.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>Page 2</title>
+		<link rel="stylesheet" href="/assets/main.css" />
+		<script src="/dist/Swup.umd.js"></script>
+		<script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3/dist/cdn.min.js"></script>
+	</head>
+	<body>
+		<header class="header">
+			<div
+				class="alpine-component"
+				x-data="{ clickFired: false, allFired: false }"
+				:class="{'click-fired': clickFired, 'all-fired': allFired}"
+				x-on:swup:link:click.window="clickFired = true"
+				x-on:swup:all.window="allFired = true"
+			>
+				Alpine Component
+			</div>
+			<ul>
+				<li><a href="/alpinejs/page-1.html">Page 1</a></li>
+				<li><a href="/alpinejs/page-2.html">Page 2</a></li>
+			</ul>
+		</header>
+		<main id="swup" class="wrapper transition-default" data-testid="container">
+			<div class="wrapper-inner">
+				<h1>Page 2</h1>
+				<p>
+					Lorem ipsum dolor sit amet, consectetur adipisicing elit. Alias assumenda
+					consectetur consequatur enim esse incidunt iusto, magnam maxime molestias nisi
+					perferendis perspiciatis quibusdam quos repellat, vel veniam vero voluptate
+					voluptatem.
+				</p>
+				<p>
+					Lorem ipsum dolor sit amet, consectetur adipisicing elit. Alias assumenda
+					consectetur consequatur enim esse incidunt iusto, magnam maxime molestias nisi
+					perferendis perspiciatis quibusdam quos repellat, vel veniam vero voluptate
+					voluptatem.
+				</p>
+				<p>
+					Lorem ipsum dolor sit amet, consectetur adipisicing elit. Alias assumenda
+					consectetur consequatur enim esse incidunt iusto, magnam maxime molestias nisi
+					perferendis perspiciatis quibusdam quos repellat, vel veniam vero voluptate
+					voluptatem.
+				</p>
+				<p>
+					Lorem ipsum dolor sit amet, consectetur adipisicing elit. Alias assumenda
+					consectetur consequatur enim esse incidunt iusto, magnam maxime molestias nisi
+					perferendis perspiciatis quibusdam quos repellat, vel veniam vero voluptate
+					voluptatem.
+				</p>
+				<p>
+					Lorem ipsum dolor sit amet, consectetur adipisicing elit. Alias assumenda
+					consectetur consequatur enim esse incidunt iusto, magnam maxime molestias nisi
+					perferendis perspiciatis quibusdam quos repellat, vel veniam vero voluptate
+					voluptatem.
+				</p>
+				<p>
+					Lorem ipsum dolor sit amet, consectetur adipisicing elit. Alias assumenda
+					consectetur consequatur enim esse incidunt iusto, magnam maxime molestias nisi
+					perferendis perspiciatis quibusdam quos repellat, vel veniam vero voluptate
+					voluptatem.
+				</p>
+				<p>
+					Lorem ipsum dolor sit amet, consectetur adipisicing elit. Alias assumenda
+					consectetur consequatur enim esse incidunt iusto, magnam maxime molestias nisi
+					perferendis perspiciatis quibusdam quos repellat, vel veniam vero voluptate
+					voluptatem.
+				</p>
+				<p>
+					Lorem ipsum dolor sit amet, consectetur adipisicing elit. Alias assumenda
+					consectetur consequatur enim esse incidunt iusto, magnam maxime molestias nisi
+					perferendis perspiciatis quibusdam quos repellat, vel veniam vero voluptate
+					voluptatem.
+				</p>
+			</div>
+		</main>
+		<script>
+			window._swup = new Swup();
+		</script>
+	</body>
+</html>

--- a/tests/fixtures/alpinejs/page-2.html
+++ b/tests/fixtures/alpinejs/page-2.html
@@ -12,10 +12,10 @@
 		<header class="header">
 			<div
 				class="alpine-component"
-				x-data="{ clickFired: false, allFired: false }"
-				:class="{'click-fired': clickFired, 'all-fired': allFired}"
+				x-data="{ clickFired: false, anyFired: false }"
+				:class="{'click-fired': clickFired, 'any-fired': anyFired}"
 				x-on:swup:link:click.window="clickFired = true"
-				x-on:swup:any.window="allFired = true"
+				x-on:swup:any.window="anyFired = true"
 			>
 				Alpine Component
 			</div>

--- a/tests/functional/alpinejs.spec.ts
+++ b/tests/functional/alpinejs.spec.ts
@@ -1,0 +1,20 @@
+import { test, expect } from '@playwright/test';
+
+import { waitForSwup } from '../support/swup.js';
+import { clickOnLink } from '../support/commands.js';
+import { prefixed } from '../support/utils.js'
+
+const url = prefixed('/alpinejs/');
+
+test.describe('alpinejs compatibility', () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto(url('/page-1.html'));
+		await waitForSwup(page);
+	});
+
+	test('should listen to dom events', async ({ page }) => {
+		await clickOnLink(page, url('/page-2.html'));
+		await page.waitForSelector('.alpine-component.click-fired');
+		await page.waitForSelector('.alpine-component.all-fired');
+	});
+});

--- a/tests/functional/alpinejs.spec.ts
+++ b/tests/functional/alpinejs.spec.ts
@@ -2,7 +2,7 @@ import { test } from '@playwright/test';
 
 import { waitForSwup } from '../support/swup.js';
 import { clickOnLink } from '../support/commands.js';
-import { prefixed } from '../support/utils.js'
+import { prefixed } from '../support/utils.js';
 
 const url = prefixed('/alpinejs/');
 

--- a/tests/functional/alpinejs.spec.ts
+++ b/tests/functional/alpinejs.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test } from '@playwright/test';
 
 import { waitForSwup } from '../support/swup.js';
 import { clickOnLink } from '../support/commands.js';

--- a/tests/functional/alpinejs.spec.ts
+++ b/tests/functional/alpinejs.spec.ts
@@ -15,6 +15,6 @@ test.describe('alpinejs compatibility', () => {
 	test('should listen to dom events', async ({ page }) => {
 		await clickOnLink(page, url('/page-2.html'));
 		await page.waitForSelector('.alpine-component.click-fired');
-		await page.waitForSelector('.alpine-component.all-fired');
+		await page.waitForSelector('.alpine-component.any-fired');
 	});
 });

--- a/tests/functional/events.spec.ts
+++ b/tests/functional/events.spec.ts
@@ -9,7 +9,10 @@ test.describe('events', () => {
 
 	test('triggers custom dom events on document', async ({ page }) => {
 		await page.evaluate(() => {
-			document.addEventListener('swup:link:click', (event: any) => window.data = event.detail.hook);
+			document.addEventListener(
+				'swup:link:click',
+				(event: any) => (window.data = event.detail.hook)
+			);
 		});
 		await clickOnLink(page, '/page-2.html');
 		expect(await page.evaluate(() => window.data)).toStrictEqual('link:click');
@@ -17,16 +20,19 @@ test.describe('events', () => {
 
 	test('custom dom events bubble to window', async ({ page }) => {
 		await page.evaluate(() => {
-			window.addEventListener('swup:link:click', (event: any) => window.data = event.detail.hook);
+			window.addEventListener(
+				'swup:link:click',
+				(event: any) => (window.data = event.detail.hook)
+			);
 		});
 		await clickOnLink(page, '/page-2.html');
 		expect(await page.evaluate(() => window.data)).toStrictEqual('link:click');
 	});
 
-	test('triggers wildcard dom events', async ({ page }) => {
+	test('triggers dom events for "swup:all"', async ({ page }) => {
 		await page.evaluate(() => {
-			document.addEventListener('swup:*', (event: any) => {
-				if (event.detail.hook === 'link:click') window.data = event.detail.hook
+			document.addEventListener('swup:all', (event: any) => {
+				if (event.detail.hook === 'link:click') window.data = event.detail.hook;
 			});
 		});
 		await clickOnLink(page, '/page-2.html');
@@ -35,7 +41,10 @@ test.describe('events', () => {
 
 	test('prevents the default click event', async ({ page }) => {
 		await page.evaluate(() => {
-			document.documentElement.addEventListener('click', (event) => window.data = event.defaultPrevented);
+			document.documentElement.addEventListener(
+				'click',
+				(event) => (window.data = event.defaultPrevented)
+			);
 		});
 		await clickOnLink(page, '/page-2.html');
 		expect(await page.evaluate(() => window.data)).toStrictEqual(true);

--- a/tests/functional/events.spec.ts
+++ b/tests/functional/events.spec.ts
@@ -29,9 +29,9 @@ test.describe('events', () => {
 		expect(await page.evaluate(() => window.data)).toStrictEqual('link:click');
 	});
 
-	test('triggers dom events for "swup:all"', async ({ page }) => {
+	test('triggers dom events for "swup:any"', async ({ page }) => {
 		await page.evaluate(() => {
-			document.addEventListener('swup:all', (event: any) => {
+			document.addEventListener('swup:any', (event: any) => {
 				if (event.detail.hook === 'link:click') window.data = event.detail.hook;
 			});
 		});


### PR DESCRIPTION
Related: #826, #827

**Description**

Listening for `swup:*` isn't working with the [Alpine.js `x-on` directive](https://alpinejs.dev/directives/on). The asterisk is breaking the attribute. Changing the hook to `swup:all` works. Example code:

```html
<div
	class="alpine-component"
	x-data="{ clickFired: false, allFired: false }"
	:class="{'click-fired': clickFired, 'all-fired': allFired}"
	x-on:swup:link:click.window="clickFired = true"
	x-on:swup:all.window="allFired = true"
>
	Alpine Component
</div>
<div id="swup"><!-- swup container --></div>
```

**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [x] New or updated tests are included
- [ ] The documentation was updated as required

**Additional information**

<!--
Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc.
-->
