### PR TITLE
 Restore focus to persisted element after replacing content

### DIFF
--- a/src/modules/replaceContent.ts
+++ b/src/modules/replaceContent.ts
@@ -11,6 +11,9 @@ export const replaceContent = function (this: Swup, visit: Visit): boolean {
 	const incomingDocument = visit.to.document;
 	if (!incomingDocument) return false;
 
+	// Store currently focused element
+	const activeElement = document.activeElement;
+
 	// Update browser title
 	const title = incomingDocument.querySelector('title')?.innerText || '';
 	document.title = title;
@@ -43,6 +46,11 @@ export const replaceContent = function (this: Swup, visit: Visit): boolean {
 		const replacement = query(`[data-swup-persist="${key}"]`);
 		if (replacement && replacement !== existing) {
 			replacement.replaceWith(existing);
+
+			// Restore focus to the persisted element if it was focused before
+			if (existing === activeElement) {
+				existing.focus();
+			}
 		}
 	});
 


### PR DESCRIPTION
<!--
Thanks for creating this pull request!

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple PRs instead of opening a huge one.
-->

This PR restores focus to a DOM Element persisted with `data-swup-persist` if it was the focused element before content replacing took place.

This is useful for input elements that trigger a search and should remain focused when the result is added to the DOM.

To further illustrate what this PR tries to solve please see the example on replit [here](https://replit.com/@ove2/data-swup-persist-bug-report)

<!--
Clear and concise description of the proposed changes, as well as a convincing reason for adding them to swup.
-->

**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [ ] New or updated tests are included
- [ ] The documentation was updated as required

**Additional information**

- Tests are missing and would appreciate help in adding them if this PR should be merged. 
- Documentation for `data-swup-persist` should reflect that focus is persisted.