### PR TITLE
Apply swup prefix to `ignore` data attribute

### DIFF
--- a/src/Swup.ts
+++ b/src/Swup.ts
@@ -64,7 +64,7 @@ const defaults: Options = {
 	cache: true,
 	containers: ['#swup'],
 	hooks: {},
-	ignoreVisit: (url, { el } = {}) => !!el?.closest('[data-no-swup]'),
+	ignoreVisit: (url, { el } = {}) => !!el?.closest('[data-swup-ignore]'),
 	linkSelector: 'a[href]',
 	linkToSelf: 'scroll',
 	native: false,

--- a/tests/fixtures/ignore-visits.html
+++ b/tests/fixtures/ignore-visits.html
@@ -13,9 +13,9 @@
                 <a href="/page-2.html" data-testid="ignore-none">Normal link</a>
             </li>
             <li>
-                <a href="/page-2.html" data-no-swup data-testid="ignore-element">Ignored link</a>
+                <a href="/page-2.html" data-swup-ignore data-testid="ignore-element">Ignored link</a>
             </li>
-            <li data-no-swup>
+            <li data-swup-ignore>
                 <a href="/page-2.html" data-testid="ignore-parent">Ignored link parent</a>
             </li>
             <li>

--- a/tests/functional/ignore-visit.spec.ts
+++ b/tests/functional/ignore-visit.spec.ts
@@ -9,12 +9,12 @@ test.describe('ignore visit', () => {
 		await waitForSwup(page);
 	});
 
-	test('ignores links with data-no-swup attr', async ({ page }) => {
+	test('ignores links with data-swup-ignore attr', async ({ page }) => {
 		await expectPageReload(page, () => page.getByTestId('ignore-element').click());
 		await expectToBeAt(page, '/page-2.html', 'Page 2');
 	});
 
-	test('ignores links with data-no-swup parent', async ({ page }) => {
+	test('ignores links with data-swup-ignore parent', async ({ page }) => {
 		await expectPageReload(page, () =>  page.getByTestId('ignore-parent').click());
 		await expectToBeAt(page, '/page-2.html', 'Page 2');
 	});

--- a/tests/unit/exports.test.ts
+++ b/tests/unit/exports.test.ts
@@ -16,7 +16,7 @@ describe('Exports', () => {
 			animationSelector: '[class*="transition-"]',
 			cache: true,
 			containers: ['#swup'],
-			ignoreVisit: (url, { el } = {}) => !!el?.closest('[data-no-swup]'),
+			ignoreVisit: (url, { el } = {}) => !!el?.closest('[data-swup-ignore]'),
 			linkSelector: 'a[href]',
 			plugins: [],
 			hooks: {},


### PR DESCRIPTION
**Description**

- Swup data attributes across core and plugin should have the same `data-swup-*` prefix
- This applies it to the ignore-visit attribute: `data-no-swup` → `data-swup-ignore`
- Breaking → `next`

**Checks**

- [x] The PR is submitted to the `next` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [x] New or updated tests are included
- [ ] The documentation was updated as required
