### PR TITLE
feat: path-to-regexp 8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "delegate-it": "^6.0.0",
         "opencollective-postinstall": "^2.0.2",
-        "path-to-regexp": "^6.2.1"
+        "path-to-regexp": "^8.2.0"
       },
       "devDependencies": {
         "@babel/preset-typescript": "^7.18.6",
@@ -8476,9 +8476,13 @@
       "dev": true
     },
     "node_modules/path-to-regexp": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
-      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
+      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/path-type": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
   "dependencies": {
     "delegate-it": "^6.0.0",
     "opencollective-postinstall": "^2.0.2",
-    "path-to-regexp": "^6.2.1"
+    "path-to-regexp": "^8.2.0"
   },
   "devDependencies": {
     "@babel/preset-typescript": "^7.18.6",

--- a/src/helpers/matchPath.ts
+++ b/src/helpers/matchPath.ts
@@ -1,19 +1,15 @@
 import { match } from 'path-to-regexp';
 
-import type {
-	Path,
-	ParseOptions,
-	TokensToRegexpOptions,
-	RegexpToFunctionOptions,
-	MatchFunction
-} from 'path-to-regexp';
+import type { Path, MatchFunction } from 'path-to-regexp';
 
 export { type Path };
 
+type Params = Parameters<typeof match>;
+
 /** Create a match function from a path pattern that checks if a URLs matches it. */
 export const matchPath = <P extends object = object>(
-	path: Path,
-	options?: ParseOptions & TokensToRegexpOptions & RegexpToFunctionOptions
+	path: Params[0],
+	options?: Params[1]
 ): MatchFunction<P> => {
 	try {
 		return match<P>(path, options);

--- a/tests/unit/matchPath.test.ts
+++ b/tests/unit/matchPath.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'vitest';
 import { matchPath } from '../../src/index.js';
-import { pathToRegexp } from 'path-to-regexp';
 
 describe('matchPath', () => {
 	it('should return false if not matching', () => {
@@ -14,7 +13,6 @@ describe('matchPath', () => {
 		const match = urlMatch('/users/bob');
 		expect(match).toEqual({
 			path: '/users/bob',
-			index: 0,
 			params: { user: 'bob' }
 		});
 	});
@@ -34,17 +32,6 @@ describe('matchPath', () => {
 
 		const { params: withoutParams } = urlMatch('/users/') || {};
 		expect(withoutParams).toEqual({});
-	});
-
-	/**
-	 * When passing a regex to `match`, the params in the response are sorted by appearance.
-	 * Only helpful for falsy/truthy detection
-	 */
-	it('should work with regex', () => {
-		const re = pathToRegexp('/users/:user');
-		const urlMatch = matchPath(re);
-		const { params } = urlMatch('/users/bob') || {};
-		expect(params).toEqual({ '0': 'bob' });
 	});
 
 	it('should throw with malformed paths', () => {

--- a/tests/unit/matchPath.test.ts
+++ b/tests/unit/matchPath.test.ts
@@ -51,4 +51,12 @@ describe('matchPath', () => {
 		// prettier-ignore
 		expect(() => matchPath('/\?user=:user')).toThrowError('[swup] Error parsing path');
 	});
+
+	it('should treat an empty array like an empty string', () => {
+		const urlMatch = matchPath([]);
+
+		expect(urlMatch('')).toEqual({ path: '', params: {} });
+
+		expect(urlMatch('/foo/bar')).toBe(false);
+	});
 });


### PR DESCRIPTION
Fixes #993 

**Description**

- Update path-to-regexp to [version 8.2.0](https://github.com/pillarjs/path-to-regexp/releases/tag/v8.2.0)
- Add test for handling empty arrays like an empty string

**Breaking**

- Removes support for regular expressions as an argument for `matchPath`. I'd like to discuss if we want to be absolutely non-breaking during minor versions or if we think we can get away with it in this case.

**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `main` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [x] New or updated tests are included
