### PR TITLE
Standardize usage of globals

### DIFF
--- a/src/Swup.ts
+++ b/src/Swup.ts
@@ -242,7 +242,7 @@ export default class Swup {
 		const { origin, url, hash } = Location.fromUrl(href);
 
 		// Ignore if the new origin doesn't match the current one
-		if (origin !== window.location.origin) {
+		if (origin !== location.origin) {
 			return true;
 		}
 

--- a/src/Swup.ts
+++ b/src/Swup.ts
@@ -154,7 +154,7 @@ export default class Swup {
 		this.hooks = new Hooks(this);
 		this.visit = this.createVisit({ to: '' });
 
-		this.currentHistoryIndex = (history.state as HistoryState)?.index ?? 1;
+		this.currentHistoryIndex = (window.history.state as HistoryState)?.index ?? 1;
 
 		if (!this.checkRequirements()) {
 			return;
@@ -197,7 +197,7 @@ export default class Swup {
 		this.options.plugins.forEach((plugin) => this.use(plugin));
 
 		// Create initial history record
-		if ((history.state as HistoryState)?.source !== 'swup') {
+		if ((window.history.state as HistoryState)?.source !== 'swup') {
 			updateHistoryRecord(null, { index: this.currentHistoryIndex });
 		}
 

--- a/src/Swup.ts
+++ b/src/Swup.ts
@@ -242,7 +242,7 @@ export default class Swup {
 		const { origin, url, hash } = Location.fromUrl(href);
 
 		// Ignore if the new origin doesn't match the current one
-		if (origin !== location.origin) {
+		if (origin !== window.location.origin) {
 			return true;
 		}
 
@@ -326,7 +326,7 @@ export default class Swup {
 	}
 
 	protected handlePopState(event: PopStateEvent) {
-		const href: string = (event.state as HistoryState)?.url ?? location.href;
+		const href: string = (event.state as HistoryState)?.url ?? window.location.href;
 
 		// Exit early if this event should be ignored
 		if (this.options.skipPopStateHandling(event)) {

--- a/src/helpers/getCurrentUrl.ts
+++ b/src/helpers/getCurrentUrl.ts
@@ -1,4 +1,4 @@
 /** Get the current page URL: path name + query params. Optionally including hash. */
 export const getCurrentUrl = ({ hash }: { hash?: boolean } = {}): string => {
-	return location.pathname + location.search + (hash ? location.hash : '');
+	return window.location.pathname + window.location.search + (hash ? window.location.hash : '');
 };

--- a/src/helpers/history.ts
+++ b/src/helpers/history.ts
@@ -19,13 +19,13 @@ export const createHistoryRecord = (url: string, data: HistoryData = {}): void =
 		source: 'swup',
 		...data
 	};
-	history.pushState(state, '', url);
+	window.history.pushState(state, '', url);
 };
 
 /** Update the current history record with a custom swup identifier. */
 export const updateHistoryRecord = (url: string | null = null, data: HistoryData = {}): void => {
 	url = url || getCurrentUrl({ hash: true });
-	const currentState = (history.state as HistoryState) || {};
+	const currentState = (window.history.state as HistoryState) || {};
 	const state: HistoryState = {
 		...currentState,
 		url,
@@ -33,5 +33,5 @@ export const updateHistoryRecord = (url: string | null = null, data: HistoryData
 		source: 'swup',
 		...data
 	};
-	history.replaceState(state, '', url);
+	window.history.replaceState(state, '', url);
 };

--- a/src/modules/navigate.ts
+++ b/src/modules/navigate.ts
@@ -44,7 +44,7 @@ export function navigate(
 
 	// Check if the visit should be ignored
 	if (this.shouldIgnoreVisit(url, { el: init.el, event: init.event })) {
-		window.location.href = url;
+		location.assign(url);
 		return;
 	}
 
@@ -221,13 +221,14 @@ export async function performNavigation(
 		// Log to console as we swallow almost all hook errors
 		console.error(error);
 
-		// Rewrite `skipPopStateHandling` to redirect manually when `history.go` is processed
+		// Remove current history entry, then load requested url in browser
+
 		this.options.skipPopStateHandling = () => {
-			window.location.href = visit.to.url + visit.to.hash;
+			location.assign(visit.to.url + visit.to.hash);
 			return true;
 		};
 
 		// Go back to the actual page we're still at
-		window.history.go(-1);
+		window.history.back();
 	}
 }

--- a/src/modules/navigate.ts
+++ b/src/modules/navigate.ts
@@ -44,7 +44,7 @@ export function navigate(
 
 	// Check if the visit should be ignored
 	if (this.shouldIgnoreVisit(url, { el: init.el, event: init.event })) {
-		location.assign(url);
+		window.location.assign(url);
 		return;
 	}
 
@@ -224,7 +224,7 @@ export async function performNavigation(
 		// Remove current history entry, then load requested url in browser
 
 		this.options.skipPopStateHandling = () => {
-			location.assign(visit.to.url + visit.to.hash);
+			window.location.assign(visit.to.url + visit.to.hash);
 			return true;
 		};
 

--- a/tests/functional/history.spec.ts
+++ b/tests/functional/history.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 
-import { expectToBeAt, sleep } from '../support/commands.js';
+import { clickOnLink, expectPageReload, expectToBeAt, sleep } from '../support/commands.js';
 import { navigateWithSwup, pushSwupHistoryState } from '../support/swup.js';
 
 test.describe('history', () => {
@@ -107,5 +107,28 @@ test.describe('history', () => {
 		await pushSwupHistoryState(page, '/page-3.html', { source: 'not-swup' });
 		await page.goBack();
 		await expectToBeAt(page, '/page-2.html', 'History');
+	});
+
+	test('replaces current history entry on error', async ({ page }) => {
+		await page.route('/error-500.html', route => route.fulfill({
+			status: 500,
+			headers: { 'Content-Type': 'text/html' },
+			body: '<!DOCTYPE html><head><title>Error</title></head><body><h1>Error</h1></body></html>'
+		}));
+
+		await navigateWithSwup(page, '/page-2.html');
+		await expectToBeAt(page, '/page-2.html', 'Page 2');
+
+		await page.goBack();
+		await expectToBeAt(page, '/history.html', 'History');
+
+		await page.goForward();
+		await expectToBeAt(page, '/page-2.html', 'Page 2');
+
+		await expectPageReload(page, () => navigateWithSwup(page, '/error-500.html'));
+		await expectToBeAt(page, '/error-500.html', 'Error');
+
+		await page.goBack();
+		await expectToBeAt(page, '/page-2.html', 'Page 2');
 	});
 });

--- a/tests/functional/history.spec.ts
+++ b/tests/functional/history.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 
-import { clickOnLink, expectPageReload, expectToBeAt, sleep } from '../support/commands.js';
+import { expectPageReload, expectToBeAt, sleep } from '../support/commands.js';
 import { navigateWithSwup, pushSwupHistoryState } from '../support/swup.js';
 
 test.describe('history', () => {


### PR DESCRIPTION
**Description**

- Standardize the usage of global properties on the window: `window.location` and `window.history`
- Avoid ambiguity and confusion with local variables
- Use `location.assign` instead of `location.href = *` for (I think) better semantics
- Add test for expected behavior on errors: remove current history entry, force-reload page

**Checks**

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [x] New or updated tests are included
- [ ] ~~The documentation was updated as required~~