### PR TITLE
Remove animation type branch

### DIFF
--- a/src/modules/awaitAnimations.ts
+++ b/src/modules/awaitAnimations.ts
@@ -108,7 +108,7 @@ function awaitAnimationsOnElement(element: Element): Promise<void> | false {
 	});
 }
 
-export function getTransitionInfo(element: Element) {
+function getTransitionInfo(element: Element) {
 	const styles = window.getComputedStyle(element) as AnimationStyleDeclarations;
 
 	const transitionDelays = getStyleProperties(styles, `${TRANSITION}Delay`);

--- a/src/modules/awaitAnimations.ts
+++ b/src/modules/awaitAnimations.ts
@@ -108,7 +108,7 @@ function awaitAnimationsOnElement(element: Element): Promise<void> | false {
 	});
 }
 
-export function getTransitionInfo(element: Element, expectedType?: AnimationTypes) {
+export function getTransitionInfo(element: Element) {
 	const styles = window.getComputedStyle(element) as AnimationStyleDeclarations;
 
 	const transitionDelays = getStyleProperties(styles, `${TRANSITION}Delay`);
@@ -118,31 +118,14 @@ export function getTransitionInfo(element: Element, expectedType?: AnimationType
 	const animationDurations = getStyleProperties(styles, `${ANIMATION}Duration`);
 	const animationTimeout = calculateTimeout(animationDelays, animationDurations);
 
-	let type: AnimationTypes | null = null;
-	let timeout = 0;
-	let propCount = 0;
-
-	if (expectedType === TRANSITION) {
-		if (transitionTimeout > 0) {
-			type = TRANSITION;
-			timeout = transitionTimeout;
-			propCount = transitionDurations.length;
-		}
-	} else if (expectedType === ANIMATION) {
-		if (animationTimeout > 0) {
-			type = ANIMATION;
-			timeout = animationTimeout;
-			propCount = animationDurations.length;
-		}
-	} else {
-		timeout = Math.max(transitionTimeout, animationTimeout);
-		type = timeout > 0 ? (transitionTimeout > animationTimeout ? TRANSITION : ANIMATION) : null;
-		propCount = type
-			? type === TRANSITION
-				? transitionDurations.length
-				: animationDurations.length
-			: 0;
-	}
+	const timeout = Math.max(transitionTimeout, animationTimeout);
+	const type =
+		timeout > 0 ? (transitionTimeout > animationTimeout ? TRANSITION : ANIMATION) : null;
+	const propCount = type
+		? type === TRANSITION
+			? transitionDurations.length
+			: animationDurations.length
+		: 0;
 
 	return {
 		type,


### PR DESCRIPTION
**Description**

- Remove a branch of logic in the animation utilities which we aren't using
- This was left over from Vue's implementation, which allows specifically checking for transition or animation styles
- Since we're always checking for both transitions and animations, this logic is never required and not in use

**Checks**

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [ ] ~~New or updated tests are included~~
- [ ] ~~The documentation was updated as required~~