### PR TITLE
Remove `secrets: inherit` from caller workflow

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,8 +1,8 @@
 name: Automerge Dependabot PRs
+
 on:
   pull_request:
 
 jobs:
   auto-merge:
     uses: swup/.github/.github/workflows/dependabot-automerge.yml@master
-    secrets: inherit


### PR DESCRIPTION
**Description**

Attempt to fix the dependabot automerge reusable workflow.

**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `master` branch
