### PR TITLE
fix: transition classes mutation if pausing before `content:replace`

### DIFF
--- a/src/modules/renderPage.ts
+++ b/src/modules/renderPage.ts
@@ -14,8 +14,6 @@ export const renderPage = async function (this: Swup, visit: Visit, page: PageDa
 
 	const { url } = page;
 
-	this.classes.remove('is-leaving');
-
 	// update state if the url was redirected
 	if (!this.isSameResolvedUrl(getCurrentUrl(), url)) {
 		updateHistoryRecord(url);
@@ -23,13 +21,13 @@ export const renderPage = async function (this: Swup, visit: Visit, page: PageDa
 		visit.to.url = this.currentPageUrl;
 	}
 
-	// only add for animated page loads
-	if (visit.animation.animate) {
-		this.classes.add('is-rendering');
-	}
-
 	// replace content: allow handlers and plugins to overwrite paga data and containers
 	await this.hooks.call('content:replace', visit, { page }, (visit, { page }) => {
+		this.classes.remove('is-leaving');
+		// only add for animated page loads
+		if (visit.animation.animate) {
+			this.classes.add('is-rendering');
+		}
 		const success = this.replaceContent(page, { containers: visit.containers });
 		if (!success) {
 			throw new Error('[swup] Container mismatch, aborting');

--- a/tests/functional/animation-classes.spec.ts
+++ b/tests/functional/animation-classes.spec.ts
@@ -1,0 +1,51 @@
+import { expect, test } from '@playwright/test';
+
+import { clickOnLink, expectToBeAt, sleep } from '../support/commands.js';
+
+test.describe('animation classes', () => {
+	test("doesn't remove `is-leaving` until right before replacing the content", async ({
+		page
+	}) => {
+		await page.goto('/page-1.html');
+		await page.evaluate(() => {
+			window.data = {};
+			window._swup.hooks.before('content:replace', async (visit) => {
+				window.data.before =
+					window.document.documentElement.classList.contains('is-leaving');
+			});
+			window._swup.hooks.on('content:replace', async (visit) => {
+				window.data.after =
+					window.document.documentElement.classList.contains('is-leaving');
+			});
+		});
+		await clickOnLink(page, '/page-2.html');
+		await expectToBeAt(page, '/page-2.html', 'Page 2');
+		expect(await page.evaluate(() => window.data)).toEqual({
+			before: true,
+			after: false
+		});
+	});
+
+	test("doesn't add `is-rendering` until right before replacing the content", async ({
+		page
+	}) => {
+		await page.goto('/page-1.html');
+		await page.evaluate(() => {
+			window.data = {};
+			window._swup.hooks.before('content:replace', async (visit) => {
+				window.data.before =
+					window.document.documentElement.classList.contains('is-rendering');
+			});
+			window._swup.hooks.on('content:replace', async (visit) => {
+				window.data.after =
+					window.document.documentElement.classList.contains('is-rendering');
+			});
+		});
+		await clickOnLink(page, '/page-2.html');
+		await expectToBeAt(page, '/page-2.html', 'Page 2');
+		expect(await page.evaluate(() => window.data)).toEqual({
+			before: false,
+			after: true
+		});
+	});
+});

--- a/tests/functional/animation-timing.spec.ts
+++ b/tests/functional/animation-timing.spec.ts
@@ -20,22 +20,4 @@ test.describe('animation timing', () => {
 		await page.goto('/animation-keyframes.html');
 		await expectSwupAnimationDuration(page, { out: 700, in: 700, total: 1400 });
 	});
-
-	test('keeps is-leaving until right before replacing the content', async ({ page }) => {
-		await page.goto('/page-1.html');
-		// @see https://stackoverflow.com/a/61336937/586823
-		await page.exposeFunction('sleep', sleep);
-		await page.evaluate(() => {
-			window.data = {};
-			window._swup.hooks.before('content:replace', async (visit) => {
-				await sleep(1000);
-				window.data = window.document.documentElement.classList.toString();
-			});
-		});
-		await clickOnLink(page, '/page-2.html');
-		await expectToBeAt(page, '/page-2.html', 'Page 2');
-		expect(await page.evaluate(() => window.data)).toBe(
-			'swup-enabled is-changing is-animating is-leaving'
-		);
-	});
 });

--- a/tests/functional/animation-timing.spec.ts
+++ b/tests/functional/animation-timing.spec.ts
@@ -2,7 +2,6 @@ import { expect, test } from '@playwright/test';
 
 import { expectSwupAnimationDuration } from '../support/swup.js';
 import { clickOnLink, expectToBeAt, sleep } from '../support/commands.js';
-import { nextTick } from '../../src/utils.js';
 
 test.describe('animation timing', () => {
 	test.skip(({ browserName }) => browserName === 'webkit', 'WebKit measurements are off');

--- a/tests/functional/animation-timing.spec.ts
+++ b/tests/functional/animation-timing.spec.ts
@@ -1,6 +1,8 @@
-import { test } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 
 import { expectSwupAnimationDuration } from '../support/swup.js';
+import { clickOnLink, expectToBeAt, sleep } from '../support/commands.js';
+import { nextTick } from '../../src/utils.js';
 
 test.describe('animation timing', () => {
 	test.skip(({ browserName }) => browserName === 'webkit', 'WebKit measurements are off');
@@ -18,5 +20,23 @@ test.describe('animation timing', () => {
 	test('detects keyframe timing', async ({ page }) => {
 		await page.goto('/animation-keyframes.html');
 		await expectSwupAnimationDuration(page, { out: 700, in: 700, total: 1400 });
+	});
+
+	test('keeps is-leaving until right before replacing the content', async ({ page }) => {
+		await page.goto('/page-1.html');
+		// @see https://stackoverflow.com/a/61336937/586823
+		await page.exposeFunction('sleep', sleep);
+		await page.evaluate(() => {
+			window.data = {};
+			window._swup.hooks.before('content:replace', async (visit) => {
+				await sleep(1000);
+				window.data = window.document.documentElement.classList.toString();
+			});
+		});
+		await clickOnLink(page, '/page-2.html');
+		await expectToBeAt(page, '/page-2.html', 'Page 2');
+		expect(await page.evaluate(() => window.data)).toBe(
+			'swup-enabled is-changing is-animating is-leaving'
+		);
 	});
 });


### PR DESCRIPTION
Fixes #857 

**The Problem**

When pausing before `content:replace`, CSS transitions can get out of sync with the actual content replacement, as described in #857. The option [`awaitAssets`](https://swup.js.org/plugins/head-plugin/#awaitassets) in Head Plugin, for example, will wait for all new assets to be loaded before proceeding with `content:replace`. 

The cause for this is that the classList mutation of `is-leaving` and `is-rendering` is currently being done _outside_ of `content:replace`, while in fact it should happen _right before_ the actual replacement, as described in the docs:

> `is-leaving`: [...] Removed **right before the content is replaced**. 
> `is-rendering`: Added **right before the content is replaced** [...]

**The Solution**

Move the classList mutations inside the `content:replace` hook. 

**Questions**

Could this change have unforeseen consequences? I can't think of any, tests are passing. I'd say we should definitely fix this, as otherwise `awaitAssets` is broken right now for certain setups.

**Code to reproduce the bug with the current version of swup**

The following code will reliably:

- animate an overlay for every visit
- replace the content after a **2 second delay** after the out animation started (bad)

```html
<body>
  <div class="transition-overlay"></div>
  <div id="swup"><!-- ... --></div>
</body>
```

```css
.transition-overlay {
  position: fixed;
  top: 0;
  left: 0;
  right: 0;
  bottom: 0;
  z-index: 999;
  background-color: rgb(64, 84, 145);
  opacity: 0;
  transform: translate3d(0, -100%, 0);
  pointer-events: none;
}

html.is-changing .transition-overlay {
  transition: transform 400ms ease-in-out;
  opacity: 1;
}

html.is-animating .transition-overlay {
  transform: translate3d(0, 0, 0);
}

html.is-rendering .transition-overlay {
  transform: translate3d(0, 100%, 0);
}
```

```js
const swup = new Swup();
swup.hooks.before("content:replace", async (visit: Visit) => {
  await sleep(2000); // wait for 2 seconds before proceeding
});

function sleep(timeout = 0): Promise<void> {
  return new Promise((resolve) => setTimeout(() => resolve(undefined), timeout))
}
```

**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [x] Tested manually in local playground
- [x] New tests added