### PR TITLE
Location getter

### DIFF
--- a/src/Swup.ts
+++ b/src/Swup.ts
@@ -93,8 +93,12 @@ export default class Swup {
 	readonly hooks: Hooks;
 	/** Animation class manager */
 	readonly classes: Classes;
-	/** URL of the currently visible page */
-	currentPageUrl: string = getCurrentUrl();
+	/** Location of the currently visible page */
+	location: Location = Location.fromUrl(window.location.href);
+	/** URL of the currently visible page @deprecated Use swup.location.url instead */
+	get currentPageUrl(): string {
+		return this.location.url;
+	}
 	/** Index of the current history entry */
 	protected currentHistoryIndex: number;
 	/** Delegated event subscription handle */
@@ -322,7 +326,7 @@ export default class Swup {
 		}
 
 		// Exit early if the resolved path hasn't changed
-		if (this.isSameResolvedUrl(getCurrentUrl(), this.currentPageUrl)) {
+		if (this.isSameResolvedUrl(getCurrentUrl(), this.location.url)) {
 			return;
 		}
 

--- a/src/modules/Visit.ts
+++ b/src/modules/Visit.ts
@@ -8,6 +8,8 @@ import type { HistoryAction, HistoryDirection } from './navigate.js';
 export interface VisitFrom {
 	/** The URL of the previous page */
 	url: string;
+	/** The hash of the previous page */
+	hash?: string;
 }
 
 export interface VisitTo {
@@ -114,11 +116,11 @@ export class Visit {
 	scroll: VisitScroll;
 
 	constructor(swup: Swup, options: VisitInitOptions) {
-		const { to, from = swup.currentPageUrl, hash, el, event } = options;
+		const { to, from, hash, el, event } = options;
 
 		this.id = Math.random();
 		this.state = VisitState.CREATED;
-		this.from = { url: from };
+		this.from = { url: from ?? swup.location.url, hash: swup.location.hash };
 		this.to = { url: to, hash };
 		this.containers = swup.options.containers;
 		this.animation = {

--- a/src/modules/renderPage.ts
+++ b/src/modules/renderPage.ts
@@ -1,4 +1,4 @@
-import { updateHistoryRecord, getCurrentUrl, classify } from '../helpers.js';
+import { updateHistoryRecord, getCurrentUrl, classify, Location } from '../helpers.js';
 import type Swup from '../Swup.js';
 import type { PageData } from './fetchPage.js';
 import { VisitState, type Visit } from './Visit.js';
@@ -17,8 +17,9 @@ export const renderPage = async function (this: Swup, visit: Visit, page: PageDa
 	// update state if the url was redirected
 	if (!this.isSameResolvedUrl(getCurrentUrl(), url)) {
 		updateHistoryRecord(url);
-		this.currentPageUrl = getCurrentUrl();
-		visit.to.url = this.currentPageUrl;
+		this.location = Location.fromUrl(url);
+		visit.to.url = this.location.url;
+		visit.to.hash = this.location.hash;
 	}
 
 	// replace content: allow handlers and plugins to overwrite paga data and containers
@@ -46,5 +47,5 @@ export const renderPage = async function (this: Swup, visit: Visit, page: PageDa
 		return this.scrollToContent(visit);
 	});
 
-	await this.hooks.call('page:view', visit, { url: this.currentPageUrl, title: document.title });
+	await this.hooks.call('page:view', visit, { url: this.location.url, title: document.title });
 };


### PR DESCRIPTION
Version of #904 without the extra stuff...

**Description**

- Store the current location as a `Location` object at `swup.location`
- Save the hash of the previous page in the visit object
- Deprecate `swup.currentPageUrl` in favor of `swup.location.url`

```js
if (swup.location.url === '/about') {}
if (swup.location.hash) {}
if (visit.from.hash === '#detail') {}
```

**Checks**

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [x] New or updated tests are included
- [ ] The documentation was updated as required