### PR TITLE
fix: `matchPath`: treat empty array like an empty string

### DIFF
--- a/src/helpers/matchPath.ts
+++ b/src/helpers/matchPath.ts
@@ -1,19 +1,15 @@
 import { match } from 'path-to-regexp';
 
-import type {
-	Path,
-	ParseOptions,
-	TokensToRegexpOptions,
-	RegexpToFunctionOptions,
-	MatchFunction
-} from 'path-to-regexp';
+import type { Path, MatchFunction } from 'path-to-regexp';
 
 export { type Path };
 
+type Params = Parameters<typeof match>;
+
 /** Create a match function from a path pattern that checks if a URLs matches it. */
 export const matchPath = <P extends object = object>(
-	path: Path,
-	options?: ParseOptions & TokensToRegexpOptions & RegexpToFunctionOptions
+	path: Params[0],
+	options?: Params[1]
 ): MatchFunction<P> => {
 	try {
 		return match<P>(path, options);

--- a/src/helpers/matchPath.ts
+++ b/src/helpers/matchPath.ts
@@ -11,6 +11,10 @@ export const matchPath = <P extends object = object>(
 	path: Params[0],
 	options?: Params[1]
 ): MatchFunction<P> => {
+	if (Array.isArray(path) && !path.length) {
+		path = '';
+	}
+
 	try {
 		return match<P>(path, options);
 	} catch (error) {

--- a/tests/unit/matchPath.test.ts
+++ b/tests/unit/matchPath.test.ts
@@ -51,4 +51,12 @@ describe('matchPath', () => {
 		// prettier-ignore
 		expect(() => matchPath('/\?user=:user')).toThrowError('[swup] Error parsing path');
 	});
+
+	it('should treat an empty array like an empty string', () => {
+		const urlMatch = matchPath([]);
+
+		expect(urlMatch('')).toEqual({ index: 0, path: '', params: {} });
+
+		expect(urlMatch('/foo/bar')).toBe(false);
+	});
 });


### PR DESCRIPTION
Replaces #994

**Description**

- Transform an empty array to a string before passing it to `match`
- Fixes https://github.com/pillarjs/path-to-regexp/issues/291 without the need for a breaking update to `path-to-regexp`
- Drive-By: Simplify `matchPath` by passing on the argument types using `Parameters<typeof match>`

**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `main` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [x] New or updated tests are included

