### PR TITLE
Refactor unit tests for instance and exports

### DIFF
--- a/tests/unit/exports.test.ts
+++ b/tests/unit/exports.test.ts
@@ -1,19 +1,16 @@
 import { describe, expect, it } from 'vitest';
 
-import pckg from '../../package.json';
 import Swup from '../../src/index.js';
 import type { Options, Plugin } from '../../src/index.js';
 import * as SwupTS from '../../src/Swup.js';
 
 describe('Exports', () => {
-	it('should export Swup and Options/Plugin types', () => {
-		class SwupPlugin implements Plugin {
-			name = 'SwupPlugin';
-			isSwupPlugin = true as const;
-			mount = () => {};
-			unmount = () => {};
-		}
+	it('should export Swup', () => {
+		const swup = new Swup();
+		expect(swup).toBeInstanceOf(Swup);
+	});
 
+	it('should export Options type', () => {
 		const options: Partial<Options> = {
 			animateHistoryBrowsing: false,
 			animationSelector: '[class*="transition-"]',
@@ -21,7 +18,8 @@ describe('Exports', () => {
 			containers: ['#swup'],
 			ignoreVisit: (url, { el } = {}) => !!el?.closest('[data-no-swup]'),
 			linkSelector: 'a[href]',
-			plugins: [new SwupPlugin()],
+			plugins: [],
+			hooks: {},
 			resolveUrl: (url) => url,
 			requestHeaders: {
 				'X-Requested-With': 'swup',
@@ -34,13 +32,23 @@ describe('Exports', () => {
 		expect(swup).toBeInstanceOf(Swup);
 	});
 
-	it('should define a version', () => {
-		const swup = new Swup();
-		expect(swup.version).not.toBeUndefined();
-		expect(swup.version).toEqual(pckg.version);
+	it('should export Plugin type', () => {
+		class SwupPlugin implements Plugin {
+			name = 'SwupPlugin';
+			isSwupPlugin = true as const;
+			mount = () => {};
+			unmount = () => {};
+		}
+
+		const options: Partial<Options> = {
+			plugins: [new SwupPlugin()]
+		};
+
+		const swup = new Swup(options);
+		expect(swup.plugins[0]).toBeInstanceOf(SwupPlugin);
 	});
 
-	it('UMD compatibility: Swup.ts should only have a default export', () => {
+	it('should only have a default export for UMD compatibility', () => {
 		expect(Object.keys(SwupTS)).toEqual(['default']);
 	});
 });

--- a/tests/unit/swup.test.ts
+++ b/tests/unit/swup.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import pckg from '../../package.json';
+import Swup, { Location } from '../../src/index.js';
+import { Cache } from '../../src/modules/Cache.js';
+import { Hooks } from '../../src/modules/Hooks.js';
+
+describe('Swup', () => {
+	it('should have a version', () => {
+		const swup = new Swup();
+		expect(swup.version).not.toBeUndefined();
+		expect(swup.version).toEqual(pckg.version);
+	});
+
+	it('should have a cache instance', () => {
+		const swup = new Swup();
+		expect(swup.cache).toBeInstanceOf(Cache);
+	});
+
+	it('should have a hooks instance', () => {
+		const swup = new Swup();
+		expect(swup.hooks).toBeInstanceOf(Hooks);
+	});
+
+	it('should have a location', () => {
+		const swup = new Swup();
+		expect(swup.location).toBeInstanceOf(Location);
+	});
+});


### PR DESCRIPTION
**Description**

- Split tests into `swup` (swup class and instance) vs. `exports` (types and classes, UMD)
- Add tests for cache, hooks and location instances

**Checks**

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [x] New or updated tests are included
- [ ] ~~The documentation was updated as required~~