### PR TITLE
Ignore errors in user hooks

### DIFF
--- a/src/modules/navigate.ts
+++ b/src/modules/navigate.ts
@@ -218,11 +218,10 @@ export async function performNavigation(
 
 		visit.state = VisitState.FAILED;
 
-		// Log to console as we swallow almost all hook errors
+		// Log to console
 		console.error(error);
 
 		// Remove current history entry, then load requested url in browser
-
 		this.options.skipPopStateHandling = () => {
 			window.location.assign(visit.to.url + visit.to.hash);
 			return true;


### PR DESCRIPTION
**Description**

- Attempt to tackle #848 
- Make swup more forgiving when it comes to errors in user code
- Catch and log exceptions in user hooks to keep visits running
- Only throw and force-reload for exceptions in internal default handler

**Scenario**

- Mistyped a variable name in a user hook → swup now always reloads, making this hard to figure out in the console

**Checks**

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [x] New or updated tests are included
- [ ] ~~The documentation was updated as required~~
