### PR TITLE
Clean up animation types

### DIFF
--- a/src/modules/awaitAnimations.ts
+++ b/src/modules/awaitAnimations.ts
@@ -131,11 +131,11 @@ function getTransitionInfo(element: Element) {
 	};
 }
 
-function getStyleProperties(styles: CSSStyleDeclaration, key: AnimationStyleKey): string[] {
+export function getStyleProperties(styles: CSSStyleDeclaration, key: AnimationStyleKey): string[] {
 	return (styles[key] || '').split(', ');
 }
 
-function calculateTimeout(delays: string[], durations: string[]): number {
+export function calculateTimeout(delays: string[], durations: string[]): number {
 	while (delays.length < durations.length) {
 		delays = delays.concat(delays);
 	}
@@ -143,6 +143,6 @@ function calculateTimeout(delays: string[], durations: string[]): number {
 	return Math.max(...durations.map((duration, i) => toMs(duration) + toMs(delays[i])));
 }
 
-function toMs(time: string): number {
+export function toMs(time: string): number {
 	return parseFloat(time) * 1000;
 }

--- a/src/modules/awaitAnimations.ts
+++ b/src/modules/awaitAnimations.ts
@@ -5,10 +5,10 @@ import type { Options } from '../Swup.js';
 const TRANSITION = 'transition';
 const ANIMATION = 'animation';
 
-type AnimationTypes = typeof TRANSITION | typeof ANIMATION;
-type AnimationProperties = 'Delay' | 'Duration';
-type AnimationStyleKeys = `${AnimationTypes}${AnimationProperties}` | 'transitionProperty';
-type AnimationStyleDeclarations = Pick<CSSStyleDeclaration, AnimationStyleKeys>;
+type AnimationType = typeof TRANSITION | typeof ANIMATION;
+type AnimationProperty = 'Delay' | 'Duration';
+type AnimationStyleKey = `${AnimationType}${AnimationProperty}` | 'transitionProperty';
+type AnimationStyleDeclaration = Pick<CSSStyleDeclaration, AnimationStyleKey>;
 
 export type AnimationDirection = 'in' | 'out';
 
@@ -109,7 +109,7 @@ function awaitAnimationsOnElement(element: Element): Promise<void> | false {
 }
 
 function getTransitionInfo(element: Element) {
-	const styles = window.getComputedStyle(element) as AnimationStyleDeclarations;
+	const styles = window.getComputedStyle(element) as AnimationStyleDeclaration;
 
 	const transitionDelays = getStyleProperties(styles, `${TRANSITION}Delay`);
 	const transitionDurations = getStyleProperties(styles, `${TRANSITION}Duration`);
@@ -138,7 +138,7 @@ function isTransitionOrAnimationEvent(event: Event): event is TransitionEvent | 
 	return [`${TRANSITION}end`, `${ANIMATION}end`].includes(event.type);
 }
 
-function getStyleProperties(styles: AnimationStyleDeclarations, key: AnimationStyleKeys): string[] {
+function getStyleProperties(styles: AnimationStyleDeclaration, key: AnimationStyleKey): string[] {
 	return (styles[key] || '').split(', ');
 }
 

--- a/src/modules/awaitAnimations.ts
+++ b/src/modules/awaitAnimations.ts
@@ -6,6 +6,7 @@ const TRANSITION = 'transition';
 const ANIMATION = 'animation';
 
 type AnimationType = typeof TRANSITION | typeof ANIMATION;
+type AnimationEndEvent = `${AnimationType}end`;
 type AnimationProperty = 'Delay' | 'Duration';
 type AnimationStyleKey = `${AnimationType}${AnimationProperty}` | 'transitionProperty';
 type AnimationStyleDeclaration = Pick<CSSStyleDeclaration, AnimationStyleKey>;
@@ -67,7 +68,7 @@ function awaitAnimationsOnElement(element: Element): Promise<void> | false {
 	}
 
 	return new Promise((resolve) => {
-		const endEvent = `${type}end`;
+		const endEvent: AnimationEndEvent = `${type}end`;
 		const startTime = performance.now();
 		let propsTransitioned = 0;
 
@@ -119,7 +120,7 @@ function getTransitionInfo(element: Element) {
 	const animationTimeout = calculateTimeout(animationDelays, animationDurations);
 
 	const timeout = Math.max(transitionTimeout, animationTimeout);
-	const type =
+	const type: AnimationType | null =
 		timeout > 0 ? (transitionTimeout > animationTimeout ? TRANSITION : ANIMATION) : null;
 	const propCount = type
 		? type === TRANSITION

--- a/src/modules/awaitAnimations.ts
+++ b/src/modules/awaitAnimations.ts
@@ -59,7 +59,7 @@ export async function awaitAnimations(
 	await Promise.all(awaitedAnimations);
 }
 
-function awaitAnimationsOnElement(element: Element): Promise<void> | false {
+function awaitAnimationsOnElement(element: HTMLElement): Promise<void> | false {
 	const { type, timeout, propCount } = getTransitionInfo(element);
 
 	// Resolve immediately if no transition defined
@@ -77,7 +77,7 @@ function awaitAnimationsOnElement(element: Element): Promise<void> | false {
 			resolve();
 		};
 
-		const onEnd: EventListener = (event) => {
+		const onEnd = (event: TransitionEvent | AnimationEvent) => {
 			// Skip transitions on child elements
 			if (event.target !== element) {
 				return;

--- a/src/modules/awaitAnimations.ts
+++ b/src/modules/awaitAnimations.ts
@@ -83,10 +83,6 @@ function awaitAnimationsOnElement(element: HTMLElement): Promise<void> | false {
 				return;
 			}
 
-			if (!isTransitionOrAnimationEvent(event)) {
-				throw new Error('Not a transition or animation event.');
-			}
-
 			// Skip transitions that happened before we started listening
 			const elapsedTime = (performance.now() - startTime) / 1000;
 			if (elapsedTime < event.elapsedTime) {
@@ -133,10 +129,6 @@ function getTransitionInfo(element: Element) {
 		timeout,
 		propCount
 	};
-}
-
-function isTransitionOrAnimationEvent(event: Event): event is TransitionEvent | AnimationEvent {
-	return [`${TRANSITION}end`, `${ANIMATION}end`].includes(event.type);
 }
 
 function getStyleProperties(styles: AnimationStyleDeclaration, key: AnimationStyleKey): string[] {

--- a/src/modules/awaitAnimations.ts
+++ b/src/modules/awaitAnimations.ts
@@ -9,7 +9,6 @@ type AnimationType = typeof TRANSITION | typeof ANIMATION;
 type AnimationEndEvent = `${AnimationType}end`;
 type AnimationProperty = 'Delay' | 'Duration';
 type AnimationStyleKey = `${AnimationType}${AnimationProperty}` | 'transitionProperty';
-type AnimationStyleDeclaration = Pick<CSSStyleDeclaration, AnimationStyleKey>;
 
 export type AnimationDirection = 'in' | 'out';
 
@@ -106,11 +105,12 @@ function awaitAnimationsOnElement(element: HTMLElement): Promise<void> | false {
 }
 
 function getTransitionInfo(element: Element) {
-	const styles = window.getComputedStyle(element) as AnimationStyleDeclaration;
+	const styles = window.getComputedStyle(element);
 
 	const transitionDelays = getStyleProperties(styles, `${TRANSITION}Delay`);
 	const transitionDurations = getStyleProperties(styles, `${TRANSITION}Duration`);
 	const transitionTimeout = calculateTimeout(transitionDelays, transitionDurations);
+
 	const animationDelays = getStyleProperties(styles, `${ANIMATION}Delay`);
 	const animationDurations = getStyleProperties(styles, `${ANIMATION}Duration`);
 	const animationTimeout = calculateTimeout(animationDelays, animationDurations);
@@ -131,7 +131,7 @@ function getTransitionInfo(element: Element) {
 	};
 }
 
-function getStyleProperties(styles: AnimationStyleDeclaration, key: AnimationStyleKey): string[] {
+function getStyleProperties(styles: CSSStyleDeclaration, key: AnimationStyleKey): string[] {
 	return (styles[key] || '').split(', ');
 }
 

--- a/src/modules/awaitAnimations.ts
+++ b/src/modules/awaitAnimations.ts
@@ -20,8 +20,8 @@ export type AnimationDirection = 'in' | 'out';
 export async function awaitAnimations(
 	this: Swup,
 	{
-		elements,
-		selector
+		selector,
+		elements
 	}: {
 		selector: Options['animationSelector'];
 		elements?: NodeListOf<HTMLElement> | HTMLElement[];

--- a/tests/unit/awaitAnimations.test.ts
+++ b/tests/unit/awaitAnimations.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import Swup from '../../src/index.js';
+import { calculateTimeout, getStyleProperties, toMs } from '../../src/modules/awaitAnimations.js';
+
+describe('awaitAnimations', () => {
+	it('returns a Promise', () => {
+		const swup = new Swup();
+		expect(swup.awaitAnimations({ selector: 'main' })).toBeInstanceOf(Promise);
+		expect(swup.awaitAnimations({ selector: false })).toBeInstanceOf(Promise);
+		expect(swup.awaitAnimations({ selector: false, elements: [] })).toBeInstanceOf(Promise);
+	});
+});
+
+describe('getStyleProperties', () => {
+	let element: HTMLElement;
+
+	beforeEach(() => {
+		element = document.createElement('div');
+	});
+
+	it('returns an array', () => {
+		const style = window.getComputedStyle(element);
+		expect(getStyleProperties(style, 'transitionDelay')).toBeInstanceOf(Array);
+	});
+
+	it('gets correct element style', () => {
+		element.style.transitionDuration = '1s';
+		const style = window.getComputedStyle(element);
+		expect(getStyleProperties(style, 'transitionDuration')).toEqual(['1s']);
+		expect(getStyleProperties(style, 'animationDuration')).toEqual(['']);
+	});
+
+	it('splits style declaration by comma', () => {
+		element.style.transitionDelay = '1s, 2s';
+		const style = window.getComputedStyle(element);
+		expect(getStyleProperties(style, 'transitionDelay')).toEqual(['1s', '2s']);
+	});
+});
+
+describe('calculateTimeout', () => {
+	it('returns a number', () => {
+		expect(typeof calculateTimeout(['1000ms'], ['0ms'])).toBe('number');
+	});
+
+	it('converts to milliseconds', () => {
+		expect(calculateTimeout(['1s'], ['0s'])).toEqual(1000);
+	});
+
+	it('adds delay to duration', () => {
+		expect(calculateTimeout(['1s'], ['3s'])).toEqual(4000);
+	});
+
+	it('uses highest value', () => {
+		expect(calculateTimeout(['1s', '2s'], ['1s', '2s'])).toEqual(4000);
+		expect(calculateTimeout(['1s', '2s'], ['4s', '1s'])).toEqual(5000);
+		expect(calculateTimeout(['3s', '2s'], ['2s', '4s'])).toEqual(6000);
+	});
+});
+
+describe('toMs', () => {
+	it('returns a number', () => {
+		expect(typeof toMs('1000s')).toBe('number');
+	});
+
+	it('converts to milliseconds', () => {
+		expect(toMs('1s')).toBe(1000);
+		expect(toMs('2s')).toBe(2000);
+		expect(toMs('10s')).toBe(10000);
+	});
+
+	it('ignores units', () => {
+		expect(toMs('1ms')).toBe(1000);
+		expect(toMs('2sec')).toBe(2000);
+		expect(toMs(10 as any as string)).toBe(10000);
+	});
+});

--- a/tests/unit/awaitAnimations.test.ts
+++ b/tests/unit/awaitAnimations.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import Swup from '../../src/index.js';
 import { calculateTimeout, getStyleProperties, toMs } from '../../src/modules/awaitAnimations.js';


### PR DESCRIPTION
**Description**

- Use strict types for animation end event handler
- Rename types for singular to match TypeScript naming
- Remove unnecessary type guard that was only introduced to make the compiler happy
- Simplify style declaration types

**Drive-by**

- Add missing unit tests for animation helpers

**Checks**

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [x] New or updated tests are included
- [ ] ~~The documentation was updated as required~~