### PR TITLE
Fix functional timing tests

### DIFF
--- a/tests/functional/animation-classes.spec.ts
+++ b/tests/functional/animation-classes.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 
-import { clickOnLink, expectToBeAt, sleep } from '../support/commands.js';
+import { clickOnLink, expectToBeAt } from '../support/commands.js';
 
 test.describe('animation classes', () => {
 	test("doesn't remove `is-leaving` until right before replacing the content", async ({

--- a/tests/functional/animation-timing.spec.ts
+++ b/tests/functional/animation-timing.spec.ts
@@ -1,7 +1,6 @@
-import { expect, test } from '@playwright/test';
+import { test } from '@playwright/test';
 
 import { expectSwupAnimationDuration } from '../support/swup.js';
-import { clickOnLink, expectToBeAt, sleep } from '../support/commands.js';
 
 test.describe('animation timing', () => {
 	test.skip(({ browserName }) => browserName === 'webkit', 'WebKit measurements are off');

--- a/tests/functional/animation-timing.spec.ts
+++ b/tests/functional/animation-timing.spec.ts
@@ -3,8 +3,6 @@ import { test } from '@playwright/test';
 import { expectSwupAnimationDuration } from '../support/swup.js';
 
 test.describe('animation timing', () => {
-	test.skip(({ browserName }) => browserName === 'webkit', 'WebKit measurements are off');
-
 	test('detects animation timing', async ({ page }) => {
 		await page.goto('/animation-duration.html');
 		await expectSwupAnimationDuration(page, { out: 400, in: 400, total: 800 });

--- a/tests/support/commands.ts
+++ b/tests/support/commands.ts
@@ -93,6 +93,6 @@ export function expectNumberWithinRange(value: number, min: number, max: number)
 	expect(value).toBeLessThanOrEqual(max);
 }
 
-export function expectNumberWithTolerance(value: number, expected: number, tolerance: number = 0.1) {
-	expectNumberWithinRange(value, expected * (1 - tolerance), expected * (1 + tolerance));
+export function expectNumberCloseTo(value: number, expected: number, range: number[] = []) {
+	expectNumberWithinRange(value, expected * (range[0] ?? 1), expected * (range[1] ?? 1));
 }

--- a/tests/support/swup.ts
+++ b/tests/support/swup.ts
@@ -64,7 +64,7 @@ export async function expectSwupAnimationDuration(page: Page, expected: { total?
 	const timing: { start: 0, end: 0, outStart: 0, outEnd: 0, inStart: 0, inEnd: 0 } = await page.evaluate(() => window.data);
 	const seen = { total: timing.end - timing.start, out: timing.outEnd - timing.outStart, in: timing.inEnd - timing.inStart };
 
-	const tolerance = expected ? [0.9, 1.3] : [1, 1];
+	const tolerance = expected ? [0.85, 1.35] : [1, 1];
 
 	if (typeof expected.out === 'number') {
 		expectNumberCloseTo(seen.out, expected.out, tolerance);

--- a/tests/support/swup.ts
+++ b/tests/support/swup.ts
@@ -1,7 +1,7 @@
 import { expect } from '@playwright/test';
 import type { Page } from '@playwright/test';
 import type Swup from '../../src/Swup.js';
-import { expectNumberWithTolerance } from './commands.js';
+import { expectNumberCloseTo } from './commands.js';
 
 declare global {
 	interface Window {
@@ -61,17 +61,18 @@ export async function expectSwupAnimationDuration(page: Page, expected: { total?
 
 	await page.waitForFunction(() => window.data.end > 0);
 
-	const tolerance = expected ? 0.25 : 0; // 25% plus/minus
 	const timing: { start: 0, end: 0, outStart: 0, outEnd: 0, inStart: 0, inEnd: 0 } = await page.evaluate(() => window.data);
 	const seen = { total: timing.end - timing.start, out: timing.outEnd - timing.outStart, in: timing.inEnd - timing.inStart };
 
+	const tolerance = expected ? [0.9, 1.3] : [1, 1];
+
 	if (typeof expected.out === 'number') {
-		expectNumberWithTolerance(seen.out, expected.out, tolerance);
+		expectNumberCloseTo(seen.out, expected.out, tolerance);
 	}
 	if (typeof expected.in === 'number') {
-		expectNumberWithTolerance(seen.in, expected.in, tolerance);
+		expectNumberCloseTo(seen.in, expected.in, tolerance);
 	}
 	if (typeof expected.total === 'number') {
-		expectNumberWithTolerance(seen.total, expected.total, tolerance);
+		expectNumberCloseTo(seen.total, expected.total, tolerance);
 	}
 }

--- a/tests/unit/replaceContent.test.ts
+++ b/tests/unit/replaceContent.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it, vi, afterEach, beforeEach } from 'vitest';
 import Swup from '../../src/Swup.js';
-import type { PageData } from '../../src/modules/fetchPage.js';
 import { Visit, createVisit } from '../../src/modules/Visit.js';
 import { JSDOM } from 'jsdom';
 


### PR DESCRIPTION
**Description**

- Try to fix the flaky tests around animation timing
- Suggested solution: instead of fixed tolerance (±25%), use sliding range focussed on upper part (-10% to +30%)
- Also remove some old unused imports

**Checks**

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [x] New or updated tests are included
- [ ] ~~The documentation was updated as required~~