### PR TITLE
Unmount all plugins on destroy

### DIFF
--- a/src/Swup.ts
+++ b/src/Swup.ts
@@ -227,7 +227,7 @@ export default class Swup {
 		this.cache.clear();
 
 		// unmount plugins
-		this.options.plugins.forEach((plugin) => this.unuse(plugin));
+		this.plugins.forEach((plugin) => this.unuse(plugin));
 
 		// trigger disable hook
 		await this.hooks.call('disable', undefined, undefined, () => {

--- a/tests/unit/plugins.test.ts
+++ b/tests/unit/plugins.test.ts
@@ -30,6 +30,23 @@ describe('Plugins', () => {
 		expect(plugin.mount.mock.calls).toHaveLength(1);
 	});
 
+	it('should unmount all plugins on destroy', async () => {
+		const runtimePlugin = {
+			name: 'RuntimePlugin',
+			isSwupPlugin: true as const,
+			mount: vi.fn(),
+			unmount: vi.fn(),
+			_checkRequirements: () => true,
+		};
+
+		const swup = new Swup();
+		swup.use(runtimePlugin);
+		expect(runtimePlugin.mount).toHaveBeenCalledTimes(1);
+
+		await swup.destroy();
+		expect(runtimePlugin.unmount).toHaveBeenCalledTimes(1);
+	});
+
 	it('should find a plugin instance by reference', function () {
 		const plugin = createPlugin({ name: 'SwupExamplePlugin' });
 		const swup = new Swup({ plugins: [plugin] });


### PR DESCRIPTION
**Description**

- The `destroy` method only unmounts plugins defined in the initial options object
- This will iterate over the actual plugin list instead, including plugins added during runtime

**Checks**

- [x] The PR is submitted to the `main` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [x] New or updated tests are included
- [ ] ~~The documentation was updated as required~~
