### PR TITLE
Switch `CacheData` back to an interface

### DIFF
--- a/src/modules/Cache.ts
+++ b/src/modules/Cache.ts
@@ -2,6 +2,7 @@ import type Swup from '../Swup.js';
 import { Location } from '../helpers.js';
 import { type PageData } from './fetchPage.js';
 
+// CacheData is intended for augmentation in user land
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface CacheData extends PageData {}
 

--- a/src/modules/Cache.ts
+++ b/src/modules/Cache.ts
@@ -2,7 +2,8 @@ import type Swup from '../Swup.js';
 import { Location } from '../helpers.js';
 import { type PageData } from './fetchPage.js';
 
-export type CacheData = PageData;
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface CacheData extends PageData {}
 
 /**
  * In-memory page cache.


### PR DESCRIPTION
**Description**

`CacheData` was intended as a way to extend cached data in user land. Only interfaces are extensible/augmentable.

Related discussion: https://github.com/swup/fragment-plugin/pull/101

While working on this, I noticed that `lint:ts` is currently only checking the `src` folder, not the test files. I'll open another PR where this is fixed, including a new type test for the `CacheData` interface.

**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `main` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
