### PR TITLE
Location getter + abortable check

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4182,9 +4182,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001566",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001566.tgz",
-      "integrity": "sha512-ggIhCsTxmITBAMmK8yZjEhCO5/47jKXPu6Dha/wuCS4JePVL+3uiDEBuhu2aIoT+bqTOR8L76Ip1ARL9xYsEJA==",
+      "version": "1.0.30001634",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001634.tgz",
+      "integrity": "sha512-fbBYXQ9q3+yp1q1gBk86tOFs4pyn/yxFm5ZNP18OXJDfA3txImOY9PhfxVggZ4vRHDqoU8NrKU81eN0OtzOgRA==",
       "dev": true,
       "funding": [
         {

--- a/src/Swup.ts
+++ b/src/Swup.ts
@@ -93,8 +93,12 @@ export default class Swup {
 	readonly hooks: Hooks;
 	/** Animation class manager */
 	readonly classes: Classes;
-	/** URL of the currently visible page */
-	currentPageUrl: string = getCurrentUrl();
+	/** Location of the currently visible page */
+	location: Location = Location.fromUrl(getCurrentUrl({ hash: true }));
+	/** URL of the currently visible page @deprecated Use swup.location.url instead */
+	get currentPageUrl(): string {
+		return this.location.url;
+	}
 	/** Index of the current history entry */
 	protected currentHistoryIndex: number;
 	/** Delegated event subscription handle */
@@ -334,7 +338,7 @@ export default class Swup {
 		}
 
 		// Exit early if the resolved path hasn't changed
-		if (this.isSameResolvedUrl(getCurrentUrl(), this.currentPageUrl)) {
+		if (this.isSameResolvedUrl(getCurrentUrl(), this.location.url)) {
 			return;
 		}
 

--- a/src/Swup.ts
+++ b/src/Swup.ts
@@ -94,7 +94,7 @@ export default class Swup {
 	/** Animation class manager */
 	readonly classes: Classes;
 	/** Location of the currently visible page */
-	location: Location = Location.fromUrl(getCurrentUrl({ hash: true }));
+	location: Location = Location.fromUrl(window.location.href);
 	/** URL of the currently visible page @deprecated Use swup.location.url instead */
 	get currentPageUrl(): string {
 		return this.location.url;

--- a/src/modules/Visit.ts
+++ b/src/modules/Visit.ts
@@ -155,12 +155,20 @@ export class Visit {
 
 	/** @internal */
 	abort() {
+		if (!this.abortable) return;
 		this.state = VisitState.ABORTED;
 	}
 
 	/** Is this visit done, i.e. completed, failed, or aborted? */
 	get done(): boolean {
 		return this.state >= VisitState.COMPLETED;
+	}
+
+	/** Can this visit be aborted safely? @internal */
+	get abortable(): boolean {
+		if (this.history.popstate) return false;
+		if (this.state >= VisitState.ENTERING) return false;
+		return true;
 	}
 }
 

--- a/src/modules/Visit.ts
+++ b/src/modules/Visit.ts
@@ -114,7 +114,7 @@ export class Visit {
 	scroll: VisitScroll;
 
 	constructor(swup: Swup, options: VisitInitOptions) {
-		const { to, from = swup.currentPageUrl, hash, el, event } = options;
+		const { to, from = swup.location.url, hash, el, event } = options;
 
 		this.id = Math.random();
 		this.state = VisitState.CREATED;

--- a/src/modules/Visit.ts
+++ b/src/modules/Visit.ts
@@ -8,6 +8,8 @@ import type { HistoryAction, HistoryDirection } from './navigate.js';
 export interface VisitFrom {
 	/** The URL of the previous page */
 	url: string;
+	/** The hash of the previous page */
+	hash?: string;
 }
 
 export interface VisitTo {
@@ -114,11 +116,11 @@ export class Visit {
 	scroll: VisitScroll;
 
 	constructor(swup: Swup, options: VisitInitOptions) {
-		const { to, from = swup.location.url, hash, el, event } = options;
+		const { to, from, hash, el, event } = options;
 
 		this.id = Math.random();
 		this.state = VisitState.CREATED;
-		this.from = { url: from };
+		this.from = { url: from ?? swup.location.url, hash: swup.location.hash };
 		this.to = { url: to, hash };
 		this.containers = swup.options.containers;
 		this.animation = {

--- a/src/modules/Visit.ts
+++ b/src/modules/Visit.ts
@@ -166,7 +166,6 @@ export class Visit {
 
 	/** Can this visit be aborted safely? @internal */
 	get abortable(): boolean {
-		if (this.history.popstate) return false;
 		if (this.state >= VisitState.ENTERING) return false;
 		return true;
 	}

--- a/src/modules/animatePageOut.ts
+++ b/src/modules/animatePageOut.ts
@@ -1,11 +1,13 @@
 import type Swup from '../Swup.js';
-import type { Visit } from './Visit.js';
+import { VisitState, type Visit } from './Visit.js';
 
 /**
  * Perform the out/leave animation of the current page.
  * @returns Promise<void>
  */
 export const animatePageOut = async function (this: Swup, visit: Visit) {
+	visit.advance(VisitState.LEAVING);
+
 	await this.hooks.call('animation:out:start', visit, undefined, () => {
 		this.classes.add('is-changing', 'is-animating', 'is-leaving');
 	});

--- a/src/modules/navigate.ts
+++ b/src/modules/navigate.ts
@@ -123,6 +123,18 @@ export async function performNavigation(
 
 		visit.state = VisitState.STARTED;
 
+		// Create/update history record if this is not a popstate call or leads to the same URL
+		const newUrl = visit.to.url + visit.to.hash;
+		if (!visit.history.popstate) {
+			if (visit.history.action === 'replace' || visit.to.url === this.location.url) {
+				updateHistoryRecord(newUrl);
+			} else {
+				this.currentHistoryIndex++;
+				createHistoryRecord(newUrl, { index: this.currentHistoryIndex });
+			}
+		}
+		this.location = Location.fromUrl(newUrl);
+
 		// Begin loading page
 		const page = this.hooks.call('page:load', visit, { options }, async (visit, args) => {
 			// Read from cache
@@ -146,20 +158,6 @@ export async function performNavigation(
 			visit.to.html = html;
 			visit.to.document = new DOMParser().parseFromString(html, 'text/html');
 		});
-
-		const newUrl = visit.to.url + visit.to.hash;
-
-		// Create/update history record if this is not a popstate call or leads to the same URL
-		if (!visit.history.popstate) {
-			if (visit.history.action === 'replace' || visit.to.url === this.location.url) {
-				updateHistoryRecord(newUrl);
-			} else {
-				this.currentHistoryIndex++;
-				createHistoryRecord(newUrl, { index: this.currentHistoryIndex });
-			}
-		}
-
-		this.location = Location.fromUrl(newUrl);
 
 		// Mark visit type with classes
 		if (visit.history.popstate) {

--- a/src/modules/navigate.ts
+++ b/src/modules/navigate.ts
@@ -117,6 +117,10 @@ export async function performNavigation(
 
 	try {
 		await this.hooks.call('visit:start', visit, undefined);
+
+		// Check if failed/aborted in the first hook
+		if (visit.done) return;
+
 		visit.state = VisitState.STARTED;
 
 		// Begin loading page

--- a/src/modules/navigate.ts
+++ b/src/modules/navigate.ts
@@ -1,13 +1,7 @@
 import type Swup from '../Swup.js';
 import { FetchError, type FetchOptions, type PageData } from './fetchPage.js';
 import { type VisitInitOptions, type Visit, VisitState } from './Visit.js';
-import {
-	createHistoryRecord,
-	updateHistoryRecord,
-	getCurrentUrl,
-	Location,
-	classify
-} from '../helpers.js';
+import { createHistoryRecord, updateHistoryRecord, Location, classify } from '../helpers.js';
 
 export type HistoryAction = 'push' | 'replace';
 export type HistoryDirection = 'forwards' | 'backwards';
@@ -88,7 +82,7 @@ export async function performNavigation(
 	this.visit = visit;
 
 	const { el } = visit.trigger;
-	options.referrer = options.referrer || this.currentPageUrl;
+	options.referrer = options.referrer || this.location.url;
 
 	if (options.animate === false) {
 		visit.animation.animate = false;
@@ -149,11 +143,11 @@ export async function performNavigation(
 			visit.to.document = new DOMParser().parseFromString(html, 'text/html');
 		});
 
+		const newUrl = visit.to.url + visit.to.hash;
+
 		// Create/update history record if this is not a popstate call or leads to the same URL
 		if (!visit.history.popstate) {
-			// Add the hash directly from the trigger element
-			const newUrl = visit.to.url + visit.to.hash;
-			if (visit.history.action === 'replace' || visit.to.url === this.currentPageUrl) {
+			if (visit.history.action === 'replace' || visit.to.url === this.location.url) {
 				updateHistoryRecord(newUrl);
 			} else {
 				this.currentHistoryIndex++;
@@ -161,7 +155,7 @@ export async function performNavigation(
 			}
 		}
 
-		this.currentPageUrl = getCurrentUrl();
+		this.location = Location.fromUrl(newUrl);
 
 		// Mark visit type with classes
 		if (visit.history.popstate) {

--- a/src/modules/navigate.ts
+++ b/src/modules/navigate.ts
@@ -118,9 +118,6 @@ export async function performNavigation(
 	try {
 		await this.hooks.call('visit:start', visit, undefined);
 
-		// Check if failed/aborted in the first hook
-		if (visit.done) return;
-
 		visit.state = VisitState.STARTED;
 
 		// Create/update history record if this is not a popstate call or leads to the same URL

--- a/src/modules/navigate.ts
+++ b/src/modules/navigate.ts
@@ -183,7 +183,6 @@ export async function performNavigation(
 			}
 
 			// Animate page out, render page, animate page in
-			visit.advance(VisitState.LEAVING);
 			await this.animatePageOut(visit);
 			if (visit.animation.native && document.startViewTransition) {
 				await document.startViewTransition(

--- a/src/modules/renderPage.ts
+++ b/src/modules/renderPage.ts
@@ -1,4 +1,4 @@
-import { updateHistoryRecord, getCurrentUrl, classify } from '../helpers.js';
+import { updateHistoryRecord, getCurrentUrl, classify, Location } from '../helpers.js';
 import type Swup from '../Swup.js';
 import type { PageData } from './fetchPage.js';
 import { VisitState, type Visit } from './Visit.js';
@@ -17,8 +17,8 @@ export const renderPage = async function (this: Swup, visit: Visit, page: PageDa
 	// update state if the url was redirected
 	if (!this.isSameResolvedUrl(getCurrentUrl(), url)) {
 		updateHistoryRecord(url);
-		this.currentPageUrl = getCurrentUrl();
-		visit.to.url = this.currentPageUrl;
+		this.location = Location.fromUrl(url);
+		visit.to.url = this.location.url;
 	}
 
 	// replace content: allow handlers and plugins to overwrite paga data and containers
@@ -46,5 +46,5 @@ export const renderPage = async function (this: Swup, visit: Visit, page: PageDa
 		return this.scrollToContent(visit);
 	});
 
-	await this.hooks.call('page:view', visit, { url: this.currentPageUrl, title: document.title });
+	await this.hooks.call('page:view', visit, { url: this.location.url, title: document.title });
 };

--- a/src/modules/renderPage.ts
+++ b/src/modules/renderPage.ts
@@ -19,6 +19,7 @@ export const renderPage = async function (this: Swup, visit: Visit, page: PageDa
 		updateHistoryRecord(url);
 		this.location = Location.fromUrl(url);
 		visit.to.url = this.location.url;
+		visit.to.hash = this.location.hash;
 	}
 
 	// replace content: allow handlers and plugins to overwrite paga data and containers

--- a/tests/fixtures/plugins/scroll-plugin/page-1.html
+++ b/tests/fixtures/plugins/scroll-plugin/page-1.html
@@ -40,9 +40,9 @@
 			</div>
 
 			<p>
-			    Lorem ipsum dolor sit amet, consectetur adipisicing elit. Alias assumenda consectetur
-    			consequatur enim esse incidunt iusto, magnam maxime molestias nisi perferendis
-    			perspiciatis quibusdam quos repellat, vel veniam vero voluptate voluptatem.
+				Lorem ipsum dolor sit amet, consectetur adipisicing elit. Alias assumenda consectetur
+				consequatur enim esse incidunt iusto, magnam maxime molestias nisi perferendis
+				perspiciatis quibusdam quos repellat, vel veniam vero voluptate voluptatem.
 			</p>
 
 			<h2>Links</h2>

--- a/tests/fixtures/plugins/scroll-plugin/page-2.html
+++ b/tests/fixtures/plugins/scroll-plugin/page-2.html
@@ -24,9 +24,9 @@
 			</div>
 
 			<p>
-			    Lorem ipsum dolor sit amet, consectetur adipisicing elit. Alias assumenda consectetur
-    			consequatur enim esse incidunt iusto, magnam maxime molestias nisi perferendis
-    			perspiciatis quibusdam quos repellat, vel veniam vero voluptate voluptatem.
+				Lorem ipsum dolor sit amet, consectetur adipisicing elit. Alias assumenda consectetur
+				consequatur enim esse incidunt iusto, magnam maxime molestias nisi perferendis
+				perspiciatis quibusdam quos repellat, vel veniam vero voluptate voluptatem.
 			</p>
 		</main>
 	</body>

--- a/tests/functional/navigation.spec.ts
+++ b/tests/functional/navigation.spec.ts
@@ -78,23 +78,33 @@ test.describe('navigation', () => {
 		expect(received).toEqual(expected);
 	});
 
-	test('ignores aborted visits', async ({ page }) => {
+	test('ignores visits aborted before content loads', async ({ page }) => {
+		await page.goto('/rapid-navigation/page-1.html');
+		await waitForSwup(page);
+		await page.evaluate(() => {
+			window._swup.hooks.on('animation:out:start', (visit) => visit.abort());
+		});
+		await clickOnLink(page, '/rapid-navigation/page-2.html');
+		await sleep(1000); // we have to wait here, since we cannot rely on anything from swup (the visit is being exited)
+		const received = await page.evaluate(() => window.data.received);
+		expect(received).toContain('visit:start');
+		expect(received).not.toContain('page:load');
+		expect(received).not.toContain('content:replace');
+		expect(received).not.toContain('visit:end');
+	});
+
+	test('does not ignore visits after content loaded', async ({ page }) => {
 		await page.goto('/rapid-navigation/page-1.html');
 		await waitForSwup(page);
 		await page.evaluate(() => {
 			window._swup.hooks.on('content:replace', (visit) => visit.abort());
 		});
-		const expected = [
-			'visit:start',
-			'animation:out:start',
-			'fetch:request',
-			'page:load',
-			'animation:out:await',
-			'animation:out:end'
-		];
 		await clickOnLink(page, '/rapid-navigation/page-2.html');
-		await sleep(1000); // we have to wait here, since we cannot rely on anything from swup (the visit is being exited)
+		await sleep(1500); // we have to wait here, since we cannot rely on anything from swup (the visit is being exited)
 		const received = await page.evaluate(() => window.data.received);
-		expect(received).toEqual(expected);
+		expect(received).toContain('visit:start');
+		expect(received).toContain('page:load');
+		expect(received).toContain('content:replace');
+		expect(received).toContain('visit:end');
 	});
 });

--- a/tests/unit/replaceContent.test.ts
+++ b/tests/unit/replaceContent.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it, vi, afterEach, beforeEach } from 'vitest';
 import Swup from '../../src/Swup.js';
-import type { PageData } from '../../src/modules/fetchPage.js';
 import { Visit, createVisit } from '../../src/modules/Visit.js';
 import { JSDOM } from 'jsdom';
 

--- a/tests/unit/visit.test.ts
+++ b/tests/unit/visit.test.ts
@@ -53,7 +53,7 @@ describe('Visit', () => {
 			name: undefined,
 			scope: swup.options.animationScope,
 			selector: swup.options.animationSelector
-		 });
+		});
 	});
 
 	it('has a container array', () => {
@@ -66,7 +66,7 @@ describe('Visit', () => {
 		expect(visit.trigger).toMatchObject({
 			el: undefined,
 			event: undefined
-		 });
+		});
 	});
 
 	it('has a cache object', () => {


### PR DESCRIPTION
**Description**

- Re-implement some changes from the `visit:abort` branch that make sense

**Location object**
- Store the current location as a `Location` object at `swup.location`
- Allows checking the current hash in addition to just the path/query
- Save the hash of the previous page in the visit object
- Deprecate `swup.currentPageUrl` in favor of `swup.location.url`

```js
if (swup.location.url === '/about') {}
if (swup.location.hash) {}
if (visit.from.hash === '#detail') {}
```

**Location update**
- Update browser url at earliest possible time

**Aborting visits**
- Add `visit.abortable` getter that defines when a visit can be aborted
- Visits that have started entering cannot be aborted
- ~~History visits cannot be aborted~~ (wrong assumption, needs to be abortable)
- Refactor aborting visits from `swup.navigate()`

**Note to self**
- Not allowing aborting history doesn't make too much sense here (we only abort visits if there's a new one)

**Checks**

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [x] New or updated tests are included
- [ ] The documentation was updated as required