### PR TITLE
Remove compatibility checks that are no longer required

### DIFF
--- a/src/Swup.ts
+++ b/src/Swup.ts
@@ -156,15 +156,7 @@ export default class Swup {
 
 		this.currentHistoryIndex = (window.history.state as HistoryState)?.index ?? 1;
 
-		if (!this.checkRequirements()) {
-			return;
-		}
-
 		this.enable();
-	}
-
-	protected checkRequirements() {
-		return true;
 	}
 
 	/** Enable this instance, adding listeners and classnames. */

--- a/src/Swup.ts
+++ b/src/Swup.ts
@@ -164,10 +164,6 @@ export default class Swup {
 	}
 
 	protected checkRequirements() {
-		if (typeof Promise === 'undefined') {
-			console.warn('Promise is not supported');
-			return false;
-		}
 		return true;
 	}
 

--- a/src/modules/awaitAnimations.ts
+++ b/src/modules/awaitAnimations.ts
@@ -1,4 +1,4 @@
-import { queryAll, toMs } from '../utils.js';
+import { queryAll } from '../utils.js';
 import type Swup from '../Swup.js';
 import type { Options } from '../Swup.js';
 
@@ -165,4 +165,8 @@ function calculateTimeout(delays: string[], durations: string[]): number {
 	}
 
 	return Math.max(...durations.map((duration, i) => toMs(duration) + toMs(delays[i])));
+}
+
+function toMs(time: string): number {
+	return parseFloat(time) * 1000;
 }

--- a/src/modules/getAnchorElement.ts
+++ b/src/modules/getAnchorElement.ts
@@ -1,4 +1,4 @@
-import { escapeCssIdentifier as escape, query } from '../utils.js';
+import { query } from '../utils.js';
 
 /**
  * Find the anchor element for a given hash.
@@ -21,8 +21,8 @@ export const getAnchorElement = (hash?: string): Element | null => {
 	let element =
 		document.getElementById(hash) ||
 		document.getElementById(decoded) ||
-		query(`a[name='${escape(hash)}']`) ||
-		query(`a[name='${escape(decoded)}']`);
+		query(`a[name='${CSS.escape(hash)}']`) ||
+		query(`a[name='${CSS.escape(decoded)}']`);
 
 	if (!element && hash === 'top') {
 		element = document.body;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -55,11 +55,7 @@ export function forceReflow(element?: HTMLElement): void {
 
 /** Escape a string with special chars to not break CSS selectors. */
 export const escapeCssIdentifier = (ident: string) => {
-	// @ts-ignore this is for support check, so it's correct that TS complains
-	if (window.CSS && window.CSS.escape) {
-		return CSS.escape(ident);
-	}
-	return ident;
+	return CSS.escape(ident);
 };
 
 /** Fix for Chrome below v61 formatting CSS floats with comma in some locales. */

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -52,8 +52,3 @@ export function forceReflow(element?: HTMLElement): void {
 	element = element || document.body;
 	element?.getBoundingClientRect();
 }
-
-/** Fix for Chrome below v61 formatting CSS floats with comma in some locales. */
-export const toMs = (s: string) => {
-	return Number(s.slice(0, -1).replace(',', '.')) * 1000;
-};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -53,11 +53,6 @@ export function forceReflow(element?: HTMLElement): void {
 	element?.getBoundingClientRect();
 }
 
-/** Escape a string with special chars to not break CSS selectors. */
-export const escapeCssIdentifier = (ident: string) => {
-	return CSS.escape(ident);
-};
-
 /** Fix for Chrome below v61 formatting CSS floats with comma in some locales. */
 export const toMs = (s: string) => {
 	return Number(s.slice(0, -1).replace(',', '.')) * 1000;


### PR DESCRIPTION
**Description**

- Remove some compatibility checks and fixes no longer required given our current browser support matrix
  - Any browsers that support our UMD build syntax support `Promise` and `CSS.escape`
  - Our current browser support after polyfilling is Chrome 66, so the bug in `toMs` is no longer an issue
- I've removed the (now empty) `checkRequirements` method, we can always add it back in the future
- Changes are non-breaking, as other modern browser features would be an issue long before these are
- Slims the bundle down by 2% or 0.13K

**Checks**

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [ ] ~~New or updated tests are included~~
- [ ] ~~The documentation was updated as required~~