### PR TITLE
Fix reflow helper being optimized away

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -46,12 +46,11 @@ export function runAsPromise(func: Function, args: unknown[] = []): Promise<unkn
 
 /**
  * Force a layout reflow, e.g. after adding classnames
- * @returns The offset height, just here so it doesn't get optimized away by the JS engine
  * @see https://stackoverflow.com/a/21665117/3759615
  */
-export function forceReflow(element?: HTMLElement) {
+export function forceReflow(element?: HTMLElement): void {
 	element = element || document.body;
-	return element?.offsetHeight;
+	element?.getBoundingClientRect();
 }
 
 /** Escape a string with special chars to not break CSS selectors. */


### PR DESCRIPTION
**Description**

- The `forceReflow` helper seems to be getting optimized away by minifiers
- Accessing `el.offsetHeight` forces the reflow, but [to minifiers it looks like a side-effect free getter](https://github.com/terser/terser/issues/464)
- Switching to `getBoundingClientRect()` fixes this as [it's a method and methods have side-effects](https://github.com/angular/angular-cli/issues/17494#issuecomment-635592036)
- Required to fix this [issue in parallel-plugin](https://github.com/swup/parallel-plugin/issues/13) where the helper is removed in UMD builds
- Tested to work in local playground

**Checks**

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [ ] ~~New or updated tests are included~~
- [ ] ~~The documentation was updated as required~~