### PR TITLE
Fix ESLint errors for enums

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -9,7 +9,8 @@ module.exports = {
 	/* First exclude everything, then re-include /src, then exclude tests */
 	ignorePatterns: ['/*', '!/src', '*.test.ts'],
 	rules: {
-		'no-unused-vars': ['error', { vars: 'all', args: 'none' }],
+		'no-unused-vars': 'off',
+		'@typescript-eslint/no-unused-vars': ['error', { vars: 'all', args: 'none' }],
 		'@typescript-eslint/ban-ts-comment': ['error', { 'ts-ignore': 'allow-with-description' }],
 		'@typescript-eslint/unbound-method': 'off',
 		'@typescript-eslint/no-floating-promises': 'off',


### PR DESCRIPTION
**Description**

- Default ESLint has issues recognizing TS enum types
- Disabling the default rule and enabling TSLint's rule for it fixes the issue

**Checks**

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [ ] ~~New or updated tests are included~~
- [ ] ~~The documentation was updated as required~~