### PR TITLE
Store new document in visit object

### DIFF
--- a/src/modules/Visit.ts
+++ b/src/modules/Visit.ts
@@ -18,7 +18,7 @@ export interface VisitTo {
 	/** The HTML content of the next page */
 	html?: string;
 	/** The parsed document of the next page, available during visit */
-	document?: HTMLElement;
+	document?: Document;
 }
 
 export interface VisitAnimation {

--- a/src/modules/Visit.ts
+++ b/src/modules/Visit.ts
@@ -17,6 +17,8 @@ export interface VisitTo {
 	hash?: string;
 	/** The HTML content of the next page */
 	html?: string;
+	/** The parsed document of the next page, available during visit */
+	document?: HTMLElement;
 }
 
 export interface VisitAnimation {

--- a/src/modules/navigate.ts
+++ b/src/modules/navigate.ts
@@ -139,7 +139,10 @@ export async function performNavigation(
 			return args.page;
 		});
 
-		// When page loaded: mark visit as loaded, save html into visit object
+		/**
+		 * When the page is loaded: mark the visit as loaded and save
+		 * the raw html and a parsed document of the received page in the visit object
+		 */
 		page.then(({ html }) => {
 			visit.advance(VisitState.LOADED);
 			visit.to.html = html;

--- a/src/modules/navigate.ts
+++ b/src/modules/navigate.ts
@@ -79,6 +79,7 @@ export async function performNavigation(
 		} else {
 			// Currently navigating and content not loaded? Abort running visit
 			await this.hooks.call('visit:abort', this.visit, undefined);
+			delete this.visit.to.document;
 			this.visit.state = VisitState.ABORTED;
 		}
 	}
@@ -230,5 +231,7 @@ export async function performNavigation(
 
 		// Go back to the actual page we're still at
 		window.history.back();
+	} finally {
+		delete visit.to.document;
 	}
 }

--- a/src/modules/navigate.ts
+++ b/src/modules/navigate.ts
@@ -142,6 +142,7 @@ export async function performNavigation(
 		page.then(({ html }) => {
 			visit.advance(VisitState.LOADED);
 			visit.to.html = html;
+			visit.to.document = new DOMParser().parseFromString(html, 'text/html');
 		});
 
 		// Create/update history record if this is not a popstate call or leads to the same URL

--- a/src/modules/renderPage.ts
+++ b/src/modules/renderPage.ts
@@ -28,7 +28,7 @@ export const renderPage = async function (this: Swup, visit: Visit, page: PageDa
 		if (visit.animation.animate) {
 			this.classes.add('is-rendering');
 		}
-		const success = this.replaceContent(visit, { containers: visit.containers });
+		const success = this.replaceContent(visit);
 		if (!success) {
 			throw new Error('[swup] Container mismatch, aborting');
 		}

--- a/src/modules/renderPage.ts
+++ b/src/modules/renderPage.ts
@@ -28,7 +28,7 @@ export const renderPage = async function (this: Swup, visit: Visit, page: PageDa
 		if (visit.animation.animate) {
 			this.classes.add('is-rendering');
 		}
-		const success = this.replaceContent(page, { containers: visit.containers });
+		const success = this.replaceContent(visit, { containers: visit.containers });
 		if (!success) {
 			throw new Error('[swup] Container mismatch, aborting');
 		}

--- a/src/modules/replaceContent.ts
+++ b/src/modules/replaceContent.ts
@@ -24,7 +24,7 @@ export const replaceContent = function (this: Swup, visit: Visit): boolean {
 			const currentEl = document.querySelector(selector);
 			const incomingEl = incomingDocument.querySelector(selector);
 			if (currentEl && incomingEl) {
-				currentEl.replaceWith(incomingEl);
+				currentEl.replaceWith(incomingEl.cloneNode(true));
 				return true;
 			}
 			if (!currentEl) {

--- a/src/modules/replaceContent.ts
+++ b/src/modules/replaceContent.ts
@@ -1,7 +1,7 @@
 import type Swup from '../Swup.js';
 import type { Options } from '../Swup.js';
 import { query, queryAll } from '../utils.js';
-import type { PageData } from './fetchPage.js';
+import type { Visit } from './Visit.js';
 
 /**
  * Perform the replacement of content after loading a page.
@@ -13,10 +13,11 @@ import type { PageData } from './fetchPage.js';
  */
 export const replaceContent = function (
 	this: Swup,
-	{ html }: PageData,
+	visit: Visit,
 	{ containers }: { containers: Options['containers'] } = this.options
 ): boolean {
-	const incomingDocument = new DOMParser().parseFromString(html, 'text/html');
+	const incomingDocument = visit.to.document;
+	if (!incomingDocument) return false;
 
 	// Update browser title
 	const title = incomingDocument.querySelector('title')?.innerText || '';

--- a/src/modules/replaceContent.ts
+++ b/src/modules/replaceContent.ts
@@ -5,9 +5,6 @@ import type { Visit } from './Visit.js';
 /**
  * Perform the replacement of content after loading a page.
  *
- * It takes an object with the page data as returned from `fetchPage` and a list
- * of container selectors to replace.
- *
  * @returns Whether all containers were replaced.
  */
 export const replaceContent = function (this: Swup, visit: Visit): boolean {

--- a/src/modules/replaceContent.ts
+++ b/src/modules/replaceContent.ts
@@ -1,5 +1,4 @@
 import type Swup from '../Swup.js';
-import type { Options } from '../Swup.js';
 import { query, queryAll } from '../utils.js';
 import type { Visit } from './Visit.js';
 
@@ -11,11 +10,7 @@ import type { Visit } from './Visit.js';
  *
  * @returns Whether all containers were replaced.
  */
-export const replaceContent = function (
-	this: Swup,
-	visit: Visit,
-	{ containers }: { containers: Options['containers'] } = this.options
-): boolean {
+export const replaceContent = function (this: Swup, visit: Visit): boolean {
 	const incomingDocument = visit.to.document;
 	if (!incomingDocument) return false;
 
@@ -27,7 +22,7 @@ export const replaceContent = function (
 	const persistedElements = queryAll('[data-swup-persist]:not([data-swup-persist=""])');
 
 	// Update content containers
-	const replaced = containers
+	const replaced = visit.containers
 		.map((selector) => {
 			const currentEl = document.querySelector(selector);
 			const incomingEl = incomingDocument.querySelector(selector);
@@ -55,5 +50,5 @@ export const replaceContent = function (
 	});
 
 	// Return true if all containers were replaced
-	return replaced.length === containers.length;
+	return replaced.length === visit.containers.length;
 };

--- a/tests/unit/replaceContent.test.ts
+++ b/tests/unit/replaceContent.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it, vi, afterEach } from 'vitest';
+import { describe, expect, it, vi, afterEach, beforeEach } from 'vitest';
 import Swup from '../../src/Swup.js';
 import type { PageData } from '../../src/modules/fetchPage.js';
+import { Visit, createVisit } from '../../src/modules/Visit.js';
 import { JSDOM } from 'jsdom';
 
 const getHtml = (body: string): string => {
@@ -12,19 +13,22 @@ const getHtml = (body: string): string => {
 	`;
 };
 
-const mockPage = (body: string): PageData => {
-	return {
-		url: '',
-		html: getHtml(body)
-	};
-};
-
 const stubGlobalDocument = (body: string): void => {
 	const dom = new JSDOM(getHtml(body));
 	vi.stubGlobal('document', dom.window.document);
 };
 
+class SwupWithPublicVisitMethods extends Swup {
+	public createVisit = createVisit;
+}
+
+const swup = new SwupWithPublicVisitMethods();
+let visit: Visit;
+
 describe('replaceContent', () => {
+	beforeEach(() => {
+		visit = swup.createVisit({ to: '' });
+	});
 	afterEach(() => {
 		vi.unstubAllGlobals();
 	});
@@ -36,12 +40,13 @@ describe('replaceContent', () => {
 			<div id="container-3" data-from="current"></div>
 		`);
 
-		const page = mockPage(/*html*/ `
+		const html = `
 			<div id="container-1" data-from="incoming"></div>
-			<div id="container-2" data-from="incoming"></div>`);
-		const swup = new Swup();
+			<div id="container-2" data-from="incoming"></div>`;
+		visit.to.document = new DOMParser().parseFromString(html, 'text/html')
 
-		const result = swup.replaceContent(page, { containers: ['#container-1', '#container-2'] });
+		const swup = new Swup();
+		const result = swup.replaceContent(visit, { containers: ['#container-1', '#container-2'] });
 
 		expect(result).toBe(true);
 		expect(document.querySelector('#container-1')?.getAttribute('data-from')).toBe('incoming');
@@ -54,13 +59,14 @@ describe('replaceContent', () => {
 			<div id="container-1" data-from="current"></div>
 		`);
 		const warn = vi.spyOn(console, 'warn');
-		const page = mockPage(/*html*/ `
+		const html = `
 			<div id="container-1" data-from="incoming"></div>
 			<div id="container-2" data-from="incoming"></div>
-			`);
+			`;
+		visit.to.document = new DOMParser().parseFromString(html, 'text/html')
 
 		const swup = new Swup();
-		const result = swup.replaceContent(page, { containers: ['#container-1', '#missing'] });
+		const result = swup.replaceContent(visit, { containers: ['#container-1', '#missing'] });
 
 		expect(result).toBe(false);
 		expect(warn).not.toBeCalledWith(
@@ -76,11 +82,11 @@ describe('replaceContent', () => {
 			<div id="container-3" data-from="current"></div>
 		`);
 		const warn = vi.spyOn(console, 'warn');
-		const page = mockPage(/*html*/ `
-			<div id="container-1" data-from="incoming"></div>`);
+		const html = `<div id="container-1" data-from="incoming"></div>`;
+		visit.to.document = new DOMParser().parseFromString(html, 'text/html')
 
 		const swup = new Swup();
-		const result = swup.replaceContent(page, { containers: ['#container-1', '#missing'] });
+		const result = swup.replaceContent(visit, { containers: ['#container-1', '#missing'] });
 
 		expect(result).toBe(false);
 		expect(warn).not.toBeCalledWith(

--- a/tests/unit/replaceContent.test.ts
+++ b/tests/unit/replaceContent.test.ts
@@ -94,4 +94,18 @@ describe('replaceContent', () => {
 		);
 		expect(warn).toBeCalledWith('[swup] Container missing in incoming document: #missing');
 	});
+
+	it('should not modify new document in visit object', () => {
+		stubGlobalDocument(/*html*/ `<div id="container" data-from="current"></div>`);
+		const html = /*html*/ `<div id="container" data-from="incoming"></div>`;
+		visit.to.document = new DOMParser().parseFromString(html, 'text/html')
+		visit.containers = ['#container'];
+
+		const documentBefore = visit.to.document.documentElement.innerHTML;
+		new Swup().replaceContent(visit);
+		const documentAfter = visit.to.document.documentElement.innerHTML;
+
+		expect(documentBefore).toEqual(documentAfter);
+		expect(documentAfter).toContain(html);
+	});
 });

--- a/tests/unit/replaceContent.test.ts
+++ b/tests/unit/replaceContent.test.ts
@@ -44,9 +44,9 @@ describe('replaceContent', () => {
 			<div id="container-1" data-from="incoming"></div>
 			<div id="container-2" data-from="incoming"></div>`;
 		visit.to.document = new DOMParser().parseFromString(html, 'text/html')
+		visit.containers = ['#container-1', '#container-2'];
 
-		const swup = new Swup();
-		const result = swup.replaceContent(visit, { containers: ['#container-1', '#container-2'] });
+		const result = new Swup().replaceContent(visit);
 
 		expect(result).toBe(true);
 		expect(document.querySelector('#container-1')?.getAttribute('data-from')).toBe('incoming');
@@ -64,9 +64,9 @@ describe('replaceContent', () => {
 			<div id="container-2" data-from="incoming"></div>
 			`;
 		visit.to.document = new DOMParser().parseFromString(html, 'text/html')
+		visit.containers = ['#container-1', '#missing'];
 
-		const swup = new Swup();
-		const result = swup.replaceContent(visit, { containers: ['#container-1', '#missing'] });
+		const result = new Swup().replaceContent(visit);
 
 		expect(result).toBe(false);
 		expect(warn).not.toBeCalledWith(
@@ -84,9 +84,9 @@ describe('replaceContent', () => {
 		const warn = vi.spyOn(console, 'warn');
 		const html = `<div id="container-1" data-from="incoming"></div>`;
 		visit.to.document = new DOMParser().parseFromString(html, 'text/html')
+		visit.containers = ['#container-1', '#missing'];
 
-		const swup = new Swup();
-		const result = swup.replaceContent(visit, { containers: ['#container-1', '#missing'] });
+		const result = new Swup().replaceContent(visit);
 
 		expect(result).toBe(false);
 		expect(warn).not.toBeCalledWith(

--- a/tests/unit/replaceContent.test.ts
+++ b/tests/unit/replaceContent.test.ts
@@ -40,7 +40,7 @@ describe('replaceContent', () => {
 			<div id="container-3" data-from="current"></div>
 		`);
 
-		const html = `
+		const html = /*html*/ `
 			<div id="container-1" data-from="incoming"></div>
 			<div id="container-2" data-from="incoming"></div>`;
 		visit.to.document = new DOMParser().parseFromString(html, 'text/html')
@@ -59,7 +59,7 @@ describe('replaceContent', () => {
 			<div id="container-1" data-from="current"></div>
 		`);
 		const warn = vi.spyOn(console, 'warn');
-		const html = `
+		const html = /*html*/ `
 			<div id="container-1" data-from="incoming"></div>
 			<div id="container-2" data-from="incoming"></div>
 			`;
@@ -82,7 +82,7 @@ describe('replaceContent', () => {
 			<div id="container-3" data-from="current"></div>
 		`);
 		const warn = vi.spyOn(console, 'warn');
-		const html = `<div id="container-1" data-from="incoming"></div>`;
+		const html = /*html*/ `<div id="container-1" data-from="incoming"></div>`;
 		visit.to.document = new DOMParser().parseFromString(html, 'text/html')
 		visit.containers = ['#container-1', '#missing'];
 


### PR DESCRIPTION
**Description**

- Store the parsed `Document` of the new page in the visit object as `visit.to.document`
- Allow reuse in plugins and consumer hooks to improve performance
- Remove the parsed document when the visit ends, is aborted, or throws an exception
- Read the containers from the visit object directly instead of duplicating them as arguments

**Questions**

- Are we rewriting the html in any plugins where we'd also need to rewrite the document?

**Checks**

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [x] New or updated tests are included
- [ ] The documentation was updated as required

**Context**

- Closes #862