### PR TITLE
Return the full `href` in `Location.url` for external URLs

### DIFF
--- a/src/helpers/Location.ts
+++ b/src/helpers/Location.ts
@@ -14,6 +14,7 @@ export class Location extends URL {
 	 * The full local path including query params.
 	 */
 	get url(): string {
+		if (this.origin !== window.location.origin) return this.href;
 		return this.pathname + this.search;
 	}
 


### PR DESCRIPTION
Fixes https://github.com/swup/preload-plugin/issues/118

**Description**

Return the full `href` for external URLs if accessing `Location.url`

**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
