### PR TITLE
Remove postinstall script from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "lint:compat": "npx eslint --config .eslintrc.compat.cjs --no-eslintrc .",
     "lint:prettier": "prettier 'src/**/*.ts'",
     "prepublishOnly": "npm run build",
-    "postinstall": "opencollective-postinstall || true",
     "test": "npm run test:unit && npm run test:e2e",
     "test:ci": "npm run test:unit && npm run test:e2e:ci",
     "test:unit": "vitest run --config ./tests/config/vitest.config.ts",


### PR DESCRIPTION
**Description**

As discussed in #1022 : Remove the `postinstall` script to prevent warnings when installing swup via PNPM.

**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `main` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
