### PR TITLE
Manage visits via state

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -9,7 +9,8 @@ module.exports = {
 	/* First exclude everything, then re-include /src, then exclude tests */
 	ignorePatterns: ['/*', '!/src', '*.test.ts'],
 	rules: {
-		'no-unused-vars': ['error', { vars: 'all', args: 'none' }],
+		'no-unused-vars': 'off',
+		'@typescript-eslint/no-unused-vars': ['error', { vars: 'all', args: 'none' }],
 		'@typescript-eslint/ban-ts-comment': ['error', { 'ts-ignore': 'allow-with-description' }],
 		'@typescript-eslint/unbound-method': 'off',
 		'@typescript-eslint/no-floating-promises': 'off',

--- a/src/Swup.ts
+++ b/src/Swup.ts
@@ -262,7 +262,7 @@ export default class Swup {
 		}
 
 		// Ignore if swup is currently navigating towards the link's URL
-		if (this.visit?.to.url === url) {
+		if (this.navigating && url === this.visit.to.url) {
 			event.preventDefault();
 			return;
 		}

--- a/src/Swup.ts
+++ b/src/Swup.ts
@@ -296,14 +296,11 @@ export default class Swup {
 				} else {
 					// Without hash: scroll to top or load/reload page
 					this.hooks.callSync('link:self', visit, undefined, () => {
-						switch (this.options.linkToSelf) {
-							case 'navigate':
-								this.performNavigation(visit);
-								return;
-							case 'scroll':
-							default:
-								updateHistoryRecord(url);
-								return this.scrollToContent(visit);
+						if (this.options.linkToSelf === 'navigate') {
+							this.performNavigation(visit);
+						} else {
+							updateHistoryRecord(url);
+							this.scrollToContent(visit);
 						}
 					});
 				}

--- a/src/Swup.ts
+++ b/src/Swup.ts
@@ -98,11 +98,8 @@ export default class Swup {
 	protected clickDelegate?: DelegateEventUnsubscribe;
 	/** Navigation status */
 	protected navigating: boolean = false;
-	/**
-	 * Run anytime a visit ends
-	 * @private
-	 */
-	protected onVisitEnd?: () => void;
+	/** Run anytime a visit ends */
+	protected onVisitEnd?: () => Promise<unknown>;
 
 	/** Install a plugin */
 	use = use;

--- a/src/Swup.ts
+++ b/src/Swup.ts
@@ -356,11 +356,6 @@ export default class Swup {
 			visit.scroll.reset = true;
 		}
 
-		// Does this even do anything?
-		// if (!hash) {
-		// 	event.preventDefault();
-		// }
-
 		this.hooks.callSync('history:popstate', visit, { event }, () => {
 			this.performNavigation(visit);
 		});

--- a/src/Swup.ts
+++ b/src/Swup.ts
@@ -7,8 +7,7 @@ import { type DelegateEventUnsubscribe } from './helpers/delegateEvent.js';
 
 import { Cache } from './modules/Cache.js';
 import { Classes } from './modules/Classes.js';
-import { createVisit } from './modules/Visit.js';
-import type { Visit } from './modules/Visit.js';
+import { createVisit, type Visit } from './modules/Visit.js';
 import { Hooks } from './modules/Hooks.js';
 import { getAnchorElement } from './modules/getAnchorElement.js';
 import { awaitAnimations } from './modules/awaitAnimations.js';

--- a/src/Swup.ts
+++ b/src/Swup.ts
@@ -98,6 +98,11 @@ export default class Swup {
 	protected clickDelegate?: DelegateEventUnsubscribe;
 	/** Navigation status */
 	protected navigating: boolean = false;
+	/**
+	 * Run anytime a visit ends
+	 * @private
+	 */
+	protected onVisitEnd?: () => void;
 
 	/** Install a plugin */
 	use = use;
@@ -372,5 +377,19 @@ export default class Swup {
 			return true;
 		}
 		return false;
+	}
+
+	/**
+	 * Queues a function to be called either
+	 *
+	 * - right now, if currently not navigating
+	 * - the next time the current visit ends
+	 */
+	protected queue(fn: () => void): void {
+		if (this.navigating) {
+			this.onVisitEnd = fn;
+			return;
+		}
+		fn();
 	}
 }

--- a/src/Swup.ts
+++ b/src/Swup.ts
@@ -7,7 +7,7 @@ import { type DelegateEventUnsubscribe } from './helpers/delegateEvent.js';
 
 import { Cache } from './modules/Cache.js';
 import { Classes } from './modules/Classes.js';
-import { createVisit, type Visit } from './modules/Visit.js';
+import { type Visit, createVisit } from './modules/Visit.js';
 import { Hooks } from './modules/Hooks.js';
 import { getAnchorElement } from './modules/getAnchorElement.js';
 import { awaitAnimations } from './modules/awaitAnimations.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,6 @@ import Swup from './Swup.js';
 import type { Options } from './Swup.js';
 import type { CacheData } from './modules/Cache.js';
 import type { PageData } from './modules/fetchPage.js';
-import { VisitState } from './modules/Visit.js';
 import type {
 	Visit,
 	VisitFrom,
@@ -30,7 +29,6 @@ import type { Plugin } from './modules/plugins.js';
 export default Swup;
 export * from './helpers.js';
 export * from './utils.js';
-export { VisitState };
 export type {
 	Swup,
 	Options,

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import Swup from './Swup.js';
 import type { Options } from './Swup.js';
 import type { CacheData } from './modules/Cache.js';
 import type { PageData } from './modules/fetchPage.js';
+import { VisitState } from './modules/Visit.js';
 import type {
 	Visit,
 	VisitFrom,
@@ -29,6 +30,7 @@ import type { Plugin } from './modules/plugins.js';
 export default Swup;
 export * from './helpers.js';
 export * from './utils.js';
+export { VisitState };
 export type {
 	Swup,
 	Options,

--- a/src/modules/Cache.ts
+++ b/src/modules/Cache.ts
@@ -49,7 +49,7 @@ export class Cache {
 		url = this.resolve(url);
 		page = { ...page, url };
 		this.pages.set(url, page);
-		this.swup.hooks.callSync('cache:set', { page });
+		this.swup.hooks.callSync('cache:set', undefined, { page });
 	}
 
 	/** Update a cache record, overwriting or adding custom data. */
@@ -67,7 +67,7 @@ export class Cache {
 	/** Empty the cache. */
 	clear(): void {
 		this.pages.clear();
-		this.swup.hooks.callSync('cache:clear', undefined);
+		this.swup.hooks.callSync('cache:clear', undefined, undefined);
 	}
 
 	/** Remove all cache entries that return true for a given predicate function.  */

--- a/src/modules/Classes.ts
+++ b/src/modules/Classes.ts
@@ -3,7 +3,14 @@ import { queryAll } from '../utils.js';
 
 export class Classes {
 	protected swup: Swup;
-	protected swupClasses = ['to-', 'is-changing', 'is-rendering', 'is-popstate', 'is-animating'];
+	protected swupClasses = [
+		'to-',
+		'is-changing',
+		'is-rendering',
+		'is-popstate',
+		'is-animating',
+		'is-leaving'
+	];
 
 	constructor(swup: Swup) {
 		this.swup = swup;

--- a/src/modules/Hooks.ts
+++ b/src/modules/Hooks.ts
@@ -37,7 +37,7 @@ export interface HookDefinitions {
 }
 
 export interface HookReturnValues {
-	'content:scroll': Promise<boolean>;
+	'content:scroll': Promise<boolean> | boolean;
 	'fetch:request': Promise<Response>;
 	'page:load': Promise<PageData>;
 	'scroll:top': boolean;

--- a/src/modules/Hooks.ts
+++ b/src/modules/Hooks.ts
@@ -33,6 +33,7 @@ export interface HookDefinitions {
 	'scroll:anchor': { hash: string; options: ScrollIntoViewOptions };
 	'visit:start': undefined;
 	'visit:transition': undefined;
+	'visit:abort': undefined;
 	'visit:end': undefined;
 }
 
@@ -154,6 +155,7 @@ export class Hooks {
 		'scroll:anchor',
 		'visit:start',
 		'visit:transition',
+		'visit:abort',
 		'visit:end'
 	];
 

--- a/src/modules/Hooks.ts
+++ b/src/modules/Hooks.ts
@@ -399,9 +399,9 @@ export class Hooks {
 		arg2: HookArguments<T> | HookDefaultHandler<T>,
 		arg3?: HookDefaultHandler<T>
 	): [Visit | undefined, HookArguments<T>, HookDefaultHandler<T> | undefined] {
-		const legacyOrder =
+		const isLegacyOrder =
 			!(arg1 instanceof Visit) && (typeof arg1 === 'object' || typeof arg2 === 'function');
-		if (legacyOrder) {
+		if (isLegacyOrder) {
 			// Legacy positioning: arguments in second or handler passed in third place
 			return [undefined, arg1 as HookArguments<T>, arg2 as HookDefaultHandler<T>];
 		} else {

--- a/src/modules/Hooks.ts
+++ b/src/modules/Hooks.ts
@@ -456,10 +456,10 @@ export class Hooks {
 		visit: Visit | undefined,
 		args: HookArguments<T>
 	): (ReturnType<HookDefaultHandler<T>> | unknown)[] {
-		if (visit?.done) return [];
 		const results = [];
 		for (const { hook, handler, defaultHandler, once } of registrations) {
 			if (once) this.off(hook, handler);
+			if (visit?.done) continue;
 			const result = (handler as HookDefaultHandler<T>)(visit || this.swup.visit, args, defaultHandler); // prettier-ignore
 			results.push(result);
 			if (isPromise(result)) {

--- a/src/modules/Hooks.ts
+++ b/src/modules/Hooks.ts
@@ -429,7 +429,7 @@ export class Hooks {
 		const results = [];
 		for (const { hook, handler, defaultHandler, once } of registrations) {
 			if (once) this.off(hook, handler);
-			if (visit?.aborted) continue;
+			if (visit?.done) continue;
 			const result = await runAsPromise(handler, [
 				visit || this.swup.visit,
 				args,
@@ -456,7 +456,7 @@ export class Hooks {
 		visit: Visit | undefined,
 		args: HookArguments<T>
 	): (ReturnType<HookDefaultHandler<T>> | unknown)[] {
-		if (visit?.aborted) return [];
+		if (visit?.done) return [];
 		const results = [];
 		for (const { hook, handler, defaultHandler, once } of registrations) {
 			if (once) this.off(hook, handler);
@@ -548,7 +548,7 @@ export class Hooks {
 		visit: Visit | undefined,
 		args?: HookArguments<T>
 	): void {
-		if (visit?.aborted) return;
+		if (visit?.done) return;
 
 		const detail: HookEventDetail = { hook, args, visit: visit || this.swup.visit };
 		document.dispatchEvent(

--- a/src/modules/Hooks.ts
+++ b/src/modules/Hooks.ts
@@ -428,8 +428,8 @@ export class Hooks {
 	): Promise<Awaited<ReturnType<HookDefaultHandler<T>>> | unknown[]> {
 		const results = [];
 		for (const { hook, handler, defaultHandler, once } of registrations) {
-			if (once) this.off(hook, handler);
 			if (visit?.done) continue;
+			if (once) this.off(hook, handler);
 			const result = await runAsPromise(handler, [
 				visit || this.swup.visit,
 				args,
@@ -458,8 +458,8 @@ export class Hooks {
 	): (ReturnType<HookDefaultHandler<T>> | unknown)[] {
 		const results = [];
 		for (const { hook, handler, defaultHandler, once } of registrations) {
-			if (once) this.off(hook, handler);
 			if (visit?.done) continue;
+			if (once) this.off(hook, handler);
 			const result = (handler as HookDefaultHandler<T>)(visit || this.swup.visit, args, defaultHandler); // prettier-ignore
 			results.push(result);
 			if (isPromise(result)) {

--- a/src/modules/Visit.ts
+++ b/src/modules/Visit.ts
@@ -70,6 +70,7 @@ export interface VisitInitOptions {
 	event?: Event;
 }
 
+/** @internal */
 export enum VisitState {
 	CREATED = 1,
 	QUEUED,
@@ -86,7 +87,7 @@ export enum VisitState {
 export class Visit {
 	/** A unique ID to identify this visit */
 	id: number;
-	/** The current state of this visit */
+	/** The current state of this visit @internal */
 	state: VisitState;
 	/** The previous page, about to leave */
 	from: VisitFrom;
@@ -135,17 +136,19 @@ export class Visit {
 			target: undefined
 		};
 	}
-
+	/** @internal */
 	advance(state: VisitState) {
 		if (this.state <= state) {
 			this.state = state;
 		}
 	}
 
+	/** @internal */
 	abort() {
 		this.state = VisitState.ABORTED;
 	}
 
+	/** Was the visit aborted? */
 	get aborted(): boolean {
 		return this.state === VisitState.ABORTED;
 	}

--- a/src/modules/Visit.ts
+++ b/src/modules/Visit.ts
@@ -71,17 +71,20 @@ export interface VisitInitOptions {
 }
 
 /** @internal */
-export enum VisitState {
-	CREATED = 1,
-	QUEUED,
-	STARTED,
-	LEAVING,
-	LOADED,
-	ENTERING,
-	COMPLETED,
-	ABORTED,
-	FAILED
-}
+export const VisitState = {
+	CREATED: 1,
+	QUEUED: 2,
+	STARTED: 3,
+	LEAVING: 4,
+	LOADED: 5,
+	ENTERING: 6,
+	COMPLETED: 7,
+	ABORTED: 8,
+	FAILED: 9
+} as const;
+
+/** @internal */
+export type VisitState = (typeof VisitState)[keyof typeof VisitState];
 
 /** An object holding details about the current visit. */
 export class Visit {

--- a/src/modules/Visit.ts
+++ b/src/modules/Visit.ts
@@ -148,6 +148,11 @@ export class Visit {
 		this.state = VisitState.ABORTED;
 	}
 
+	/** Is this visit done, i.e. completed, failed, or aborted? */
+	get done(): boolean {
+		return this.state >= VisitState.COMPLETED;
+	}
+
 	/** Was the visit aborted? */
 	get aborted(): boolean {
 		return this.state === VisitState.ABORTED;

--- a/src/modules/Visit.ts
+++ b/src/modules/Visit.ts
@@ -136,14 +136,18 @@ export class Visit {
 		};
 	}
 
-	get aborted(): boolean {
-		return this.state === VisitState.aborted;
-	}
-
 	advance(state: VisitState) {
 		if (this.state <= state) {
 			this.state = state;
 		}
+	}
+
+	abort() {
+		this.state = VisitState.aborted;
+	}
+
+	get aborted(): boolean {
+		return this.state === VisitState.aborted;
 	}
 }
 

--- a/src/modules/Visit.ts
+++ b/src/modules/Visit.ts
@@ -93,7 +93,6 @@ export class Visit {
 
 	constructor(swup: Swup, options: VisitInitOptions) {
 		const { to, from = swup.currentPageUrl, hash, el, event } = options;
-		Object.assign(this, createVisit.call(swup, options));
 
 		this.id = Math.random();
 		this.from = { url: from };

--- a/src/modules/Visit.ts
+++ b/src/modules/Visit.ts
@@ -2,27 +2,8 @@ import type Swup from '../Swup.js';
 import type { Options } from '../Swup.js';
 import type { HistoryAction, HistoryDirection } from './navigate.js';
 
-/** An object holding details about the current visit. */
-export interface Visit {
-	/** A unique ID to identify this visit */
-	id: number;
-	/** The previous page, about to leave */
-	from: VisitFrom;
-	/** The next page, about to enter */
-	to: VisitTo;
-	/** The content containers, about to be replaced */
-	containers: Options['containers'];
-	/** Information about animated page transitions */
-	animation: VisitAnimation;
-	/** What triggered this visit */
-	trigger: VisitTrigger;
-	/** Cache behavior for this visit */
-	cache: VisitCache;
-	/** Browser history behavior on this visit */
-	history: VisitHistory;
-	/** Scroll behavior on this visit */
-	scroll: VisitScroll;
-}
+/** See below for the class Visit {} definition */
+// export interface Visit {}
 
 export interface VisitFrom {
 	/** The URL of the previous page */
@@ -89,39 +70,60 @@ export interface VisitInitOptions {
 	event?: Event;
 }
 
-/** Create a new visit object. */
-export function createVisit(
-	this: Swup,
-	{ to, from = this.currentPageUrl, hash, el, event }: VisitInitOptions
-): Visit {
-	return {
-		id: Math.random(),
-		from: { url: from },
-		to: { url: to, hash },
-		containers: this.options.containers,
-		animation: {
+/** An object holding details about the current visit. */
+export class Visit {
+	/** A unique ID to identify this visit */
+	id: number;
+	/** The previous page, about to leave */
+	from: VisitFrom;
+	/** The next page, about to enter */
+	to: VisitTo;
+	/** The content containers, about to be replaced */
+	containers: Options['containers'];
+	/** Information about animated page transitions */
+	animation: VisitAnimation;
+	/** What triggered this visit */
+	trigger: VisitTrigger;
+	/** Cache behavior for this visit */
+	cache: VisitCache;
+	/** Browser history behavior on this visit */
+	history: VisitHistory;
+	/** Scroll behavior on this visit */
+	scroll: VisitScroll;
+
+	constructor(swup: Swup, options: VisitInitOptions) {
+		const { to, from = swup.currentPageUrl, hash, el, event } = options;
+		Object.assign(this, createVisit.call(swup, options));
+
+		this.id = Math.random();
+		this.from = { url: from };
+		this.to = { url: to, hash };
+		this.containers = swup.options.containers;
+		this.animation = {
 			animate: true,
 			wait: false,
 			name: undefined,
-			scope: this.options.animationScope,
-			selector: this.options.animationSelector
-		},
-		trigger: {
-			el,
-			event
-		},
-		cache: {
-			read: this.options.cache,
-			write: this.options.cache
-		},
-		history: {
+			scope: swup.options.animationScope,
+			selector: swup.options.animationSelector
+		};
+		this.trigger = { el, event };
+		this.cache = {
+			read: swup.options.cache,
+			write: swup.options.cache
+		};
+		this.history = {
 			action: 'push',
 			popstate: false,
 			direction: undefined
-		},
-		scroll: {
+		};
+		this.scroll = {
 			reset: true,
 			target: undefined
-		}
-	};
+		};
+	}
+}
+
+/** Create a new visit object. */
+export function createVisit(this: Swup, options: VisitInitOptions): Visit {
+	return new Visit(this, options);
 }

--- a/src/modules/Visit.ts
+++ b/src/modules/Visit.ts
@@ -71,15 +71,15 @@ export interface VisitInitOptions {
 }
 
 export enum VisitState {
-	created = 1,
-	queued,
-	started,
-	leaving,
-	loaded,
-	entering,
-	completed,
-	aborted,
-	failed
+	CREATED = 1,
+	QUEUED,
+	STARTED,
+	LEAVING,
+	LOADED,
+	ENTERING,
+	COMPLETED,
+	ABORTED,
+	FAILED
 }
 
 /** An object holding details about the current visit. */
@@ -109,7 +109,7 @@ export class Visit {
 		const { to, from = swup.currentPageUrl, hash, el, event } = options;
 
 		this.id = Math.random();
-		this.state = VisitState.created;
+		this.state = VisitState.CREATED;
 		this.from = { url: from };
 		this.to = { url: to, hash };
 		this.containers = swup.options.containers;
@@ -143,11 +143,11 @@ export class Visit {
 	}
 
 	abort() {
-		this.state = VisitState.aborted;
+		this.state = VisitState.ABORTED;
 	}
 
 	get aborted(): boolean {
-		return this.state === VisitState.aborted;
+		return this.state === VisitState.ABORTED;
 	}
 }
 

--- a/src/modules/Visit.ts
+++ b/src/modules/Visit.ts
@@ -70,10 +70,24 @@ export interface VisitInitOptions {
 	event?: Event;
 }
 
+export enum VisitState {
+	created = 1,
+	queued,
+	started,
+	leaving,
+	loaded,
+	entering,
+	completed,
+	aborted,
+	failed
+}
+
 /** An object holding details about the current visit. */
 export class Visit {
 	/** A unique ID to identify this visit */
 	id: number;
+	/** The current state of this visit */
+	state: VisitState;
 	/** The previous page, about to leave */
 	from: VisitFrom;
 	/** The next page, about to enter */
@@ -95,6 +109,7 @@ export class Visit {
 		const { to, from = swup.currentPageUrl, hash, el, event } = options;
 
 		this.id = Math.random();
+		this.state = VisitState.created;
 		this.from = { url: from };
 		this.to = { url: to, hash };
 		this.containers = swup.options.containers;
@@ -119,6 +134,16 @@ export class Visit {
 			reset: true,
 			target: undefined
 		};
+	}
+
+	get aborted(): boolean {
+		return this.state === VisitState.aborted;
+	}
+
+	advance(state: VisitState) {
+		if (this.state <= state) {
+			this.state = state;
+		}
 	}
 }
 

--- a/src/modules/animatePageIn.ts
+++ b/src/modules/animatePageIn.ts
@@ -7,9 +7,7 @@ import type { Visit } from './Visit.js';
  * @returns Promise<void>
  */
 export const animatePageIn = async function (this: Swup, visit: Visit) {
-	if (!visit.animation.animate) {
-		return;
-	}
+	if (!visit.animation.animate) return;
 
 	const animation = this.hooks.call(
 		'animation:in:await',

--- a/src/modules/animatePageIn.ts
+++ b/src/modules/animatePageIn.ts
@@ -9,6 +9,8 @@ import type { Visit } from './Visit.js';
 export const animatePageIn = async function (this: Swup, visit: Visit) {
 	if (!visit.animation.animate) return;
 
+	if (visit.aborted) return;
+
 	const animation = this.hooks.call(
 		'animation:in:await',
 		visit,

--- a/src/modules/animatePageIn.ts
+++ b/src/modules/animatePageIn.ts
@@ -9,7 +9,8 @@ import type { Visit } from './Visit.js';
 export const animatePageIn = async function (this: Swup, visit: Visit) {
 	if (!visit.animation.animate) return;
 
-	if (visit.aborted) return;
+	// Check if failed/aborted in the meantime
+	if (visit.done) return;
 
 	const animation = this.hooks.call(
 		'animation:in:await',

--- a/src/modules/animatePageIn.ts
+++ b/src/modules/animatePageIn.ts
@@ -7,7 +7,7 @@ import type { Visit } from './Visit.js';
  * @returns Promise<void>
  */
 export const animatePageIn = async function (this: Swup, visit: Visit) {
-	if (!this.visit.animation.animate) {
+	if (!visit.animation.animate) {
 		return;
 	}
 

--- a/src/modules/animatePageIn.ts
+++ b/src/modules/animatePageIn.ts
@@ -1,17 +1,19 @@
 import type Swup from '../Swup.js';
 import { nextTick } from '../utils.js';
+import type { Visit } from './Visit.js';
 
 /**
  * Perform the in/enter animation of the next page.
  * @returns Promise<void>
  */
-export const animatePageIn = async function (this: Swup) {
+export const animatePageIn = async function (this: Swup, visit: Visit) {
 	if (!this.visit.animation.animate) {
 		return;
 	}
 
 	const animation = this.hooks.call(
 		'animation:in:await',
+		visit,
 		{ skip: false },
 		async (visit, { skip }) => {
 			if (skip) return;
@@ -21,11 +23,11 @@ export const animatePageIn = async function (this: Swup) {
 
 	await nextTick();
 
-	await this.hooks.call('animation:in:start', undefined, () => {
+	await this.hooks.call('animation:in:start', visit, undefined, () => {
 		this.classes.remove('is-animating');
 	});
 
 	await animation;
 
-	await this.hooks.call('animation:in:end', undefined);
+	await this.hooks.call('animation:in:end', visit, undefined);
 };

--- a/src/modules/animatePageOut.ts
+++ b/src/modules/animatePageOut.ts
@@ -12,6 +12,8 @@ export const animatePageOut = async function (this: Swup, visit: Visit) {
 		return;
 	}
 
+	if (visit.aborted) return;
+
 	await this.hooks.call('animation:out:start', visit, undefined, (visit) => {
 		this.classes.add('is-changing', 'is-leaving', 'is-animating');
 		if (visit.history.popstate) {

--- a/src/modules/animatePageOut.ts
+++ b/src/modules/animatePageOut.ts
@@ -12,8 +12,6 @@ export const animatePageOut = async function (this: Swup, visit: Visit) {
 		return;
 	}
 
-	if (visit.aborted) return;
-
 	await this.hooks.call('animation:out:start', visit, undefined, (visit) => {
 		this.classes.add('is-changing', 'is-leaving', 'is-animating');
 		if (visit.history.popstate) {

--- a/src/modules/animatePageOut.ts
+++ b/src/modules/animatePageOut.ts
@@ -7,7 +7,7 @@ import type { Visit } from './Visit.js';
  * @returns Promise<void>
  */
 export const animatePageOut = async function (this: Swup, visit: Visit) {
-	if (!this.visit.animation.animate) {
+	if (!visit.animation.animate) {
 		await this.hooks.call('animation:skip', visit, undefined);
 		return;
 	}

--- a/src/modules/animatePageOut.ts
+++ b/src/modules/animatePageOut.ts
@@ -1,17 +1,18 @@
 import type Swup from '../Swup.js';
 import { classify } from '../helpers.js';
+import type { Visit } from './Visit.js';
 
 /**
  * Perform the out/leave animation of the current page.
  * @returns Promise<void>
  */
-export const animatePageOut = async function (this: Swup) {
+export const animatePageOut = async function (this: Swup, visit: Visit) {
 	if (!this.visit.animation.animate) {
-		await this.hooks.call('animation:skip', undefined);
+		await this.hooks.call('animation:skip', visit, undefined);
 		return;
 	}
 
-	await this.hooks.call('animation:out:start', undefined, (visit) => {
+	await this.hooks.call('animation:out:start', visit, undefined, (visit) => {
 		this.classes.add('is-changing', 'is-leaving', 'is-animating');
 		if (visit.history.popstate) {
 			this.classes.add('is-popstate');
@@ -21,10 +22,15 @@ export const animatePageOut = async function (this: Swup) {
 		}
 	});
 
-	await this.hooks.call('animation:out:await', { skip: false }, async (visit, { skip }) => {
-		if (skip) return;
-		await this.awaitAnimations({ selector: visit.animation.selector });
-	});
+	await this.hooks.call(
+		'animation:out:await',
+		visit,
+		{ skip: false },
+		async (visit, { skip }) => {
+			if (skip) return;
+			await this.awaitAnimations({ selector: visit.animation.selector });
+		}
+	);
 
-	await this.hooks.call('animation:out:end', undefined);
+	await this.hooks.call('animation:out:end', visit, undefined);
 };

--- a/src/modules/fetchPage.ts
+++ b/src/modules/fetchPage.ts
@@ -53,6 +53,7 @@ export async function fetchPage(
 ): Promise<PageData> {
 	url = Location.fromUrl(url).url;
 
+	const { visit } = options;
 	const headers = { ...this.options.requestHeaders, ...options.headers };
 	const timeout = options.timeout ?? this.options.timeout;
 	const controller = new AbortController();
@@ -73,7 +74,7 @@ export async function fetchPage(
 	try {
 		response = await this.hooks.call(
 			'fetch:request',
-			options.visit,
+			visit,
 			{ url, options },
 			(visit, { url, options }) => fetch(url, options)
 		);
@@ -82,7 +83,7 @@ export async function fetchPage(
 		}
 	} catch (error) {
 		if (timedOut) {
-			this.hooks.call('fetch:timeout', options.visit, { url });
+			this.hooks.call('fetch:timeout', visit, { url });
 			throw new FetchError(`Request timed out: ${url}`, { url, timedOut });
 		}
 		if ((error as Error)?.name === 'AbortError' || signal.aborted) {
@@ -98,7 +99,7 @@ export async function fetchPage(
 	const html = await response.text();
 
 	if (status === 500) {
-		this.hooks.call('fetch:error', options.visit, { status, response, url: responseUrl });
+		this.hooks.call('fetch:error', visit, { status, response, url: responseUrl });
 		throw new FetchError(`Server error: ${responseUrl}`, { status, url: responseUrl });
 	}
 
@@ -111,11 +112,7 @@ export async function fetchPage(
 	const page = { url: finalUrl, html };
 
 	// Write to cache for safe methods and non-redirects
-	if (
-		this.visit.cache.write &&
-		(!options.method || options.method === 'GET') &&
-		url === finalUrl
-	) {
+	if (visit?.cache.write && (!options.method || options.method === 'GET') && url === finalUrl) {
 		this.cache.set(page.url, page);
 	}
 

--- a/src/modules/fetchPage.ts
+++ b/src/modules/fetchPage.ts
@@ -106,7 +106,7 @@ export async function fetchPage(
 	const page = { url: finalUrl, html };
 
 	// Write to cache for safe methods and non-redirects
-	if (visit?.cache.write && (!options.method || options.method === 'GET') && url === finalUrl) {
+	if (visit.cache.write && (!options.method || options.method === 'GET') && url === finalUrl) {
 		this.cache.set(page.url, page);
 	}
 

--- a/src/modules/fetchPage.ts
+++ b/src/modules/fetchPage.ts
@@ -18,10 +18,7 @@ export interface FetchOptions extends Omit<RequestInit, 'cache'> {
 	body?: string | FormData | URLSearchParams;
 	/** The request timeout in milliseconds. */
 	timeout?: number;
-	/**
-	 * Optional visit object
-	 * @internal
-	 */
+	/** Optional visit object with additional context. @internal */
 	visit?: Visit;
 }
 
@@ -53,7 +50,7 @@ export async function fetchPage(
 ): Promise<PageData> {
 	url = Location.fromUrl(url).url;
 
-	const { visit } = options;
+	const { visit = this.visit } = options;
 	const headers = { ...this.options.requestHeaders, ...options.headers };
 	const timeout = options.timeout ?? this.options.timeout;
 	const controller = new AbortController();
@@ -87,10 +84,7 @@ export async function fetchPage(
 			throw new FetchError(`Request timed out: ${url}`, { url, timedOut });
 		}
 		if ((error as Error)?.name === 'AbortError' || signal.aborted) {
-			throw new FetchError(`Request aborted: ${url}`, {
-				url: url,
-				aborted: true
-			});
+			throw new FetchError(`Request aborted: ${url}`, { url, aborted: true });
 		}
 		throw error;
 	}

--- a/src/modules/navigate.ts
+++ b/src/modules/navigate.ts
@@ -164,18 +164,12 @@ export async function performNavigation(
 
 		// perform the actual transition: animate and replace content
 		await this.hooks.call('visit:transition', visit, undefined, async () => {
-			// Check if aborted in the meantime
-			if (visit.aborted) return false;
-
 			// Start leave animation
 			visit.advance(VisitState.leaving);
 			const animationPromise = this.animatePageOut(visit);
 
 			// Wait for page to load and leave animation to finish
 			const [page] = await Promise.all([pagePromise, animationPromise]);
-
-			// Check if aborted in the meantime
-			if (visit.aborted) return false;
 
 			// Render page: replace content and scroll to top/fragment
 			await this.renderPage(visit, page);

--- a/src/modules/navigate.ts
+++ b/src/modules/navigate.ts
@@ -187,11 +187,6 @@ export async function performNavigation(
 		visit.state = VisitState.COMPLETED;
 		this.navigating = false;
 
-		// Reset visit info after finish?
-		// if (visit.to && this.isSameResolvedUrl(visit.to.url, requestedUrl)) {
-		// 	this.visit = this.createVisit({ to: undefined });
-		// }
-
 		/** Run eventually queued function */
 		if (this.onVisitEnd) {
 			this.onVisitEnd();

--- a/src/modules/navigate.ts
+++ b/src/modules/navigate.ts
@@ -149,7 +149,7 @@ export async function performNavigation(
 		}
 
 		// perform the actual transition: animate and replace content
-		await this.hooks.call('visit:transition', visit, undefined, async (visit) => {
+		await this.hooks.call('visit:transition', visit, undefined, async () => {
 			// Start leave animation
 			const animationPromise = this.animatePageOut(visit);
 

--- a/src/modules/navigate.ts
+++ b/src/modules/navigate.ts
@@ -72,6 +72,7 @@ export async function performNavigation(
 			return;
 		} else {
 			// Currently navigating and content not loaded? Abort running visit
+			await this.hooks.call('visit:abort', this.visit, undefined);
 			this.visit.state = VisitState.aborted;
 		}
 	}

--- a/src/modules/navigate.ts
+++ b/src/modules/navigate.ts
@@ -182,6 +182,9 @@ export async function performNavigation(
 			return true;
 		});
 
+		// Check if aborted in the meantime
+		if (visit.aborted) return;
+
 		// Finalize visit
 		await this.hooks.call('visit:end', visit, undefined, () => this.classes.clear());
 		visit.state = VisitState.COMPLETED;

--- a/src/modules/navigate.ts
+++ b/src/modules/navigate.ts
@@ -43,8 +43,11 @@ export function navigate(
 	}
 
 	const { url: to, hash } = Location.fromUrl(url);
-	this.visit = this.createVisit({ ...init, to, hash });
-	this.performNavigation(options);
+
+	this.queue(() => {
+		this.visit = this.createVisit({ ...init, to, hash });
+		this.performNavigation(options);
+	});
 }
 
 /**
@@ -168,6 +171,11 @@ export async function performNavigation(
 		// 	this.visit = this.createVisit({ to: undefined });
 		// }
 		this.navigating = false;
+		/**
+		 * Run eventually queued function
+		 */
+		this.onVisitEnd?.();
+		this.onVisitEnd = undefined;
 	} catch (error) {
 		// Return early if error is undefined or signals an aborted request
 		if (!error || (error as FetchError)?.aborted) {

--- a/src/modules/navigate.ts
+++ b/src/modules/navigate.ts
@@ -65,9 +65,7 @@ export async function performNavigation(
 	options: NavigationOptions & FetchOptions = {}
 ): Promise<void> {
 	if (this.navigating) {
-		this.onVisitEnd = () => {
-			this.performNavigation(visit, options);
-		};
+		this.onVisitEnd = () => this.performNavigation(visit, options);
 		return;
 	}
 	this.navigating = true;

--- a/src/modules/navigate.ts
+++ b/src/modules/navigate.ts
@@ -68,6 +68,7 @@ export async function performNavigation(
 		this.onVisitEnd = () => this.performNavigation(visit, options);
 		return;
 	}
+
 	this.navigating = true;
 	this.visit = visit;
 

--- a/src/modules/navigate.ts
+++ b/src/modules/navigate.ts
@@ -160,8 +160,8 @@ export async function performNavigation(
 			visit.to.html = html;
 		}
 
-		// Check if aborted in the meantime
-		if (visit.aborted) return;
+		// Check if failed/aborted in the meantime
+		if (visit.done) return;
 
 		// perform the actual transition: animate and replace content
 		await this.hooks.call('visit:transition', visit, undefined, async () => {
@@ -182,8 +182,8 @@ export async function performNavigation(
 			return true;
 		});
 
-		// Check if aborted in the meantime
-		if (visit.aborted) return;
+		// Check if failed/aborted in the meantime
+		if (visit.done) return;
 
 		// Finalize visit
 		await this.hooks.call('visit:end', visit, undefined, () => this.classes.clear());

--- a/src/modules/navigate.ts
+++ b/src/modules/navigate.ts
@@ -65,7 +65,7 @@ export async function performNavigation(
 	options: NavigationOptions & FetchOptions = {}
 ): Promise<void> {
 	if (this.navigating) {
-		if (this.visit.state >= VisitState.LOADED) {
+		if (this.visit.state >= VisitState.ENTERING) {
 			// Currently navigating and content already loaded? Finish and queue
 			visit.state = VisitState.QUEUED;
 			this.onVisitEnd = () => this.performNavigation(visit, options);

--- a/src/modules/navigate.ts
+++ b/src/modules/navigate.ts
@@ -65,15 +65,15 @@ export async function performNavigation(
 	options: NavigationOptions & FetchOptions = {}
 ): Promise<void> {
 	if (this.navigating) {
-		if (this.visit.state >= VisitState.loaded) {
+		if (this.visit.state >= VisitState.LOADED) {
 			// Currently navigating and content already loaded? Finish and queue
-			visit.state = VisitState.queued;
+			visit.state = VisitState.QUEUED;
 			this.onVisitEnd = () => this.performNavigation(visit, options);
 			return;
 		} else {
 			// Currently navigating and content not loaded? Abort running visit
 			await this.hooks.call('visit:abort', this.visit, undefined);
-			this.visit.state = VisitState.aborted;
+			this.visit.state = VisitState.ABORTED;
 		}
 	}
 
@@ -116,7 +116,7 @@ export async function performNavigation(
 
 	try {
 		await this.hooks.call('visit:start', visit, undefined);
-		visit.state = VisitState.started;
+		visit.state = VisitState.STARTED;
 
 		// Begin loading page
 		const pagePromise = this.hooks.call(
@@ -138,7 +138,7 @@ export async function performNavigation(
 		);
 
 		// Mark as loaded when finished
-		pagePromise.then(() => visit.advance(VisitState.loaded));
+		pagePromise.then(() => visit.advance(VisitState.LOADED));
 
 		// Create/update history record if this is not a popstate call or leads to the same URL
 		if (!visit.history.popstate) {
@@ -166,7 +166,7 @@ export async function performNavigation(
 		// perform the actual transition: animate and replace content
 		await this.hooks.call('visit:transition', visit, undefined, async () => {
 			// Start leave animation
-			visit.advance(VisitState.leaving);
+			visit.advance(VisitState.LEAVING);
 			const animationPromise = this.animatePageOut(visit);
 
 			// Wait for page to load and leave animation to finish
@@ -176,7 +176,7 @@ export async function performNavigation(
 			await this.renderPage(visit, page);
 
 			// Wait for enter animation
-			visit.advance(VisitState.entering);
+			visit.advance(VisitState.ENTERING);
 			await this.animatePageIn(visit);
 
 			return true;
@@ -184,7 +184,7 @@ export async function performNavigation(
 
 		// Finalize visit
 		await this.hooks.call('visit:end', visit, undefined, () => this.classes.clear());
-		visit.state = VisitState.completed;
+		visit.state = VisitState.COMPLETED;
 		this.navigating = false;
 
 		// Reset visit info after finish?
@@ -200,11 +200,11 @@ export async function performNavigation(
 	} catch (error) {
 		// Return early if error is undefined or signals an aborted request
 		if (!error || (error as FetchError)?.aborted) {
-			visit.state = VisitState.aborted;
+			visit.state = VisitState.ABORTED;
 			return;
 		}
 
-		visit.state = VisitState.failed;
+		visit.state = VisitState.FAILED;
 
 		// Log to console as we swallow almost all hook errors
 		console.error(error);

--- a/src/modules/renderPage.ts
+++ b/src/modules/renderPage.ts
@@ -1,11 +1,12 @@
 import { updateHistoryRecord, getCurrentUrl, classify } from '../helpers.js';
 import type Swup from '../Swup.js';
 import type { PageData } from './fetchPage.js';
+import type { Visit } from './Visit.js';
 
 /**
  * Render the next page: replace the content and update scroll position.
  */
-export const renderPage = async function (this: Swup, page: PageData): Promise<void> {
+export const renderPage = async function (this: Swup, visit: Visit, page: PageData): Promise<void> {
 	const { url, html } = page;
 
 	this.classes.remove('is-leaving');
@@ -26,7 +27,7 @@ export const renderPage = async function (this: Swup, page: PageData): Promise<v
 	this.visit.to.html = html;
 
 	// replace content: allow handlers and plugins to overwrite paga data and containers
-	await this.hooks.call('content:replace', { page }, (visit, { page }) => {
+	await this.hooks.call('content:replace', visit, { page }, (visit, { page }) => {
 		const success = this.replaceContent(page, { containers: visit.containers });
 		if (!success) {
 			throw new Error('[swup] Container mismatch, aborting');
@@ -43,8 +44,8 @@ export const renderPage = async function (this: Swup, page: PageData): Promise<v
 	// scroll into view: either anchor or top of page
 	// @ts-ignore: not returning a promise is intentional to allow users to pause in handler
 	await this.hooks.call('content:scroll', undefined, () => {
-		return this.scrollToContent();
+		return this.scrollToContent(visit);
 	});
 
-	await this.hooks.call('page:view', { url: this.currentPageUrl, title: document.title });
+	await this.hooks.call('page:view', visit, { url: this.currentPageUrl, title: document.title });
 };

--- a/src/modules/renderPage.ts
+++ b/src/modules/renderPage.ts
@@ -15,16 +15,16 @@ export const renderPage = async function (this: Swup, visit: Visit, page: PageDa
 	if (!this.isSameResolvedUrl(getCurrentUrl(), url)) {
 		updateHistoryRecord(url);
 		this.currentPageUrl = getCurrentUrl();
-		this.visit.to.url = this.currentPageUrl;
+		visit.to.url = this.currentPageUrl;
 	}
 
 	// only add for animated page loads
-	if (this.visit.animation.animate) {
+	if (visit.animation.animate) {
 		this.classes.add('is-rendering');
 	}
 
 	// save html into visit context for easier retrieval
-	this.visit.to.html = html;
+	visit.to.html = html;
 
 	// replace content: allow handlers and plugins to overwrite paga data and containers
 	await this.hooks.call('content:replace', visit, { page }, (visit, { page }) => {

--- a/src/modules/renderPage.ts
+++ b/src/modules/renderPage.ts
@@ -7,7 +7,8 @@ import type { Visit } from './Visit.js';
  * Render the next page: replace the content and update scroll position.
  */
 export const renderPage = async function (this: Swup, visit: Visit, page: PageData): Promise<void> {
-	if (visit.aborted) return;
+	// Check if failed/aborted in the meantime
+	if (visit.done) return;
 
 	const { url, html } = page;
 

--- a/src/modules/renderPage.ts
+++ b/src/modules/renderPage.ts
@@ -7,6 +7,8 @@ import type { Visit } from './Visit.js';
  * Render the next page: replace the content and update scroll position.
  */
 export const renderPage = async function (this: Swup, visit: Visit, page: PageData): Promise<void> {
+	if (visit.aborted) return;
+
 	const { url, html } = page;
 
 	this.classes.remove('is-leaving');

--- a/src/modules/renderPage.ts
+++ b/src/modules/renderPage.ts
@@ -42,8 +42,7 @@ export const renderPage = async function (this: Swup, visit: Visit, page: PageDa
 	});
 
 	// scroll into view: either anchor or top of page
-	// @ts-ignore: not returning a promise is intentional to allow users to pause in handler
-	await this.hooks.call('content:scroll', undefined, () => {
+	await this.hooks.call('content:scroll', visit, undefined, () => {
 		return this.scrollToContent(visit);
 	});
 

--- a/src/modules/scrollToContent.ts
+++ b/src/modules/scrollToContent.ts
@@ -7,8 +7,8 @@ import type { Visit } from './Visit.js';
  */
 export const scrollToContent = function (this: Swup, visit: Visit): boolean {
 	const options: ScrollIntoViewOptions = { behavior: 'auto' };
-	const { target, reset } = this.visit.scroll;
-	const scrollTarget = target ?? this.visit.to.hash;
+	const { target, reset } = visit.scroll;
+	const scrollTarget = target ?? visit.to.hash;
 
 	let scrolled = false;
 

--- a/src/modules/scrollToContent.ts
+++ b/src/modules/scrollToContent.ts
@@ -1,10 +1,11 @@
 import type Swup from '../Swup.js';
+import type { Visit } from './Visit.js';
 
 /**
  * Update the scroll position after page render.
  * @returns Promise<boolean>
  */
-export const scrollToContent = function (this: Swup): boolean {
+export const scrollToContent = function (this: Swup, visit: Visit): boolean {
 	const options: ScrollIntoViewOptions = { behavior: 'auto' };
 	const { target, reset } = this.visit.scroll;
 	const scrollTarget = target ?? this.visit.to.hash;
@@ -14,6 +15,7 @@ export const scrollToContent = function (this: Swup): boolean {
 	if (scrollTarget) {
 		scrolled = this.hooks.callSync(
 			'scroll:anchor',
+			visit,
 			{ hash: scrollTarget, options },
 			(visit, { hash, options }) => {
 				const anchor = this.getAnchorElement(hash);
@@ -26,7 +28,7 @@ export const scrollToContent = function (this: Swup): boolean {
 	}
 
 	if (reset && !scrolled) {
-		scrolled = this.hooks.callSync('scroll:top', { options }, (visit, { options }) => {
+		scrolled = this.hooks.callSync('scroll:top', visit, { options }, (visit, { options }) => {
 			window.scrollTo({ top: 0, left: 0, ...options });
 			return true;
 		});

--- a/tests/fixtures/rapid-navigation/page-1.html
+++ b/tests/fixtures/rapid-navigation/page-1.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>Rapid Navigation Page 1</title>
+		<link rel="stylesheet" href="/assets/main.css" />
+		<style>
+			html.is-changing .transition-default {
+				transition-property: opacity, transform;
+				transition-duration: 600ms;
+			}
+			html.is-animating .transition-default {
+				opacity: 0;
+				transform: translateY(-50px);
+			}
+			html.is-leaving .transition-default {
+				transform: translateY(50px);
+			}
+		</style>
+		<script src="/dist/Swup.umd.js"></script>
+	</head>
+	<body>
+		<header class="header">
+			<ul>
+				<li><a href="/rapid-navigation/page-1.html" data-testid="link-to-page-1">Page 1</a></li>
+				<li><a href="/rapid-navigation/page-2.html" data-testid="link-to-page-2">Page 2</a></li>
+				<li><a href="/rapid-navigation/page-3.html" data-testid="link-to-page-3">Page 3</a></li>
+			</ul>
+		</header>
+		<main id="swup" class="wrapper transition-default" data-testid="container">
+			<div class="wrapper-inner">
+				<h1>Rapid Navigation Page 1</h1>
+				<p>
+					Lorem ipsum dolor sit amet, consectetur adipisicing elit. Alias assumenda
+					consectetur consequatur enim esse incidunt iusto, magnam maxime molestias nisi
+					perferendis perspiciatis quibusdam quos repellat, vel veniam vero voluptate
+					voluptatem.
+				</p>
+			</div>
+		</main>
+		<script>
+			window.data = { received: [] };
+
+			window._swup = new Swup({ cache: false });
+
+			window.addEventListener('swup:any', (event) => {
+				const { hook } = event.detail;
+
+				if (hook === 'visit:start') {
+					document.documentElement.setAttribute('aria-busy', 'true');
+					window.data.received = [];
+				}
+
+				window.data.received.push(hook);
+
+				if (hook === 'visit:end') {
+					document.documentElement.removeAttribute('aria-busy');
+				}
+			});
+		</script>
+	</body>
+</html>

--- a/tests/fixtures/rapid-navigation/page-2.html
+++ b/tests/fixtures/rapid-navigation/page-2.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>Rapid Navigation Page 2</title>
+		<link rel="stylesheet" href="/assets/main.css" />
+		<script src="/dist/Swup.umd.js"></script>
+	</head>
+	<body>
+		<header class="header">
+			<ul>
+				<li><a href="/rapid-navigation/page-1.html" data-testid="link-to-page-1">Page 1</a></li>
+				<li><a href="/rapid-navigation/page-2.html" data-testid="link-to-page-2">Page 2</a></li>
+				<li><a href="/rapid-navigation/page-3.html" data-testid="link-to-page-3">Page 3</a></li>
+			</ul>
+		</header>
+		<main id="swup" class="wrapper transition-default" data-testid="container">
+			<div class="wrapper-inner">
+				<h1>Rapid Navigation Page 2</h1>
+				<p>
+					Lorem ipsum dolor sit amet, consectetur adipisicing elit. Alias assumenda
+					consectetur consequatur enim esse incidunt iusto, magnam maxime molestias nisi
+					perferendis perspiciatis quibusdam quos repellat, vel veniam vero voluptate
+					voluptatem.
+				</p>
+			</div>
+		</main>
+	</body>
+</html>

--- a/tests/fixtures/rapid-navigation/page-3.html
+++ b/tests/fixtures/rapid-navigation/page-3.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>Rapid Navigation Page 3</title>
+		<link rel="stylesheet" href="/assets/main.css" />
+		<script src="/dist/Swup.umd.js"></script>
+	</head>
+	<body>
+		<header class="header">
+			<ul>
+				<li><a href="/rapid-navigation/page-1.html" data-testid="link-to-page-1">Page 1</a></li>
+				<li><a href="/rapid-navigation/page-2.html" data-testid="link-to-page-2">Page 2</a></li>
+				<li><a href="/rapid-navigation/page-3.html" data-testid="link-to-page-3">Page 3</a></li>
+			</ul>
+		</header>
+		<main id="swup" class="wrapper transition-default" data-testid="container">
+			<div class="wrapper-inner">
+				<h1>Rapid Navigation Page 3</h1>
+				<p>
+					Lorem ipsum dolor sit amet, consectetur adipisicing elit. Alias assumenda
+					consectetur consequatur enim esse incidunt iusto, magnam maxime molestias nisi
+					perferendis perspiciatis quibusdam quos repellat, vel veniam vero voluptate
+					voluptatem.
+				</p>
+			</div>
+		</main>
+	</body>
+</html>

--- a/tests/functional/history.spec.ts
+++ b/tests/functional/history.spec.ts
@@ -18,6 +18,7 @@ test.describe('history', () => {
 		await navigateWithSwup(page, '/page-2.html');
 		await expectToBeAt(page, '/page-2.html', 'Page 2');
 		await page.goBack();
+		await expectToBeAt(page, '/history.html', 'History');
 		const state = await page.evaluate(() => window.history.state);
 		await navigateWithSwup(page, '/page-2.html');
 		await expectToBeAt(page, '/page-2.html', 'Page 2');
@@ -31,6 +32,7 @@ test.describe('history', () => {
 		await navigateWithSwup(page, '/page-2.html');
 		await expectToBeAt(page, '/page-2.html', 'Page 2');
 		await page.goBack();
+		await expectToBeAt(page, '/history.html', 'History');
 		const state = await page.evaluate(() => window.history.state);
 		await navigateWithSwup(page, '/page-2.html');
 		await expectToBeAt(page, '/page-2.html', 'Page 2');

--- a/tests/functional/navigation.spec.ts
+++ b/tests/functional/navigation.spec.ts
@@ -77,4 +77,24 @@ test.describe('navigation', () => {
 		const received = await page.evaluate(() => window.data.received);
 		expect(received).toEqual(expected);
 	});
+
+	test('ignores aborted visits', async ({ page }) => {
+		await page.goto('/rapid-navigation/page-1.html');
+		await waitForSwup(page);
+		await page.evaluate(() => {
+			window._swup.hooks.on('content:replace', (visit) => visit.abort());
+		});
+		const expected = [
+			'visit:start',
+			'animation:out:start',
+			'fetch:request',
+			'page:load',
+			'animation:out:await',
+			'animation:out:end'
+		];
+		await clickOnLink(page, '/rapid-navigation/page-2.html');
+		await sleep(1000); // we have to wait here, since we cannot rely on anything from swup (the visit is being exited)
+		const received = await page.evaluate(() => window.data.received);
+		expect(received).toEqual(expected);
+	});
 });

--- a/tests/support/commands.ts
+++ b/tests/support/commands.ts
@@ -52,14 +52,14 @@ export function expectNotToHaveClasses(locator: Locator, classNames: string) {
 	return expectToHaveClasses(locator, classNames, true);
 }
 
-export async function expectPageReload(page: Page, action: (page: Page) => Promise<void> | void, not: boolean = false) {
+export async function expectPageReload(page: Page, action: (page: Page) => Promise<unknown> | unknown, not: boolean = false) {
 	const origin = () => page.evaluate(() => Math.floor(window.performance.timeOrigin));
 	const before = await origin();
 	await action(page);
 	await expect(async () => expect(await origin()).not.toBe(before)).toPass();
 }
 
-export function expectNoPageReload(page: Page, action: (page: Page) => Promise<void> | void) {
+export function expectNoPageReload(page: Page, action: (page: Page) => Promise<unknown> | unknown) {
 	return expectPageReload(page, action, true);
 }
 

--- a/tests/support/swup.ts
+++ b/tests/support/swup.ts
@@ -24,6 +24,7 @@ export async function pushSwupHistoryState(page: Page, url: string, data: Record
 
 export async function expectSwupToHaveCacheEntry(page: Page, url: string) {
 	const entry = await page.evaluate((url) => window._swup.cache.get(url), url);
+	expect(entry).toBeTruthy();
 	expect(entry).toHaveProperty('url', url);
 }
 

--- a/tests/unit/cache.test.ts
+++ b/tests/unit/cache.test.ts
@@ -149,9 +149,9 @@ describe('Types', () => {
 		const cache = new Cache(swup);
 
 		// @ts-expect-no-error
-		swup.hooks.on('history:popstate', (visit: Visit, { event: PopStateEvent }) => {});
+		swup.hooks.on('history:popstate', (visit: Visit, { event }: { event: PopStateEvent }) => {});
 		// @ts-expect-no-error
-		await swup.hooks.call('history:popstate', { event: new PopStateEvent('') });
+		await swup.hooks.call('history:popstate', swup.visit, { event: new PopStateEvent('') });
 
 		try {
 			// @ts-expect-error

--- a/tests/unit/hooks.test.ts
+++ b/tests/unit/hooks.test.ts
@@ -37,14 +37,14 @@ describe('Hook registry', () => {
 		swup.hooks.on('enable', handler1);
 		swup.hooks.on('enable', handler2);
 
-		await swup.hooks.call('enable', undefined);
+		await swup.hooks.call('enable', undefined, undefined);
 
 		expect(handler1).toBeCalledTimes(1);
 		expect(handler2).toBeCalledTimes(1);
 
 		swup.hooks.off('enable', handler2);
 
-		await swup.hooks.call('enable', undefined);
+		await swup.hooks.call('enable', undefined, undefined);
 
 		expect(handler1).toBeCalledTimes(2);
 		expect(handler2).toBeCalledTimes(1);
@@ -60,14 +60,14 @@ describe('Hook registry', () => {
 
 		expect(unregister1).toBeTypeOf('function');
 
-		await swup.hooks.call('enable', undefined);
+		await swup.hooks.call('enable', undefined, undefined);
 
 		expect(handler1).toBeCalledTimes(1);
 		expect(handler2).toBeCalledTimes(1);
 
 		unregister2();
 
-		await swup.hooks.call('enable', undefined);
+		await swup.hooks.call('enable', undefined, undefined);
 
 		expect(handler1).toBeCalledTimes(2);
 		expect(handler2).toBeCalledTimes(1);
@@ -79,7 +79,7 @@ describe('Hook registry', () => {
 
 		swup.hooks.on('enable', handler);
 
-		await swup.hooks.call('enable', undefined);
+		await swup.hooks.call('enable', undefined, undefined);
 
 		expect(handler).toBeCalledTimes(1);
 	});
@@ -90,8 +90,8 @@ describe('Hook registry', () => {
 
 		swup.hooks.on('enable', handler, { once: true });
 
-		await swup.hooks.call('enable', undefined, () => {});
-		await swup.hooks.call('enable', undefined, () => {});
+		await swup.hooks.call('enable', undefined, undefined, () => {});
+		await swup.hooks.call('enable', undefined, undefined, () => {});
 
 		expect(handler).toBeCalledTimes(1);
 	});
@@ -102,8 +102,8 @@ describe('Hook registry', () => {
 
 		swup.hooks.once('enable', handler);
 
-		await swup.hooks.call('enable', undefined, () => {});
-		await swup.hooks.call('enable', undefined, () => {});
+		await swup.hooks.call('enable', undefined, undefined, () => {});
+		await swup.hooks.call('enable', undefined, undefined, () => {});
 
 		expect(handler).toBeCalledTimes(1);
 	});
@@ -112,7 +112,7 @@ describe('Hook registry', () => {
 		const swup = new Swup();
 		const handler = vi.fn();
 
-		await swup.hooks.call('enable', undefined, handler);
+		await swup.hooks.call('enable', undefined, undefined, handler);
 
 		expect(handler).toBeCalledTimes(1);
 	});
@@ -140,7 +140,7 @@ describe('Hook registry', () => {
 		swup.hooks.on('disable', handlers.normal, {});
 		swup.hooks.on('disable', handlers.after, {});
 
-		await swup.hooks.call('disable', undefined, handlers.original);
+		await swup.hooks.call('disable', undefined, undefined, handlers.original);
 
 		expect(called).toEqual(['before', 'original', 'normal', 'after']);
 	});
@@ -187,7 +187,7 @@ describe('Hook registry', () => {
 		swup.hooks.on('disable', handlers['8'], { priority: 4 });
 		swup.hooks.on('disable', handlers['7'], { priority: 4 });
 
-		await swup.hooks.call('disable', undefined, handlers['5']);
+		await swup.hooks.call('disable', undefined, undefined, handlers['5']);
 
 		expect(called).toEqual([2, 1, 5, 9, 4, 3, 8, 7]);
 	});
@@ -199,7 +199,7 @@ describe('Hook registry', () => {
 
 		swup.hooks.on('enable', customHandler, { replace: true });
 
-		await swup.hooks.call('enable', undefined, defaultHandler);
+		await swup.hooks.call('enable', undefined, undefined, defaultHandler);
 
 		expect(defaultHandler).toBeCalledTimes(0);
 		expect(customHandler).toBeCalledTimes(1);
@@ -214,7 +214,7 @@ describe('Hook registry', () => {
 		swup.hooks.on('enable', firstHandler, { replace: true });
 		swup.hooks.on('enable', secondHandler, { replace: true });
 
-		await swup.hooks.call('enable', undefined, defaultHandler);
+		await swup.hooks.call('enable', undefined, undefined, defaultHandler);
 
 		expect(defaultHandler).toBeCalledTimes(0);
 		expect(firstHandler).toBeCalledTimes(0);
@@ -230,7 +230,7 @@ describe('Hook registry', () => {
 
 		swup.hooks.on('enable', customHandler, { replace: true });
 
-		await swup.hooks.call('enable', undefined, defaultHandler);
+		await swup.hooks.call('enable', undefined, undefined, defaultHandler);
 
 		expect(customHandler).toBeCalledWith(visit, undefined, defaultHandler);
 		expect(defaultHandler).toBeCalledWith(visit, args);
@@ -243,7 +243,7 @@ describe('Hook registry', () => {
 
 		swup.hooks.on('enable', customHandler, { replace: true });
 
-		const result = await swup.hooks.call('enable', undefined, defaultHandler);
+		const result = await swup.hooks.call('enable', undefined, undefined, defaultHandler);
 
 		expect(result).toEqual('foo');
 	});
@@ -263,7 +263,7 @@ describe('Hook registry', () => {
 		swup.hooks.on('enable', secondHandler, { replace: true });
 		swup.hooks.on('enable', thirdHandler, { replace: true });
 
-		await swup.hooks.call('enable', undefined, defaultHandler);
+		await swup.hooks.call('enable', undefined, undefined, defaultHandler);
 
 		expect(defaultHandler).toBeCalledWith(visit, args1);
 		expect(thirdHandler).toBeCalledWith(visit, undefined, expect.any(Function));
@@ -279,7 +279,7 @@ describe('Hook registry', () => {
 
 		swup.hooks.on('enable', listener);
 
-		await swup.hooks.call('enable', undefined, handler);
+		await swup.hooks.call('enable', undefined, undefined, handler);
 
 		expect(listener).toBeCalledWith(visit, undefined, undefined);
 	});
@@ -291,7 +291,7 @@ describe('Hook registry', () => {
 		const args = { event: new PopStateEvent('') };
 
 		swup.hooks.on('history:popstate', handler);
-		await swup.hooks.call('history:popstate', args);
+		await swup.hooks.call('history:popstate', undefined, args);
 
 		expect(handler).toBeCalledTimes(1);
 		expect(handler).toBeCalledWith(visit, args, undefined);
@@ -305,14 +305,14 @@ describe('Types', () => {
 		// @ts-expect-no-error
 		swup.hooks.on('history:popstate', (visit: Visit, { event }: { event: PopStateEvent }) => {});
 		// @ts-expect-no-error
-		await swup.hooks.call('history:popstate', { event: new PopStateEvent('') });
+		await swup.hooks.call('history:popstate', undefined, { event: new PopStateEvent('') });
 
 		// @ts-expect-error: first arg must be Visit object
 		swup.hooks.on('history:popstate', ({ event: MouseEvent }) => {});
 		// @ts-expect-error: event arg must be PopStateEvent
 		swup.hooks.on('history:popstate', (visit: Visit, { event }: { event: MouseEvent }) => {});
 		// @ts-expect-error: event arg must be PopStateEvent
-		await swup.hooks.call('history:popstate', { event: new MouseEvent('') });
+		await swup.hooks.call('history:popstate', undefined, { event: new MouseEvent('') });
 		// @ts-expect-error: handler arg must be optional: handler?
 		swup.hooks.replace('enable', (visit: Visit, args: undefined, handler: HookDefaultHandler<'enable'>) => {});
 	});

--- a/tests/unit/hooks.test.ts
+++ b/tests/unit/hooks.test.ts
@@ -314,19 +314,23 @@ describe('Hook registry', () => {
 	it('should accept legacy argument position', async () => {
 		const swup = new SwupWithPublicVisitMethods();
 		const handler: HookHandler<'history:popstate'> = vi.fn();
+		const enableHandler: HookHandler<'enable'> = vi.fn();
 		const defaultHandler: HookDefaultHandler<'history:popstate'> = vi.fn();
 		const visit = swup.visit;
 		const args = { event: new PopStateEvent('') };
 
 		swup.hooks.on('history:popstate', handler);
+		swup.hooks.on('enable', enableHandler);
 
 		// Trigger with legacy argument position
 		await swup.hooks.call('history:popstate', args, defaultHandler);
 		await swup.hooks.call('history:popstate', args);
+		await swup.hooks.call('enable', undefined, undefined);
 
 		expect(handler).toBeCalledTimes(2);
 		expect(handler).toHaveBeenNthCalledWith(1, visit, args, undefined);
 		expect(handler).toHaveBeenNthCalledWith(2, visit, args, undefined);
+		expect(enableHandler).toHaveBeenNthCalledWith(1, visit, undefined, undefined);
 
 		expect(defaultHandler).toBeCalledTimes(1);
 		expect(defaultHandler).toHaveBeenNthCalledWith(1, visit, args, undefined);
@@ -338,7 +342,10 @@ describe('Types', () => {
 		const swup = new Swup();
 
 		// @ts-expect-no-error
-		swup.hooks.on('history:popstate', (visit: Visit, { event }: { event: PopStateEvent }) => {});
+		swup.hooks.on(
+			'history:popstate',
+			(visit: Visit, { event }: { event: PopStateEvent }) => {}
+		);
 		// @ts-expect-no-error
 		await swup.hooks.call('history:popstate', undefined, { event: new PopStateEvent('') });
 
@@ -349,6 +356,9 @@ describe('Types', () => {
 		// @ts-expect-error: event arg must be PopStateEvent
 		await swup.hooks.call('history:popstate', undefined, { event: new MouseEvent('') });
 		// @ts-expect-error: handler arg must be optional: handler?
-		swup.hooks.replace('enable', (visit: Visit, args: undefined, handler: HookDefaultHandler<'enable'>) => {});
+		swup.hooks.replace(
+			'enable',
+			(visit: Visit, args: undefined, handler: HookDefaultHandler<'enable'>) => {}
+		);
 	});
 });

--- a/tests/unit/visit.test.ts
+++ b/tests/unit/visit.test.ts
@@ -18,6 +18,10 @@ describe('Visit', () => {
 		expect(visit).to.be.an('object');
 	});
 
+	it('is a Visit instance', () => {
+		expect(visit).to.be.instanceof(Visit);
+	});
+
 	it('has an id', () => {
 		expect(visit.id).to.be.a('number');
 	});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,6 +24,8 @@
     /* If you're building for a library: */
     "declaration": true,
     /* If you're building for a library in a monorepo: */
-    "declarationMap": true
+    "declarationMap": true,
+    /* Don't advertise @private properties */
+    "stripInternal": true
   },
 }


### PR DESCRIPTION
**Description**

- Combine/extend @hirasso's 2 PRs: [rapid navigation](https://github.com/swup/swup/pull/825) + [queue navigation](https://github.com/swup/swup/pull/834)
- Add `Visit.state` property and `visit:abort` hook

**Features**

- Convert the `Visit` object to a class
- Pass around the `Visit` object to avoid global mutations
- Add a `state` property to the `Visit` object
  - created → queued → started → leaving → loaded → entering → completed / aborted / failed
- Queue new visit if the current visit is already past the `loaded` state
  - Otherwise, abort the visit and return early in strategic places
  - When aborting only during the `entering` phase, we can have fewer return clauses throughout the code
- Only run hooks if visit is not aborted
- Create `visit:abort` hook to allow undoing dom changes like in `visit:end`
- Always clear `is-leaving` class

**Notes**

- Regarding the naming (`visit.aborted`, `visit:abort`), I asked ChatGPT for a few suggestions and that's what it came up with. I switched to `abort` to see how it feels. I actually quite like it, slightly more than `cancel`. But we can switch back to `cancel` no problem.

**Checks**

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [x] New or updated tests are included
- [ ] The documentation was updated as required