### PR TITLE
Update package metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "type": "git",
     "url": "https://github.com/swup/swup.git"
   },
+  "homepage": "https://swup.js.org",
   "keywords": [
     "css",
     "page",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,18 @@
     "email": "gmarcuk@gmail.com",
     "url": "https://gmrchk.com"
   },
+  "contributors": [
+    {
+      "name": "Philipp Daun",
+      "email": "daun@daun.ltd",
+      "url": "https://philippdaun.net"
+    },
+    {
+      "name": "Rasso Hilber",
+      "email": "mail@rassohilber.com",
+      "url": "https://rassohilber.com"
+    }
+  ],
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,11 @@
     "test:e2e:start": "npm run test:e2e:instrument && npm run test:e2e:serve",
     "prepare": "husky"
   },
-  "author": "Georgy Marchuk",
+  "author": {
+    "name": "Georgy Marchuk",
+    "email": "gmarcuk@gmail.com",
+    "url": "https://gmrchk.com"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Description**

- Add link to homepage
- Add complete author information
- Add current core contributors

**Motivation**

Recently noticed the npm homepage link doesn't lead to the correct docs site. While at it, decided to add/complete current maintainer/author data.

<img width="435" alt="Screenshot 2025-04-28 at 18 06 33" src="https://github.com/user-attachments/assets/da21d926-e3d1-47c4-91c9-0dc79ee53c55" />

**Checks**

- [x] The PR is submitted to the `main` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [ ] ~~New or updated tests are included~~
- [ ] ~~The documentation was updated as required~~