### PR TITLE
Ability to ignore visits from hook handlers

### DIFF
--- a/src/modules/Visit.ts
+++ b/src/modules/Visit.ts
@@ -172,7 +172,7 @@ export class Visit {
 		return this.state >= VisitState.COMPLETED;
 	}
 
-	/** Was this visit aborted? */
+	/** Was this visit ignored by swup, i.e. left to the browser? */
 	get ignored(): boolean {
 		return this.state === VisitState.IGNORED;
 	}

--- a/src/modules/Visit.ts
+++ b/src/modules/Visit.ts
@@ -86,7 +86,8 @@ export const VisitState = {
 	ENTERING: 6,
 	COMPLETED: 7,
 	ABORTED: 8,
-	FAILED: 9
+	FAILED: 9,
+	IGNORED: 10
 } as const;
 
 /** @internal */
@@ -162,9 +163,18 @@ export class Visit {
 		this.state = VisitState.ABORTED;
 	}
 
-	/** Is this visit done, i.e. completed, failed, or aborted? */
+	ignore() {
+		this.state = VisitState.IGNORED;
+	}
+
+	/** Is this visit done, i.e. completed, aborted, failed, or ignored? */
 	get done(): boolean {
 		return this.state >= VisitState.COMPLETED;
+	}
+
+	/** Was this visit aborted? */
+	get ignored(): boolean {
+		return this.state === VisitState.IGNORED;
 	}
 }
 

--- a/src/modules/navigate.ts
+++ b/src/modules/navigate.ts
@@ -175,6 +175,11 @@ export async function performNavigation(
 			await page;
 		}
 
+		// Ignored in the meantime? Throw to trigger catch block and exit visit
+		if (visit.ignored) {
+			throw new Error(`Visit to ${visit.to.url} manually ignored`);
+		}
+
 		// Check if failed/aborted in the meantime
 		if (visit.done) return;
 

--- a/src/modules/navigate.ts
+++ b/src/modules/navigate.ts
@@ -216,11 +216,11 @@ export async function performNavigation(
 	} catch (error) {
 		// Return early if error is undefined or signals an aborted request
 		if (!error || (error as FetchError)?.aborted) {
-			visit.state = VisitState.ABORTED;
+			visit.advance(VisitState.ABORTED);
 			return;
 		}
 
-		visit.state = VisitState.FAILED;
+		visit.advance(VisitState.FAILED);
 
 		// Log to console
 		console.error(error);

--- a/tests/functional/navigation.spec.ts
+++ b/tests/functional/navigation.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 
-import { clickOnLink, delayRequest, expectToBeAt, sleep } from '../support/commands.js';
+import { clickOnLink, delayRequest, expectPageReload, expectToBeAt, sleep } from '../support/commands.js';
 import { navigateWithSwup, waitForSwup } from '../support/swup.js';
 
 test.describe('navigation', () => {
@@ -96,5 +96,21 @@ test.describe('navigation', () => {
 		await sleep(1000); // we have to wait here, since we cannot rely on anything from swup (the visit is being exited)
 		const received = await page.evaluate(() => window.data.received);
 		expect(received).toEqual(expected);
+	});
+
+	test('forces reload for visits ignored from hook', async ({ page }) => {
+		await page.goto('/page-1.html');
+		await waitForSwup(page);
+		await page.evaluate(() => {
+			window._swup.hooks.on('visit:start', (visit) => visit.animation.wait = true);
+			window._swup.hooks.on('page:load', (visit, { page }) => {
+				if (page!.html.includes('Page 2')) {
+					visit.ignore();
+				}
+			});
+		});
+
+		await expectPageReload(page, () => clickOnLink(page, '/page-2.html'));
+		await expectToBeAt(page, '/page-2.html', 'Page 2');
 	});
 });


### PR DESCRIPTION
**Description**

- Allow ignoring visits from hook handlers: `visit.ignore()`
- Ignored visits force a normal browser visit, just like the `ignoreVisit` option
- Useful for ignoring visits based on the actual returned response of the new page
- Closes #1008

**Example**

Ignore a visit (i.e. force a normal browser visit) if the new page has a certain meta tag.

```js
swup.hooks.on('visit:start', (visit) => {
  visit.animation.wait = true
});

swup.hooks.on('page:load', (visit, { page }) => {
  if (page!.html.includes('<meta name="evil-website" content="yes">')) {
    visit.ignore();
  }
});
```

**How it works**

- This relies on the existing try/catch logic for exceptions during navigation
- Exceptions during navigation trigger a back visit, with `skipPopStateHandling` forcing a browser visit
- This change triggers a custom exception for ignored visits
- This is the sanest option here, short of splitting up the file into multiple paths

**Checks**

- [x] The PR is submitted to the `main` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [x] New or updated tests are included
- [ ] The documentation was updated as required
