### PR TITLE
Inherit trigger element attributes from parent

### DIFF
--- a/src/modules/navigate.ts
+++ b/src/modules/navigate.ts
@@ -2,6 +2,7 @@ import type Swup from '../Swup.js';
 import { FetchError, type FetchOptions, type PageData } from './fetchPage.js';
 import { type VisitInitOptions, type Visit, VisitState } from './Visit.js';
 import { createHistoryRecord, updateHistoryRecord, Location, classify } from '../helpers.js';
+import { getClosestElementAttribute } from '../utils.js';
 
 export type HistoryAction = 'push' | 'replace';
 export type HistoryDirection = 'forwards' | 'backwards';
@@ -94,13 +95,13 @@ export async function performNavigation(
 	}
 
 	// Get history action from option or attribute on trigger element
-	const history = options.history || el?.getAttribute('data-swup-history') || undefined;
+	const history = options.history || getClosestElementAttribute(el, 'data-swup-history');
 	if (history && ['push', 'replace'].includes(history)) {
 		visit.history.action = history as HistoryAction;
 	}
 
 	// Get custom animation name from option or attribute on trigger element
-	const animation = options.animation || el?.getAttribute('data-swup-animation') || undefined;
+	const animation = options.animation || getClosestElementAttribute(el, 'data-swup-animation');
 	if (animation) {
 		visit.animation.name = animation;
 	}

--- a/src/modules/navigate.ts
+++ b/src/modules/navigate.ts
@@ -2,7 +2,7 @@ import type Swup from '../Swup.js';
 import { FetchError, type FetchOptions, type PageData } from './fetchPage.js';
 import { type VisitInitOptions, type Visit, VisitState } from './Visit.js';
 import { createHistoryRecord, updateHistoryRecord, Location, classify } from '../helpers.js';
-import { getClosestElementAttribute } from '../utils.js';
+import { getContextualAttr } from '../utils.js';
 
 export type HistoryAction = 'push' | 'replace';
 export type HistoryDirection = 'forwards' | 'backwards';
@@ -95,14 +95,14 @@ export async function performNavigation(
 	}
 
 	// Get history action from option or attribute on trigger element
-	const history = options.history || getClosestElementAttribute(el, 'data-swup-history');
-	if (history && ['push', 'replace'].includes(history)) {
+	const history = options.history || getContextualAttr(el, 'data-swup-history');
+	if (typeof history === 'string' && ['push', 'replace'].includes(history)) {
 		visit.history.action = history as HistoryAction;
 	}
 
 	// Get custom animation name from option or attribute on trigger element
-	const animation = options.animation || getClosestElementAttribute(el, 'data-swup-animation');
-	if (animation) {
+	const animation = options.animation || getContextualAttr(el, 'data-swup-animation');
+	if (typeof animation === 'string') {
 		visit.animation.name = animation;
 	}
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -52,3 +52,13 @@ export function forceReflow(element?: HTMLElement): void {
 	element = element || document.body;
 	element?.getBoundingClientRect();
 }
+
+/**
+ * Read data attribute from closest element.
+ */
+export function getClosestElementAttribute(
+	el: Element | undefined,
+	attr: string
+): string | undefined {
+	return el?.closest(`[${attr}]`)?.getAttribute(attr) ?? undefined;
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -54,11 +54,15 @@ export function forceReflow(element?: HTMLElement): void {
 }
 
 /**
- * Read data attribute from closest element.
+ * Read data attribute from closest element with that attribute.
+ *
+ * Returns `undefined` if no element is found or attribute is missing.
+ * Returns `true` if attribute is present without a value.
  */
-export function getClosestElementAttribute(
+export function getContextualAttr(
 	el: Element | undefined,
 	attr: string
-): string | undefined {
-	return el?.closest(`[${attr}]`)?.getAttribute(attr) ?? undefined;
+): string | boolean | undefined {
+	const target = el?.closest(`[${attr}]`);
+	return target?.hasAttribute(attr) ? target?.getAttribute(attr) || true : undefined;
 }

--- a/tests/fixtures/page-1.html
+++ b/tests/fixtures/page-1.html
@@ -51,8 +51,16 @@
             maxime molestias nisi perferendis perspiciatis quibusdam quos repellat,
             vel veniam vero voluptate voluptatem.</p>
             <p>
-                <a href="/page-2.html" data-swup-animation="custom">Custom animation</a>
+                <a href="/page-1.html" data-swup-animation="link">Custom animation</a>
             </p>
+            <ul data-swup-animation="list">
+                <li>
+                    <a href="/page-2.html">Custom animation</a>
+                </li>
+                <li>
+                    <a href="/page-3.html">Custom animation</a>
+                </li>
+            </ul>
         </div>
     </main>
     <script>

--- a/tests/fixtures/page-1.html
+++ b/tests/fixtures/page-1.html
@@ -51,7 +51,7 @@
             maxime molestias nisi perferendis perspiciatis quibusdam quos repellat,
             vel veniam vero voluptate voluptatem.</p>
             <p>
-                <a href="/page-1.html" data-swup-animation="link">Custom animation</a>
+                <a href="/page-2.html" data-swup-animation="link">Custom animation</a>
             </p>
             <ul data-swup-animation="list">
                 <li>

--- a/tests/functional/visit-object.spec.ts
+++ b/tests/functional/visit-object.spec.ts
@@ -99,12 +99,20 @@ test.describe('visit object', () => {
 
 	test('passes along custom animation', async ({ page }) => {
 		const link = page.locator('a[data-swup-animation]');
-		const animation = await link.getAttribute('data-swup-animation');
 		await page.evaluate(() => {
 			window._swup.hooks.on('visit:start', (visit) => window.data = visit.animation.name);
 		});
 		await link.click();
-		expect(await page.evaluate(() => window.data)).toEqual(animation);
+		expect(await page.evaluate(() => window.data)).toEqual('link');
+	});
+
+	test('passes along custom animation from parent', async ({ page }) => {
+		const link = page.locator('ul[data-swup-animation]');
+		await page.evaluate(() => {
+			window._swup.hooks.on('visit:start', (visit) => window.data = visit.animation.name);
+		});
+		await link.click();
+		expect(await page.evaluate(() => window.data)).toEqual('list');
 	});
 
 	test('allows disabling animations', async ({ page }) => {

--- a/tests/functional/visit-object.spec.ts
+++ b/tests/functional/visit-object.spec.ts
@@ -107,7 +107,7 @@ test.describe('visit object', () => {
 	});
 
 	test('passes along custom animation from parent', async ({ page }) => {
-		const link = page.locator('ul[data-swup-animation]');
+		const link = page.locator('ul[data-swup-animation] li:first-child a');
 		await page.evaluate(() => {
 			window._swup.hooks.on('visit:start', (visit) => window.data = visit.animation.name);
 		});

--- a/tests/unit/utils.test.ts
+++ b/tests/unit/utils.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi, afterEach } from 'vitest';
 import { JSDOM } from 'jsdom';
 
-import { query } from '../../src/utils.js';
+import { isPromise, query } from '../../src/utils.js';
 
 const createDocument = (body: string): Document => {
 	const dom = new JSDOM(/*html*/ `<!DOCTYPE html><body>${body}</body>`);
@@ -43,5 +43,24 @@ describe('query', () => {
 		expect(query('.sibling')).toBe(doc.querySelector('.sibling'));
 		expect(query('.sibling', root)).toBe(null);
 		expect(query('.child', root)).toBe(doc.querySelector('.child'));
+	});
+});
+
+describe('isPromise', () => {
+	it('accepts promises', () => {
+		expect(isPromise(Promise.resolve())).toBe(true);
+		expect(isPromise(new Promise(() => {}))).toBe(true);
+	});
+
+	it('accepts Promise-like objects', () => {
+		expect(isPromise({ then: () => {} })).toBe(true);
+		expect(isPromise({ then: () => {}, catch: () => {} })).toBe(true);
+	});
+
+	it('rejects non-promises', () => {
+		expect(isPromise(0)).toBe(false);
+		expect(isPromise('a')).toBe(false);
+		expect(isPromise([1, 2, 3])).toBe(false);
+		expect(isPromise({ b: 'c' })).toBe(false);
 	});
 });

--- a/tests/unit/utils.test.ts
+++ b/tests/unit/utils.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import { JSDOM } from 'jsdom';
+
+import { query } from '../../src/utils.js';
+
+const createDocument = (body: string): Document => {
+	const dom = new JSDOM(/*html*/ `<!DOCTYPE html><body>${body}</body>`);
+	return dom.window.document;
+};
+
+const stubGlobalDocument = (body: string): Document => {
+	vi.stubGlobal('document', createDocument(body));
+	return document;
+};
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+});
+
+describe('query', () => {
+	it('should call querySelector on document', () => {
+		const doc = stubGlobalDocument(``);
+		const spy = vi.spyOn(doc, 'querySelector');
+		query('.selector');
+		expect(spy).toHaveBeenCalledWith('.selector');
+	});
+
+	it('should return queried element', () => {
+		stubGlobalDocument(`<div class="test">Test</div>`);
+		const el = query('.test');
+		expect(el?.textContent).toBe('Test');
+	});
+
+	it('should accept a custom root element', () => {
+		const doc = stubGlobalDocument(/*html*/ `
+			<div class="sibling">Sibling</div>
+			<div class="nested">
+				<div class="child">Child</div>
+			</div>
+		`);
+
+		const root = doc.querySelector('.nested')!;
+		expect(query('.sibling')).toBe(doc.querySelector('.sibling'));
+		expect(query('.sibling', root)).toBe(null);
+		expect(query('.child', root)).toBe(doc.querySelector('.child'));
+	});
+});

--- a/tests/unit/utils.test.ts
+++ b/tests/unit/utils.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi, afterEach } from 'vitest';
 import { JSDOM } from 'jsdom';
 
-import { getClosestElementAttribute, isPromise, query, queryAll } from '../../src/utils.js';
+import { getContextualAttr, isPromise, query, queryAll } from '../../src/utils.js';
 
 const createDocument = (body: string): Document => {
 	const dom = new JSDOM(/*html*/ `<!DOCTYPE html><body>${body}</body>`);
@@ -98,34 +98,40 @@ describe('isPromise', () => {
 	});
 });
 
-describe('getClosestElementAttribute', () => {
+describe('getContextualAttr', () => {
 	it('gets attribute value from element', () => {
 		const doc = stubGlobalDocument(/*html*/ `<div attr="value"></div>`);
 		const el = doc.querySelector('div')!;
-		expect(getClosestElementAttribute(el, 'attr')).toBe('value');
+		expect(getContextualAttr(el, 'attr')).toBe('value');
+	});
+
+	it('returns true for attrs without value', () => {
+		const doc = stubGlobalDocument(/*html*/ `<div disabled></div>`);
+		const el = doc.querySelector('div')!;
+		expect(getContextualAttr(el, 'disabled')).toBe(true);
 	});
 
 	it('gets attribute value from parent', () => {
 		const doc = stubGlobalDocument(/*html*/ `<section attr="value"><div></div></section>`);
 		const el = doc.querySelector('div')!;
-		expect(getClosestElementAttribute(el, 'attr')).toBe('value');
+		expect(getContextualAttr(el, 'attr')).toBe('value');
 	});
 
 	it('prefers attribute value from element', () => {
 		const doc = stubGlobalDocument(/*html*/ `<section attr="parent"><div attr="self"></div></section>`);
 		const el = doc.querySelector('div')!;
-		expect(getClosestElementAttribute(el, 'attr')).toBe('self');
+		expect(getContextualAttr(el, 'attr')).toBe('self');
 	});
 
 	it('returns null for missing attribute', () => {
 		const doc = stubGlobalDocument(/*html*/ `<div></div>`);
 		const el = doc.querySelector('div')!;
-		expect(getClosestElementAttribute(el, 'attr')).toBe(undefined);
+		expect(getContextualAttr(el, 'attr')).toBe(undefined);
 	});
 
 	it('returns null for missing element', () => {
 		const doc = stubGlobalDocument(/*html*/ `<div></div>`);
 		const el = doc.querySelector('h1')!;
-		expect(getClosestElementAttribute(el, 'attr')).toBe(undefined);
+		expect(getContextualAttr(el, 'attr')).toBe(undefined);
 	});
 });

--- a/tests/unit/utils.test.ts
+++ b/tests/unit/utils.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi, afterEach } from 'vitest';
 import { JSDOM } from 'jsdom';
 
-import { isPromise, query, queryAll } from '../../src/utils.js';
+import { getClosestElementAttribute, isPromise, query, queryAll } from '../../src/utils.js';
 
 const createDocument = (body: string): Document => {
 	const dom = new JSDOM(/*html*/ `<!DOCTYPE html><body>${body}</body>`);
@@ -95,5 +95,37 @@ describe('isPromise', () => {
 		expect(isPromise('a')).toBe(false);
 		expect(isPromise([1, 2, 3])).toBe(false);
 		expect(isPromise({ b: 'c' })).toBe(false);
+	});
+});
+
+describe('getClosestElementAttribute', () => {
+	it('gets attribute value from element', () => {
+		const doc = stubGlobalDocument(/*html*/ `<div attr="value"></div>`);
+		const el = doc.querySelector('div')!;
+		expect(getClosestElementAttribute(el, 'attr')).toBe('value');
+	});
+
+	it('gets attribute value from parent', () => {
+		const doc = stubGlobalDocument(/*html*/ `<section attr="value"><div></div></section>`);
+		const el = doc.querySelector('div')!;
+		expect(getClosestElementAttribute(el, 'attr')).toBe('value');
+	});
+
+	it('prefers attribute value from element', () => {
+		const doc = stubGlobalDocument(/*html*/ `<section attr="parent"><div attr="self"></div></section>`);
+		const el = doc.querySelector('div')!;
+		expect(getClosestElementAttribute(el, 'attr')).toBe('self');
+	});
+
+	it('returns null for missing attribute', () => {
+		const doc = stubGlobalDocument(/*html*/ `<div></div>`);
+		const el = doc.querySelector('div')!;
+		expect(getClosestElementAttribute(el, 'attr')).toBe(undefined);
+	});
+
+	it('returns null for missing element', () => {
+		const doc = stubGlobalDocument(/*html*/ `<div></div>`);
+		const el = doc.querySelector('h1')!;
+		expect(getClosestElementAttribute(el, 'attr')).toBe(undefined);
 	});
 });


### PR DESCRIPTION
**Description**

- I recently had a situation where the markup of a page section was out of my control
- There was no way of defining a custom animation on the links within that section
- In such situations, it'd super helpful if custom attributes on links could be inherited from parent elements
- Applies to `data-swup-history` as well as `data-swup-animation`
- Also added some tests for `query` and `promise` utils

**Before**

```html
<ul>
  <li><a href="/1" data-swup-history="replace">Tab 1</a></li>
  <li><a href="/2" data-swup-history="replace">Tab 2</a></li>
  <li><a href="/3" data-swup-history="replace">Tab 3</a></li>
</ul>
```

**After**

```html
<ul data-swup-history="replace">
  <li><a href="/1">Tab 1</a></li>
  <li><a href="/2">Tab 2</a></li>
  <li><a href="/3">Tab 3</a></li>
</ul>
```

**Opt-out**

```html
<ul data-swup-history="replace">
  <li><a href="/1">Tab 1</a></li>
  <li><a href="/2">Tab 2</a></li>
  <li><a href="/3">Tab 3</a></li>
  <li><a href="/" data-swup-history="push">Return</a></li>
</ul>
```

**Checks**

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [x] New or updated tests are included
- [ ] The documentation was updated as required