### PR TITLE
feat: allow safely working with dom events in TypeScript

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ import type {
 	HookDefaultHandler,
 	HookOptions,
 	HookUnregister,
-	HookDOMEvent
+	HookEvent
 } from './modules/Hooks.js';
 import type { Plugin } from './modules/plugins.js';
 
@@ -51,7 +51,7 @@ export type {
 	HookDefaultHandler,
 	HookOptions,
 	HookUnregister,
-	HookDOMEvent,
+	HookEvent,
 	DelegateEvent,
 	DelegateEventHandler,
 	DelegateEventUnsubscribe

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,8 @@ import type {
 	HookHandler,
 	HookDefaultHandler,
 	HookOptions,
-	HookUnregister
+	HookUnregister,
+	HookDOMEvent
 } from './modules/Hooks.js';
 import type { Plugin } from './modules/plugins.js';
 
@@ -50,6 +51,7 @@ export type {
 	HookDefaultHandler,
 	HookOptions,
 	HookUnregister,
+	HookDOMEvent,
 	DelegateEvent,
 	DelegateEventHandler,
 	DelegateEventUnsubscribe

--- a/src/modules/Hooks.ts
+++ b/src/modules/Hooks.ts
@@ -102,7 +102,7 @@ type HookEventDetail = {
 	visit: Visit;
 };
 
-export type HookDOMEvent = CustomEvent<HookEventDetail>;
+export type HookEvent = CustomEvent<HookEventDetail>;
 
 type HookLedger<T extends HookName> = Map<HookHandler<T>, HookRegistration<T>>;
 

--- a/src/modules/Hooks.ts
+++ b/src/modules/Hooks.ts
@@ -96,6 +96,14 @@ export type HookRegistration<
 	defaultHandler?: HookDefaultHandler<T>;
 } & HookOptions;
 
+type HookEventDetail = {
+	hook: HookName;
+	args: unknown;
+	visit: Visit;
+};
+
+export type HookDOMEvent = CustomEvent<HookEventDetail>;
+
 type HookLedger<T extends HookName> = Map<HookHandler<T>, HookRegistration<T>>;
 
 interface HookRegistry extends Map<HookName, HookLedger<HookName>> {
@@ -493,8 +501,12 @@ export class Hooks {
 	 * @param hook Name of the hook.
 	 */
 	protected dispatchDomEvent<T extends HookName>(hook: T, args?: HookArguments<T>): void {
-		const detail = { hook, args, visit: this.swup.visit };
-		document.dispatchEvent(new CustomEvent(`swup:any`, { detail, bubbles: true }));
-		document.dispatchEvent(new CustomEvent(`swup:${hook}`, { detail, bubbles: true }));
+		const detail: HookEventDetail = { hook, args, visit: this.swup.visit };
+		document.dispatchEvent(
+			new CustomEvent<HookEventDetail>(`swup:any`, { detail, bubbles: true })
+		);
+		document.dispatchEvent(
+			new CustomEvent<HookEventDetail>(`swup:${hook}`, { detail, bubbles: true })
+		);
 	}
 }


### PR DESCRIPTION
**Description**

Exports a type `HookEvent`, so that `swup:...` events can be consumed more safely:

```js
import type { HookEvent } from "swup";

window.addEventListener("swup:all", (event) => {
  const hookName = (event as HookEvent).detail.hook;
  // @ts-expect-error
  const missing = (event as HookEvent).detail.missing;
});

```

**Alternatives considered**

Augmenting the global `GlobalEventHandlersEventMap`. Seems to be not be working with dynamic keys. Casting the event is the next best thing I could come up with :)

**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [ ] The documentation was updated as required

