### PR TITLE
feat: automerge dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,6 +1,6 @@
 # This workflow automatically merges dependabot PRs
 
-name: auto-merge
+name: dependabot-automerge
 
 on:
   pull_request:

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,17 @@
+# This workflow automatically merges dependabot PRs
+
+name: auto-merge
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ahmadnassri/action-dependabot-auto-merge@v2
+        with:
+          target: patch
+          github-token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -13,5 +13,5 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ahmadnassri/action-dependabot-auto-merge@v2
         with:
-          target: patch
+          target: minor
           github-token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
**Description**

A new attempt to automate the process of merging dependabot PRs.

- for now only for `patch` version bumps
- includes a manual trigger for testing it as soon as we have merged it
- we currently have a whole bunch of open PRs, so this would be a nice chance to test the action
- if it works, we can inherit the action within the plugins

**Checks**

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
