### PR TITLE
Revert "Use the default `tsconfig.json` for tests as well"

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "dev": "npm run clean && BROWSERSLIST_ENV=development microbundle src/index.ts -w -f modern",
     "format": "npx eslint . --fix",
     "lint": "npm run lint:ts && npm run lint:es",
-    "lint:ts": "tsc --noEmit --skipLibCheck",
+    "lint:ts": "tsc --noEmit --skipLibCheck && tsc --noEmit --skipLibCheck --project tsconfig.tests.json",
     "lint:es": "npx eslint .",
     "lint:compat": "npx eslint --config .eslintrc.compat.cjs .",
     "lint:prettier": "prettier 'src/**/*.ts'",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,6 @@
 {
   /** @see https://www.totaltypescript.com/tsconfig-cheat-sheet#quickstart */
-  "include": ["src", "tests"],
-  "exclude": ["tests/fixtures"],
+  "include": ["src"],
   "compilerOptions": {
     /* Base Options: */
     "esModuleInterop": true,
@@ -17,7 +16,7 @@
     /* If transpiling with TypeScript: */
     "moduleResolution": "NodeNext",
     "module": "NodeNext",
-    "rootDir": ".",
+    "rootDir": "src",
     "outDir": "dist",
     "sourceMap": true,
     /* If your code runs in the DOM: */

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["tests"],
+  "exclude": ["tests/fixtures"],
+  "compilerOptions": {
+    "rootDir": ".",
+    "noEmit": true
+  }
+}


### PR DESCRIPTION
**Description**

Fixes #1055 
Reverts commit 41031959bff0b4f1bff98816404fe866af66a3f1

- tested `npm run build` locally... the types are in `dist/types/index.d.ts` again as expected.

**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `main` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
